### PR TITLE
Fix forward declaration scope issues in semaphore class on macOS

### DIFF
--- a/MavLinkCom/include/Semaphore.hpp
+++ b/MavLinkCom/include/Semaphore.hpp
@@ -9,6 +9,8 @@
 #include <semaphore.h>
 #endif
 
+class semaphore_impl;
+
 namespace mavlink_utils
 {
 	/*
@@ -35,7 +37,6 @@ namespace mavlink_utils
 		// wait will block.  Throws exception if an error occurs.
 		bool timed_wait(int milliseconds);
 	private:
-		class semaphore_impl;
 		std::unique_ptr<semaphore_impl> impl_;
 	};
 }


### PR DESCRIPTION
This fixes building on macOS using gcc-6 for me. Not sure if this is how it should be.