### PR TITLE
Initial working version of mac and linux travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,74 @@
+language: cpp
+#git:
+# shorten this if we can nail down submodule depth
+#  depth: 3
+
+fast_finish: false
+
+matrix:
+  allow_failures:
+    - os: osx
+    - os: linux
+
+  include:
+    # linux version have unique dependencies, so we set them up individually
+    - os: linux
+      dist: trusty
+      sudo: required
+      services:
+        - docker
+
+    # OS X CMake
+    - os: osx
+      sudo: required
+      osx_image: xcode8.2
+      compiler:
+        - clang
+      env:
+        - TOOL="cmake"
+        - DESCRIPTION="OS X build/test via CMake"
+        - EIGEN_ROOT="/usr/local/Cellar/eigen/3.3.3"
+        - EIGEN3_INCLUDE_DIR="/usr/local/Cellar/eigen/3.3.3/include/eigen3"
+
+# docker exec xenial apt-get -y install clang libclang-3.8-dev;
+install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      docker pull ubuntu:xenial;
+      docker run -d --name xenial -dti ubuntu:xenial bash;
+      docker ps -a;
+      docker exec xenial mkdir /build;
+      docker cp . xenial:/build;
+      docker exec xenial apt-get update;
+      docker exec xenial apt-get -y upgrade;
+      docker exec xenial apt-get -y install git wget unzip;
+      docker exec xenial apt-get -y install build-essential software-properties-common cmake;
+      docker exec xenial wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -;
+      docker exec xenial apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-3.9 main";
+      docker exec xenial apt-get update;
+      docker exec xenial apt-get -y --allow-unauthenticated install clang-3.9 lldb-3.9;
+      docker exec xenial update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.9 60 --slave /usr/bin/clang++ clang++ /usr/bin/clang++-3.9;
+      docker exec xenial wget https://launchpad.net/ubuntu/+source/libc++/3.9.1-2/+build/11842034/+files/libc++-dev_3.9.1-2_amd64.deb;
+      docker exec xenial wget https://launchpad.net/ubuntu/+source/libc++/3.9.1-2/+build/11842034/+files/libc++-helpers_3.9.1-2_all.deb;
+      docker exec xenial wget https://launchpad.net/ubuntu/+source/libc++/3.9.1-2/+build/11842034/+files/libc++1_3.9.1-2_amd64.deb;
+      docker exec xenial wget https://launchpad.net/ubuntu/+source/libc++/3.9.1-2/+build/11842034/+files/libc++abi-dev_3.9.1-2_amd64.deb;
+      docker exec xenial wget https://launchpad.net/ubuntu/+source/libc++/3.9.1-2/+build/11842034/+files/libc++abi1_3.9.1-2_amd64.deb;
+      docker exec xenial dpkg -i libc++1_3.9.1-2_amd64.deb libc++abi1_3.9.1-2_amd64.deb libc++-dev_3.9.1-2_amd64.deb libc++-helpers_3.9.1-2_all.deb;
+    elif [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ "$TOOL" == "cmake" ]]; then
+      echo "No install osx actions--using repo eigen";
+    fi
+
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      echo "No pre-install linux actions--using docker";
+    elif [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ "$TOOL" == "cmake" ]]; then
+      echo "No pre-install osx actions";
+    fi
+
+#docker exec xenial /bin/sh -c "export EIGEN3_INCLUDE_DIR=/build/eigen/eigen3 && cd /build/cmake && sh ./build.sh && cmake . && make";
+script:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      docker exec -t --privileged xenial /build/build.sh;
+    elif  [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      git submodule update --init --recursive;
+      ./build.sh;
+    fi


### PR DESCRIPTION
As [mentioned before](https://github.com/Microsoft/AirSim/issues/2#issuecomment-285072421) in addressing the need to keep the mac and linux build working in #2, #72 (and #15, #36, #18, #19, #43), this is a working version for mac (10.12, Xcode 8.2) and linux (16.04, clang 3.9) builds through Travis CI.  A repo owner still needs to link the AirSim repo to Travis CI via repo settings (Integrations and Services). Proof of current working fork build is at https://travis-ci.org/ghexp/AirSim. 