### PR TITLE
PS3 controller information

### DIFF
--- a/docs/sitl.md
+++ b/docs/sitl.md
@@ -51,3 +51,5 @@ We have tried it and gladly switched back to regular RC. But just in case you wa
 3. Go to General tab and check the Virtual Joystick checkbox.
 4. Go back to settings screen (gears icon), click on Parameters tab, type `COM_RC_IN_MODE` in search box and change its value to either `Joystick/No RC Checks` or `Virtual RC by Joystick`.
 5. You should now see a new tab "Joystick" where you can do the calibration.
+
+A Playstation 3 controller is confirmed to work as an AirSim controller. On Windows, an emulator to make it look like an Xbox 360 controller, is required however. Many different solutions are available online, the [x360ce](https://github.com/x360ce/x360ce) _Xbox 360 Controller Emulator_ is an excellent suggestion to get everything configured easily.


### PR DESCRIPTION
Added confirmation that a Playstation 3 controller can be used as an AirSim controller. The required driver is also linked.