### PR TITLE
Fixed enum declaration.

### DIFF
--- a/Unreal/Plugins/AirSim/Source/PIPCamera.h
+++ b/Unreal/Plugins/AirSim/Source/PIPCamera.h
@@ -5,7 +5,7 @@
 
 
 UENUM(BlueprintType, meta=(Bitflags))
-enum class EPIPCameraType
+enum class EPIPCameraType : uint8
 {
     PIP_CAMERA_TYPE_NONE = 0	UMETA(DisplayName="None"),
     PIP_CAMERA_TYPE_SCENE = 1	UMETA(DisplayName="Scene"),


### PR DESCRIPTION
Hi all - thank you for releasing this really nice piece of work!

I got this error trying to build a test project:

```
Running UnrealHeaderTool "C:\Users\gawela\Documents\Unreal Projects\MyProject\MyProject.uproject" "C:\Users\gawela\Documents\Unreal Projects\MyProject\Intermediate\Build\Win64\MyProjectEditor\Development\MyProjectEditor.uhtmanifest" -LogCmds="loginit warning, logexit warning, logdatabase error" -Unattended -WarningsAsErrors -installed
1>C:/Users/gawela/Documents/Unreal Projects/MyProject/Plugins/AirSim/Source/PIPCamera.h(9): error : Invalid BlueprintType enum base - currently only uint8 supported
```
This fixes it.