### PR TITLE
Fix linux build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -80,12 +80,14 @@ make -j8 AirLib MavLinkCom
 popd &>/dev/null
 
 
-cp -p AirLib/deps/rpclib/lib/x64/Debug/librpc.a AirLib/deps/rpclib/lib
-cp -p $build_dir/AirLib/lib/libAirLib.a AirLib/lib
+
+
+mkdir -p AirLib/deps/MavLinkCom AirLib/deps/rpclib/lib AirLib/lib || true
+cp -p $build_dir/output/lib/libAirSim-rpclib.a AirLib/deps/rpclib/lib
+cp -p $build_dir/output/lib/libAirLib.a AirLib/lib
 cp -rp MavLinkCom/include AirLib/deps/MavLinkCom
-cp -rp $build_dir/MavLinkCom/lib AirLib/deps/MavLinkCom
+cp -rp $build_dir/output/lib/libMavLinkCom.a AirLib/deps/MavLinkCom/lib
 cp -rp AirLib Unreal/Plugins/AirSim/Source
-rm -rf Unreal/Plugins/AirSim/Source/AirLib/deps/rpclib/rpclib
 
 echo ""
 echo "============================================================"
@@ -95,4 +97,5 @@ echo "  (<unreal project_root> contains a file named <project>.uproject)"
 echo "============================================================"
 echo "And do (required for building the Unreal plugin):"
 echo "export BOOST_ROOT=\"$BOOST_ROOT\""
+echo "export EIGEN_ROOT=\"$EIGEN_ROOT\""
 

--- a/cmake/cmake-modules/CommonSetup.cmake
+++ b/cmake/cmake-modules/CommonSetup.cmake
@@ -1,6 +1,9 @@
 # Common setup instructions shared by all AirSim CMakeLists.
 
 macro(CommonSetup)
+
+    find_package(Threads REQUIRED)
+
     message(STATUS "Running CommonSetup...")   
     
     find_path(AIRSIM_ROOT NAMES AirSim.sln PATHS ".." "../.." "../../.." "../../../.." "../../../../.." "../../../../../..")
@@ -21,7 +24,13 @@ macro(CommonSetup)
         else ()
 		    ##TODO: Werror removed temporarily. It should be added back after Linux build is stable
             set(CMAKE_CXX_FLAGS "-std=c++14 -ggdb -lpthread -Wall -Wextra -Wstrict-aliasing -fmax-errors=2 -Wunreachable-code -Wcast-qual -Wctor-dtor-privacy -Wdisabled-optimization -Wformat=2 -Winit-self -Wmissing-include-dirs -Wnoexcept -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wstrict-null-sentinel -Wstrict-overflow=5 -Wswitch-default -Wundef -Wno-unused -Wno-variadic-macros -Wno-parentheses -fdiagnostics-show-option ${MAVLINK_OVERRIDES} ${BOOST_OVERRIDES} ${RPC_LIB_DEFINES} -ldl ${CMAKE_CXX_FLAGS}")
-            set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ")
+
+            if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+                # make sure to match the compiler flags with which the Unreal
+                # Engine is built with
+                set(CMAKE_CXX_FLAGS "-stdlib=libc++ ${CMAKE_CXX_FLAGS}")
+                set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -lc++ -lc++abi")
+            endif ()
         endif ()
         set(BUILD_PLATFORM "x64")
         set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -30,8 +39,6 @@ macro(CommonSetup)
         set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_WIN32_WINNT=0x0600 /GS /W4 /wd4100 /wd4505 /wd4820 /wd4464 /wd4514 /wd4710 /wd4571 /Zc:wchar_t /ZI /Zc:inline /fp:precise /D_SCL_SECURE_NO_WARNINGS /D_CRT_SECURE_NO_WARNINGS /D_UNICODE /DUNICODE /WX- /Zc:forScope /Gd /EHsc ")
         set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /NXCOMPAT /DYNAMICBASE /INCREMENTAL:NO ")
     ENDIF()
-
-    find_package(Threads REQUIRED)
 
     ## common boost settings to make sure we are all on the same page
     set(Boost_USE_STATIC_LIBS ON) 


### PR DESCRIPTION
This readds `-stdlib=libc++` to the linux build when building with clang. It's necessary, as described in https://github.com/Microsoft/AirSim/pull/43 and avoids problems like https://github.com/Microsoft/AirSim/issues/68