### PR TITLE
fixes errors due to new rosflight code as mentioned in issue #112

### DIFF
--- a/AirLib/include/controllers/rosflight/AirSimRosFlightBoard.hpp
+++ b/AirLib/include/controllers/rosflight/AirSimRosFlightBoard.hpp
@@ -102,7 +102,7 @@ public:
         if (index < OutputMotorCount)
             motors_pwm_[index] = value;
         else
-            throw std::exception("cannot write motor output for index > motor count");
+            throw std::runtime_error("cannot write motor output for index > motor count");
     }
 
     virtual void set_led(uint8_t index, bool is_on) override 
@@ -172,12 +172,12 @@ public:
 
     virtual void read_diff_pressure(float& differential_pressure, float& temp, float& velocity) override 
     {
-        throw std::exception("Diff pressure sensor is not available");
+        throw std::runtime_error("Diff pressure sensor is not available");
     }
 
     virtual float read_sonar() override 
     {
-        throw std::exception("Sonar sensor is not available");
+        throw std::runtime_error("Sonar sensor is not available");
     }
 
     virtual void read_mag(int16_t mag_adc[3]) override 

--- a/AirLib/include/controllers/rosflight/RosFlightDroneController.hpp
+++ b/AirLib/include/controllers/rosflight/RosFlightDroneController.hpp
@@ -75,7 +75,7 @@ public:
         case 2: index_quadx = 3; break;
         case 3: index_quadx = 0; break;
         default:
-            throw std::exception("Rotor index beyond 3 is not supported yet in ROSFlight firmware");
+            throw std::runtime_error("Rotor index beyond 3 is not supported yet in ROSFlight firmware");
         }
 
         auto control_signal = board_->getMotorControlSignal(index_quadx);

--- a/AirLib/include/controllers/rosflight/firmware/estimator.hpp
+++ b/AirLib/include/controllers/rosflight/firmware/estimator.hpp
@@ -53,7 +53,7 @@ private:
     vector_t wbar;
     vector_t wfinal;
     vector_t w_acc;
-    constexpr static vector_t g = {0.0f, 0.0f, -1.0f};
+    vector_t g = {0.0f, 0.0f, -1.0f};
     vector_t b;
     quaternion_t q_tilde;
     quaternion_t q_hat;

--- a/AirLib/include/controllers/rosflight/firmware/mixer.hpp
+++ b/AirLib/include/controllers/rosflight/firmware/mixer.hpp
@@ -38,7 +38,7 @@ public:
 
 private:
     void write_motor(uint8_t index, int32_t value);
-    void Mixer::write_servo(uint8_t index, int32_t value);
+    void write_servo(uint8_t index, int32_t value);
 
 private:
     typedef enum

--- a/AirLib/include/controllers/rosflight/firmware/mixer.hpp
+++ b/AirLib/include/controllers/rosflight/firmware/mixer.hpp
@@ -68,7 +68,7 @@ private:
     Params* params;
     Board* board;
 
-    constexpr static mixer_t quadcopter_plus_mixing =
+    mixer_t quadcopter_plus_mixing =
     {
         {M, M, M, M, NONE, NONE, NONE, NONE}, // output_type
 
@@ -79,7 +79,7 @@ private:
     };
 
 
-    constexpr static mixer_t quadcopter_x_mixing =
+    mixer_t quadcopter_x_mixing =
     {
         {M, M, M, M, NONE, NONE, NONE, NONE}, // output_type
 
@@ -89,7 +89,7 @@ private:
         {-1.0f, 1.0f, 1.0f,-1.0f,  0.0f, 0.0f, 0.0f, 0.0f}  // Z Mix
     };
 
-    constexpr static mixer_t quadcopter_h_mixing =
+    mixer_t quadcopter_h_mixing =
     {
         {M, M, M, M, NONE, NONE, NONE, NONE}, // output_type
 
@@ -99,7 +99,7 @@ private:
         {-1.0f, 1.0f, 1.0f,-1.0f,  0.0f, 0.0f, 0.0f, 0.0f}  // Z Mix
     };
 
-    constexpr static mixer_t fixedwing_mixing =
+    mixer_t fixedwing_mixing =
     {
         {S, S, M, S, NONE, NONE, NONE, NONE},
 
@@ -109,7 +109,7 @@ private:
         { 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f}  // Z Mix
     };
 
-    constexpr static mixer_t tricopter_mixing =
+    mixer_t tricopter_mixing =
     {
         {M, M, M, S, NONE, NONE, NONE, NONE},
 
@@ -119,7 +119,7 @@ private:
         { 0.0f,     0.0f,   0.0f,   1.0f, 0.0f, 0.0f, 0.0f, 0.0f}  // Z Mix
     };
 
-    constexpr static mixer_t Y6_mixing =
+    mixer_t Y6_mixing =
     {
         {M, M, M, M, M, M, NONE, NONE},
         { 1.0f,   1.0f,    1.0f,    1.0f,    1.0f,    1.0f,   0.0f, 0.0f}, // F Mix
@@ -128,7 +128,7 @@ private:
         {-1.0f,   1.0f,    1.0f,    1.0f,   -1.0f,   -1.0f,   0.0f, 0.0f}  // Z Mix
     };
 
-    constexpr static mixer_t const *array_of_mixers[NUM_MIXERS] =
+    mixer_t const *array_of_mixers[NUM_MIXERS] =
     {
         &quadcopter_plus_mixing,
         &quadcopter_x_mixing,

--- a/AirLib/include/controllers/rosflight/firmware/param.hpp
+++ b/AirLib/include/controllers/rosflight/firmware/param.hpp
@@ -313,7 +313,7 @@ void Params::init(Board* _board, CommLink* _comm_link)
 
     for (uint8_t i = 0; i < PARAMS_COUNT; i++)
     {
-        init_param_int(static_cast<param_id_t>(i), "DEFAULT", 0);
+        init_param_int(static_cast<param_id_t>(i), (char *)"DEFAULT", 0);
     }
     board->init_params();
     if (!read_params())
@@ -346,151 +346,151 @@ void Params::set_param_defaults(void)
     /******************************/
     /*** HARDWARE CONFIGURATION ***/
     /******************************/
-    init_param_int(PARAM_BOARD_REVISION, "BOARD_REV", 2); // Major board revision of naze32/flip32 | 1 | 6
-    init_param_int(PARAM_BAUD_RATE, "BAUD_RATE", 921600); // Baud rate of communication with onboard computer | 9600 | 921600
+    init_param_int(PARAM_BOARD_REVISION, (char *)"BOARD_REV", 2); // Major board revision of naze32/flip32 | 1 | 6
+    init_param_int(PARAM_BAUD_RATE, (char *)"BAUD_RATE", 921600); // Baud rate of communication with onboard computer | 9600 | 921600
 
     /*****************************/
     /*** MAVLINK CONFIGURATION ***/
     /*****************************/
-    init_param_int(PARAM_SYSTEM_ID, "SYS_ID", 1); // Mavlink System ID  | 1 | 255
-    init_param_int(PARAM_STREAM_HEARTBEAT_RATE, "STRM_HRTBT", 1); // Rate of heartbeat streaming (Hz) | 0 | 1000
+    init_param_int(PARAM_SYSTEM_ID, (char *)"SYS_ID", 1); // Mavlink System ID  | 1 | 255
+    init_param_int(PARAM_STREAM_HEARTBEAT_RATE, (char *)"STRM_HRTBT", 1); // Rate of heartbeat streaming (Hz) | 0 | 1000
 
-    init_param_int(PARAM_STREAM_ATTITUDE_RATE, "STRM_ATTITUDE", 100); // Rate of attitude stream (Hz) | 0 | 1000
-    init_param_int(PARAM_STREAM_IMU_RATE, "STRM_IMU", 500); // Rate of IMU stream (Hz) | 0 | 1000
-    init_param_int(PARAM_STREAM_MAG_RATE, "STRM_MAG", 75); // Rate of magnetometer stream (Hz) | 0 | 75
-    init_param_int(PARAM_STREAM_BARO_RATE, "STRM_BARO", 100); // Rate of barometer stream (Hz) | 0 | 100
-    init_param_int(PARAM_STREAM_AIRSPEED_RATE, "STRM_AIRSPEED", 20); // Rate of airspeed stream (Hz) | 0 |  50
-    init_param_int(PARAM_STREAM_GPS_RATE, "STRM_GPS", 0); // Rate of GPS stream (Hz) | 0 | 1
-    init_param_int(PARAM_STREAM_SONAR_RATE, "STRM_SONAR", 40); // Rate of sonar stream (Hz) | 0 | 40
+    init_param_int(PARAM_STREAM_ATTITUDE_RATE, (char *)"STRM_ATTITUDE", 100); // Rate of attitude stream (Hz) | 0 | 1000
+    init_param_int(PARAM_STREAM_IMU_RATE, (char *)"STRM_IMU", 500); // Rate of IMU stream (Hz) | 0 | 1000
+    init_param_int(PARAM_STREAM_MAG_RATE, (char *)"STRM_MAG", 75); // Rate of magnetometer stream (Hz) | 0 | 75
+    init_param_int(PARAM_STREAM_BARO_RATE, (char *)"STRM_BARO", 100); // Rate of barometer stream (Hz) | 0 | 100
+    init_param_int(PARAM_STREAM_AIRSPEED_RATE, (char *)"STRM_AIRSPEED", 20); // Rate of airspeed stream (Hz) | 0 |  50
+    init_param_int(PARAM_STREAM_GPS_RATE, (char *)"STRM_GPS", 0); // Rate of GPS stream (Hz) | 0 | 1
+    init_param_int(PARAM_STREAM_SONAR_RATE, (char *)"STRM_SONAR", 40); // Rate of sonar stream (Hz) | 0 | 40
 
-    init_param_int(PARAM_STREAM_SERVO_OUTPUT_RAW_RATE, "STRM_SERVO", 50); // Rate of raw output stream | 0 |  490
-    init_param_int(PARAM_STREAM_RC_RAW_RATE, "STRM_RC", 50); // Rate of raw RC input stream | 0 | 50
+    init_param_int(PARAM_STREAM_SERVO_OUTPUT_RAW_RATE, (char *)"STRM_SERVO", 50); // Rate of raw output stream | 0 |  490
+    init_param_int(PARAM_STREAM_RC_RAW_RATE, (char *)"STRM_RC", 50); // Rate of raw RC input stream | 0 | 50
 
     /********************************/
     /*** CONTROLLER CONFIGURATION ***/
     /********************************/
-    init_param_int(PARAM_MAX_COMMAND, "PARAM_MAX_CMD", 1000); // saturation point for PID controller output | 0 | 1000
+    init_param_int(PARAM_MAX_COMMAND, (char *)"PARAM_MAX_CMD", 1000); // saturation point for PID controller output | 0 | 1000
 
-    init_param_float(PARAM_PID_ROLL_RATE_P, "PID_ROLL_RATE_P", 0.070f); // Roll Rate Proportional Gain | 0.0 | 1000.0
-    init_param_float(PARAM_PID_ROLL_RATE_I, "PID_ROLL_RATE_I", 0.000f); // Roll Rate Integral Gain | 0.0 | 1000.0
-    init_param_float(PARAM_PID_ROLL_RATE_D, "PID_ROLL_RATE_D", 0.000f); // Rall Rate Derivative Gain | 0.0 | 1000.0
-    init_param_float(PARAM_ROLL_RATE_TRIM, "ROLL_RATE_TRIM", 0.0f); // Roll Rate Trim - See RC calibration | -1000.0 | 1000.0
-    init_param_float(PARAM_MAX_ROLL_RATE, "MAX_ROLL_RATE", 3.14159f); // Maximum Roll Rate command accepted into PID controllers | 0.0 | 1000.0
+    init_param_float(PARAM_PID_ROLL_RATE_P, (char *)"PID_ROLL_RATE_P", 0.070f); // Roll Rate Proportional Gain | 0.0 | 1000.0
+    init_param_float(PARAM_PID_ROLL_RATE_I, (char *)"PID_ROLL_RATE_I", 0.000f); // Roll Rate Integral Gain | 0.0 | 1000.0
+    init_param_float(PARAM_PID_ROLL_RATE_D, (char *)"PID_ROLL_RATE_D", 0.000f); // Rall Rate Derivative Gain | 0.0 | 1000.0
+    init_param_float(PARAM_ROLL_RATE_TRIM, (char *)"ROLL_RATE_TRIM", 0.0f); // Roll Rate Trim - See RC calibration | -1000.0 | 1000.0
+    init_param_float(PARAM_MAX_ROLL_RATE, (char *)"MAX_ROLL_RATE", 3.14159f); // Maximum Roll Rate command accepted into PID controllers | 0.0 | 1000.0
 
-    init_param_float(PARAM_PID_PITCH_RATE_P, "PID_PITCH_RATE_P", 0.070f);  // Pitch Rate Proporitional Gain | 0.0 | 1000.0
-    init_param_float(PARAM_PID_PITCH_RATE_I, "PID_PITCH_RATE_I", 0.0000f); // Pitch Rate Integral Gain | 0.0 | 1000.0
-    init_param_float(PARAM_PID_PITCH_RATE_D, "PID_PITCH_RATE_D", 0.0000f); // Pitch Rate Derivative Gain | 0.0 | 1000.0
-    init_param_float(PARAM_PITCH_RATE_TRIM, "PITCH_RATE_TRIM", 0.0f); // Pitch Rate Trim - See RC calibration | -1000.0 | 1000.0
-    init_param_float(PARAM_MAX_PITCH_RATE, "MAX_PITCH_RATE", 3.14159f);  // Maximum Pitch Rate command accepted into PID controllers | 0.0 | 1000.0
+    init_param_float(PARAM_PID_PITCH_RATE_P, (char *)"PID_PITCH_RATE_P", 0.070f);  // Pitch Rate Proporitional Gain | 0.0 | 1000.0
+    init_param_float(PARAM_PID_PITCH_RATE_I, (char *)"PID_PITCH_RATE_I", 0.0000f); // Pitch Rate Integral Gain | 0.0 | 1000.0
+    init_param_float(PARAM_PID_PITCH_RATE_D, (char *)"PID_PITCH_RATE_D", 0.0000f); // Pitch Rate Derivative Gain | 0.0 | 1000.0
+    init_param_float(PARAM_PITCH_RATE_TRIM, (char *)"PITCH_RATE_TRIM", 0.0f); // Pitch Rate Trim - See RC calibration | -1000.0 | 1000.0
+    init_param_float(PARAM_MAX_PITCH_RATE, (char *)"MAX_PITCH_RATE", 3.14159f);  // Maximum Pitch Rate command accepted into PID controllers | 0.0 | 1000.0
 
-    init_param_float(PARAM_PID_YAW_RATE_P, "PID_YAW_RATE_P", 0.25f);   // Yaw Rate Proporitional Gain | 0.0 | 1000.0
-    init_param_float(PARAM_PID_YAW_RATE_I, "PID_YAW_RATE_I", 0.0f);  // Yaw Rate Integral Gain | 0.0 | 1000.0
-    init_param_float(PARAM_PID_YAW_RATE_D, "PID_YAW_RATE_D", 0.0f);  // Yaw Rate Derivative Gain | 0.0 | 1000.0
-    init_param_float(PARAM_YAW_RATE_TRIM, "YAW_RATE_TRIM", 0.0f);  // Yaw Rate Trim - See RC calibration | -1000.0 | 1000.0
-    init_param_float(PARAM_MAX_YAW_RATE, "MAX_YAW_RATE", 6.283f);   // Maximum Yaw Rate command accepted into PID controllers | 0.0 | 1000.0
+    init_param_float(PARAM_PID_YAW_RATE_P, (char *)"PID_YAW_RATE_P", 0.25f);   // Yaw Rate Proporitional Gain | 0.0 | 1000.0
+    init_param_float(PARAM_PID_YAW_RATE_I, (char *)"PID_YAW_RATE_I", 0.0f);  // Yaw Rate Integral Gain | 0.0 | 1000.0
+    init_param_float(PARAM_PID_YAW_RATE_D, (char *)"PID_YAW_RATE_D", 0.0f);  // Yaw Rate Derivative Gain | 0.0 | 1000.0
+    init_param_float(PARAM_YAW_RATE_TRIM, (char *)"YAW_RATE_TRIM", 0.0f);  // Yaw Rate Trim - See RC calibration | -1000.0 | 1000.0
+    init_param_float(PARAM_MAX_YAW_RATE, (char *)"MAX_YAW_RATE", 6.283f);   // Maximum Yaw Rate command accepted into PID controllers | 0.0 | 1000.0
 
-    init_param_float(PARAM_PID_ROLL_ANGLE_P, "PID_ROLL_ANG_P", 0.15f);   // Roll Angle Proporitional Gain | 0.0 | 1000.0
-    init_param_float(PARAM_PID_ROLL_ANGLE_I, "PID_ROLL_ANG_I", 0.0f);   // Roll Angle Integral Gain | 0.0 | 1000.0
-    init_param_float(PARAM_PID_ROLL_ANGLE_D, "PID_ROLL_ANG_D", 0.07f);  // Roll Angle Derivative Gain | 0.0 | 1000.0
-    init_param_float(PARAM_ROLL_ANGLE_TRIM, "ROLL_TRIM", 0.0f);  // Roll Angle Trim - See RC calibration | -1000.0 | 1000.0
-    init_param_float(PARAM_MAX_ROLL_ANGLE, "MAX_ROLL_ANG", 0.786f);   // Maximum Roll Angle command accepted into PID controllers | 0.0 | 1000.0
+    init_param_float(PARAM_PID_ROLL_ANGLE_P, (char *)"PID_ROLL_ANG_P", 0.15f);   // Roll Angle Proporitional Gain | 0.0 | 1000.0
+    init_param_float(PARAM_PID_ROLL_ANGLE_I, (char *)"PID_ROLL_ANG_I", 0.0f);   // Roll Angle Integral Gain | 0.0 | 1000.0
+    init_param_float(PARAM_PID_ROLL_ANGLE_D, (char *)"PID_ROLL_ANG_D", 0.07f);  // Roll Angle Derivative Gain | 0.0 | 1000.0
+    init_param_float(PARAM_ROLL_ANGLE_TRIM, (char *)"ROLL_TRIM", 0.0f);  // Roll Angle Trim - See RC calibration | -1000.0 | 1000.0
+    init_param_float(PARAM_MAX_ROLL_ANGLE, (char *)"MAX_ROLL_ANG", 0.786f);   // Maximum Roll Angle command accepted into PID controllers | 0.0 | 1000.0
 
-    init_param_float(PARAM_PID_PITCH_ANGLE_P, "PID_PITCH_ANG_P", 0.15f);  // Pitch Angle Proporitional Gain | 0.0 | 1000.0 
-    init_param_float(PARAM_PID_PITCH_ANGLE_I, "PID_PITCH_ANG_I", 0.0f);  // Pitch Angle Integral Gain | 0.0 | 1000.0
-    init_param_float(PARAM_PID_PITCH_ANGLE_D, "PID_PITCH_ANG_D", 0.07f); // Pitch Angle Derivative Gain | 0.0 | 1000.0 
-    init_param_float(PARAM_PITCH_ANGLE_TRIM, "PITCH_TRIM", 0.0f);  // Pitch Angle Trim - See RC calibration | -1000.0 | 1000.0
-    init_param_float(PARAM_MAX_PITCH_ANGLE, "MAX_PITCH_ANG", 0.786f);   // Maximum Pitch Angle command accepted into PID controllers | 0.0 | 1000.0
+    init_param_float(PARAM_PID_PITCH_ANGLE_P, (char *)"PID_PITCH_ANG_P", 0.15f);  // Pitch Angle Proporitional Gain | 0.0 | 1000.0 
+    init_param_float(PARAM_PID_PITCH_ANGLE_I, (char *)"PID_PITCH_ANG_I", 0.0f);  // Pitch Angle Integral Gain | 0.0 | 1000.0
+    init_param_float(PARAM_PID_PITCH_ANGLE_D, (char *)"PID_PITCH_ANG_D", 0.07f); // Pitch Angle Derivative Gain | 0.0 | 1000.0 
+    init_param_float(PARAM_PITCH_ANGLE_TRIM, (char *)"PITCH_TRIM", 0.0f);  // Pitch Angle Trim - See RC calibration | -1000.0 | 1000.0
+    init_param_float(PARAM_MAX_PITCH_ANGLE, (char *)"MAX_PITCH_ANG", 0.786f);   // Maximum Pitch Angle command accepted into PID controllers | 0.0 | 1000.0
 
-    init_param_float(PARAM_PID_ALT_P, "PID_ALT_P", 0.0f); // Altitude Proporitional Gain | 0.0 | 1000.0 
-    init_param_float(PARAM_PID_ALT_I, "PID_ALT_I", 0.0f); // Altitude Integral Gain | 0.0 | 1000.0 
-    init_param_float(PARAM_PID_ALT_D, "PID_ALT_D", 0.0f); // Altitude Derivative Gain | 0.0 | 1000.0 
-    init_param_float(PARAM_HOVER_THROTTLE, "HOVER_THR", 0.5); // Hover Throttle - See RC calibration | 0.0 | 1.0
+    init_param_float(PARAM_PID_ALT_P, (char *)"PID_ALT_P", 0.0f); // Altitude Proporitional Gain | 0.0 | 1000.0 
+    init_param_float(PARAM_PID_ALT_I, (char *)"PID_ALT_I", 0.0f); // Altitude Integral Gain | 0.0 | 1000.0 
+    init_param_float(PARAM_PID_ALT_D, (char *)"PID_ALT_D", 0.0f); // Altitude Derivative Gain | 0.0 | 1000.0 
+    init_param_float(PARAM_HOVER_THROTTLE, (char *)"HOVER_THR", 0.5); // Hover Throttle - See RC calibration | 0.0 | 1.0
 
-    init_param_float(PARAM_PID_TAU, "PID_TAU", 0.05f); // Dirty Derivative time constant - See controller documentation | 0.0 | 1.0
+    init_param_float(PARAM_PID_TAU, (char *)"PID_TAU", 0.05f); // Dirty Derivative time constant - See controller documentation | 0.0 | 1.0
 
 
     /*************************/
     /*** PWM CONFIGURATION ***/
     /*************************/
-    init_param_int(PARAM_MOTOR_PWM_SEND_RATE, "MOTOR_PWM_UPDATE", 490); // Refresh rate of motor commands to motors - See motor documentation | 0 | 1000
-    init_param_int(PARAM_MOTOR_IDLE_PWM, "MOTOR_IDLE_PWM", 1100); // Idle PWM sent to motors at zero throttle (Set above 1100 to spin when armed) | 1000 | 2000
-    init_param_int(PARAM_SPIN_MOTORS_WHEN_ARMED, "ARM_SPIN_MOTORS", true); // Enforce MOTOR_IDLE_PWM | 0 | 1
+    init_param_int(PARAM_MOTOR_PWM_SEND_RATE, (char *)"MOTOR_PWM_UPDATE", 490); // Refresh rate of motor commands to motors - See motor documentation | 0 | 1000
+    init_param_int(PARAM_MOTOR_IDLE_PWM, (char *)"MOTOR_IDLE_PWM", 1100); // Idle PWM sent to motors at zero throttle (Set above 1100 to spin when armed) | 1000 | 2000
+    init_param_int(PARAM_SPIN_MOTORS_WHEN_ARMED, (char *)"ARM_SPIN_MOTORS", true); // Enforce MOTOR_IDLE_PWM | 0 | 1
 
     /*******************************/
     /*** ESTIMATOR CONFIGURATION ***/
     /*******************************/
-    init_param_int(PARAM_INIT_TIME, "FILTER_INIT_T", 3000); // Time in ms to initialize estimator | 0 | 100000
-    init_param_float(PARAM_FILTER_KP, "FILTER_KP", 1.0f); // estimator proportional gain - See estimator documentation | 0 | 10.0
-    init_param_float(PARAM_FILTER_KI, "FILTER_KI", 0.1f); // estimator integral gain - See estimator documentation | 0 | 1.0
+    init_param_int(PARAM_INIT_TIME, (char *)"FILTER_INIT_T", 3000); // Time in ms to initialize estimator | 0 | 100000
+    init_param_float(PARAM_FILTER_KP, (char *)"FILTER_KP", 1.0f); // estimator proportional gain - See estimator documentation | 0 | 10.0
+    init_param_float(PARAM_FILTER_KI, (char *)"FILTER_KI", 0.1f); // estimator integral gain - See estimator documentation | 0 | 1.0
 
-    init_param_float(PARAM_GYRO_ALPHA, "GYRO_LPF_ALPHA", 0.888f); // Low-pass filter constant - See estimator documentation | 0 | 1.0
-    init_param_float(PARAM_ACC_ALPHA, "ACC_LPF_ALPHA", 0.888f); // Low-pass filter constant - See estimator documentation | 0 | 1.0
+    init_param_float(PARAM_GYRO_ALPHA, (char *)"GYRO_LPF_ALPHA", 0.888f); // Low-pass filter constant - See estimator documentation | 0 | 1.0
+    init_param_float(PARAM_ACC_ALPHA, (char *)"ACC_LPF_ALPHA", 0.888f); // Low-pass filter constant - See estimator documentation | 0 | 1.0
 
-    init_param_float(PARAM_ACCEL_SCALE, "ACCEL_SCALE", 1.0f); // Scale factor to apply to IMU measurements - Read-Only | 0.5 | 2.0
+    init_param_float(PARAM_ACCEL_SCALE, (char *)"ACCEL_SCALE", 1.0f); // Scale factor to apply to IMU measurements - Read-Only | 0.5 | 2.0
 
-    init_param_float(PARAM_GYRO_X_BIAS, "GYRO_X_BIAS", 0.0f); // Constant x-bias of gyroscope readings | -1.0 | 1.0
-    init_param_float(PARAM_GYRO_Y_BIAS, "GYRO_Y_BIAS", 0.0f); // Constant y-bias of gyroscope readings | -1.0 | 1.0
-    init_param_float(PARAM_GYRO_Z_BIAS, "GYRO_Z_BIAS", 0.0f); // Constant z-bias of gyroscope readings | -1.0 | 1.0
-    init_param_float(PARAM_ACC_X_BIAS, "ACC_X_BIAS", 0.0f); // Constant x-bias of accelerometer readings | -2.0 | 2.0
-    init_param_float(PARAM_ACC_Y_BIAS, "ACC_Y_BIAS", 0.0f); // Constant y-bias of accelerometer readings | -2.0 | 2.0
-    init_param_float(PARAM_ACC_Z_BIAS, "ACC_Z_BIAS", 0.0f); // Constant z-bias of accelerometer readings | -2.0 | 2.0
-    init_param_float(PARAM_ACC_X_TEMP_COMP, "ACC_X_TEMP_COMP", 0.0f); // Linear x-axis temperature compensation constant | -2.0 | 2.0
-    init_param_float(PARAM_ACC_Y_TEMP_COMP, "ACC_Y_TEMP_COMP", 0.0f); // Linear y-axis temperature compensation constant | -2.0 | 2.0
-    init_param_float(PARAM_ACC_Z_TEMP_COMP, "ACC_Z_TEMP_COMP", 0.0f); // Linear z-axis temperature compensation constant | -2.0 | 2.0
+    init_param_float(PARAM_GYRO_X_BIAS, (char *)"GYRO_X_BIAS", 0.0f); // Constant x-bias of gyroscope readings | -1.0 | 1.0
+    init_param_float(PARAM_GYRO_Y_BIAS, (char *)"GYRO_Y_BIAS", 0.0f); // Constant y-bias of gyroscope readings | -1.0 | 1.0
+    init_param_float(PARAM_GYRO_Z_BIAS, (char *)"GYRO_Z_BIAS", 0.0f); // Constant z-bias of gyroscope readings | -1.0 | 1.0
+    init_param_float(PARAM_ACC_X_BIAS, (char *)"ACC_X_BIAS", 0.0f); // Constant x-bias of accelerometer readings | -2.0 | 2.0
+    init_param_float(PARAM_ACC_Y_BIAS, (char *)"ACC_Y_BIAS", 0.0f); // Constant y-bias of accelerometer readings | -2.0 | 2.0
+    init_param_float(PARAM_ACC_Z_BIAS, (char *)"ACC_Z_BIAS", 0.0f); // Constant z-bias of accelerometer readings | -2.0 | 2.0
+    init_param_float(PARAM_ACC_X_TEMP_COMP, (char *)"ACC_X_TEMP_COMP", 0.0f); // Linear x-axis temperature compensation constant | -2.0 | 2.0
+    init_param_float(PARAM_ACC_Y_TEMP_COMP, (char *)"ACC_Y_TEMP_COMP", 0.0f); // Linear y-axis temperature compensation constant | -2.0 | 2.0
+    init_param_float(PARAM_ACC_Z_TEMP_COMP, (char *)"ACC_Z_TEMP_COMP", 0.0f); // Linear z-axis temperature compensation constant | -2.0 | 2.0
 
     /************************/
     /*** RC CONFIGURATION ***/
     /************************/
-    init_param_int(PARAM_RC_TYPE, "RC_TYPE", 1); // Type of RC input 0 - Parallel PWM (PWM), 1 - Pulse-Position Modulation (PPM) | 0 | 1
-    init_param_int(PARAM_RC_X_CHANNEL, "RC_X_CHN", 0); // RC input channel mapped to x-axis commands [0 - indexed] | 0 | 3 
-    init_param_int(PARAM_RC_Y_CHANNEL, "RC_Y_CHN", 1); // RC input channel mapped to y-axis commands [0 - indexed] | 0 | 3
-    init_param_int(PARAM_RC_Z_CHANNEL, "RC_Z_CHN", 3); // RC input channel mapped to z-axis commands [0 - indexed] | 0 | 3
-    init_param_int(PARAM_RC_F_CHANNEL, "RC_F_CHN", 2); // RC input channel mapped to F-axis commands [0 - indexed] | 0 | 3
-    init_param_int(PARAM_RC_ATTITUDE_OVERRIDE_CHANNEL, "RC_ATT_OVRD_CHN", 4); // RC switch mapped to attitude override [0 -indexed] | 4 | 7
-    init_param_int(PARAM_RC_THROTTLE_OVERRIDE_CHANNEL, "RC_THR_OVRD_CHN", 5); // RC switch hannel mapped to throttle override [0 -indexed] | 4 | 7
-    init_param_int(PARAM_RC_ATT_CONTROL_TYPE_CHANNEL, "RC_ATT_CTRL_CHN", 6); // RC switch channel mapped to attitude control type [0 -indexed] | 4 | 7
-    init_param_int(PARAM_RC_F_CONTROL_TYPE_CHANNEL, "RC_F_CTRL_CHN", 7); // RC switch channel mapped to throttle control type override [0 -indexed] | 4 | 7
-    init_param_int(PARAM_RC_NUM_CHANNELS, "RC_NUM_CHN", 9); // number of RC input channels | 1 | 8
+    init_param_int(PARAM_RC_TYPE, (char *)"RC_TYPE", 1); // Type of RC input 0 - Parallel PWM (PWM), 1 - Pulse-Position Modulation (PPM) | 0 | 1
+    init_param_int(PARAM_RC_X_CHANNEL, (char *)"RC_X_CHN", 0); // RC input channel mapped to x-axis commands [0 - indexed] | 0 | 3 
+    init_param_int(PARAM_RC_Y_CHANNEL, (char *)"RC_Y_CHN", 1); // RC input channel mapped to y-axis commands [0 - indexed] | 0 | 3
+    init_param_int(PARAM_RC_Z_CHANNEL, (char *)"RC_Z_CHN", 3); // RC input channel mapped to z-axis commands [0 - indexed] | 0 | 3
+    init_param_int(PARAM_RC_F_CHANNEL, (char *)"RC_F_CHN", 2); // RC input channel mapped to F-axis commands [0 - indexed] | 0 | 3
+    init_param_int(PARAM_RC_ATTITUDE_OVERRIDE_CHANNEL, (char *)"RC_ATT_OVRD_CHN", 4); // RC switch mapped to attitude override [0 -indexed] | 4 | 7
+    init_param_int(PARAM_RC_THROTTLE_OVERRIDE_CHANNEL, (char *)"RC_THR_OVRD_CHN", 5); // RC switch hannel mapped to throttle override [0 -indexed] | 4 | 7
+    init_param_int(PARAM_RC_ATT_CONTROL_TYPE_CHANNEL, (char *)"RC_ATT_CTRL_CHN", 6); // RC switch channel mapped to attitude control type [0 -indexed] | 4 | 7
+    init_param_int(PARAM_RC_F_CONTROL_TYPE_CHANNEL, (char *)"RC_F_CTRL_CHN", 7); // RC switch channel mapped to throttle control type override [0 -indexed] | 4 | 7
+    init_param_int(PARAM_RC_NUM_CHANNELS, (char *)"RC_NUM_CHN", 9); // number of RC input channels | 1 | 8
 
-    init_param_int(PARAM_RC_X_CENTER, "RC_X_CENTER", 1500); // RC calibration x-axis center (us) | 1000 | 2000
-    init_param_int(PARAM_RC_Y_CENTER, "RC_Y_CENTER", 1500); // RC calibration y-axis center (us) | 1000 | 2000
-    init_param_int(PARAM_RC_Z_CENTER, "RC_Z_CENTER", 1500); // RC calibration z-axis center (us) | 1000 | 2000
-    init_param_int(PARAM_RC_F_BOTTOM, "RC_F_BOTTOM", 1000); // RC calibration F-axis center (us) | 1000 | 2000
-    init_param_int(PARAM_RC_X_RANGE, "RC_X_RANGE", 1000); // RC calibration x-axis range (us) | 500 | 2500
-    init_param_int(PARAM_RC_Y_RANGE, "RC_Y_RANGE", 1000); // RC calibration y-axis range (us) | 500 | 2500
-    init_param_int(PARAM_RC_Z_RANGE, "RC_Z_RANGE", 1000); // RC calibration z-axis range (us) | 500 | 2500
-    init_param_int(PARAM_RC_F_RANGE, "RC_F_RANGE", 1000); // RC calibration F-axis range (us) | 500 | 2500
-    init_param_int(PARAM_RC_SWITCH_5_DIRECTION, "SWITCH_5_DIR", 1); // RC switch 5 toggle direction | 0 | 1
-    init_param_int(PARAM_RC_SWITCH_6_DIRECTION, "SWITCH_6_DIR", 1); // RC switch 6 toggle direction | 0 | 1
-    init_param_int(PARAM_RC_SWITCH_7_DIRECTION, "SWITCH_7_DIR", 1); // RC switch 7 toggle direction | 0 | 1
-    init_param_int(PARAM_RC_SWITCH_8_DIRECTION, "SWITCH_8_DIR", 1); // RC switch 8 toggle direction | 0 | 1
+    init_param_int(PARAM_RC_X_CENTER, (char *)"RC_X_CENTER", 1500); // RC calibration x-axis center (us) | 1000 | 2000
+    init_param_int(PARAM_RC_Y_CENTER, (char *)"RC_Y_CENTER", 1500); // RC calibration y-axis center (us) | 1000 | 2000
+    init_param_int(PARAM_RC_Z_CENTER, (char *)"RC_Z_CENTER", 1500); // RC calibration z-axis center (us) | 1000 | 2000
+    init_param_int(PARAM_RC_F_BOTTOM, (char *)"RC_F_BOTTOM", 1000); // RC calibration F-axis center (us) | 1000 | 2000
+    init_param_int(PARAM_RC_X_RANGE, (char *)"RC_X_RANGE", 1000); // RC calibration x-axis range (us) | 500 | 2500
+    init_param_int(PARAM_RC_Y_RANGE, (char *)"RC_Y_RANGE", 1000); // RC calibration y-axis range (us) | 500 | 2500
+    init_param_int(PARAM_RC_Z_RANGE, (char *)"RC_Z_RANGE", 1000); // RC calibration z-axis range (us) | 500 | 2500
+    init_param_int(PARAM_RC_F_RANGE, (char *)"RC_F_RANGE", 1000); // RC calibration F-axis range (us) | 500 | 2500
+    init_param_int(PARAM_RC_SWITCH_5_DIRECTION, (char *)"SWITCH_5_DIR", 1); // RC switch 5 toggle direction | 0 | 1
+    init_param_int(PARAM_RC_SWITCH_6_DIRECTION, (char *)"SWITCH_6_DIR", 1); // RC switch 6 toggle direction | 0 | 1
+    init_param_int(PARAM_RC_SWITCH_7_DIRECTION, (char *)"SWITCH_7_DIR", 1); // RC switch 7 toggle direction | 0 | 1
+    init_param_int(PARAM_RC_SWITCH_8_DIRECTION, (char *)"SWITCH_8_DIR", 1); // RC switch 8 toggle direction | 0 | 1
 
-    init_param_int(PARAM_RC_OVERRIDE_DEVIATION, "RC_OVRD_DEV", 100); // RC stick deviation from center for overrride (us) | 0 | 1000
-    init_param_int(PARAM_OVERRIDE_LAG_TIME, "OVRD_LAG_TIME", 1000); // RC stick deviation lag time before returning control (ms) | 0 | 100000
-    init_param_int(PARAM_RC_OVERRIDE_TAKE_MIN_THROTTLE, "MIN_THROTTLE", false); // Take minimum throttle between RC and computer at all times | 0 | 1
+    init_param_int(PARAM_RC_OVERRIDE_DEVIATION, (char *)"RC_OVRD_DEV", 100); // RC stick deviation from center for overrride (us) | 0 | 1000
+    init_param_int(PARAM_OVERRIDE_LAG_TIME, (char *)"OVRD_LAG_TIME", 1000); // RC stick deviation lag time before returning control (ms) | 0 | 100000
+    init_param_int(PARAM_RC_OVERRIDE_TAKE_MIN_THROTTLE, (char *)"MIN_THROTTLE", false); // Take minimum throttle between RC and computer at all times | 0 | 1
 
-    init_param_float(PARAM_RC_MAX_ROLL, "RC_MAX_ROLL", 0.786f); // Maximum roll angle command sent by full deflection of RC sticks | 0.0 | 3.14159
-    init_param_float(PARAM_RC_MAX_PITCH, "RC_MAX_PITCH", 0.786f); // Maximum pitch angle command sent by full stick deflection of RC sticks | 0.0 | 3.14159
-    init_param_float(PARAM_RC_MAX_ROLLRATE, "RC_MAX_ROLLRATE", 3.14159f); // Maximum roll rate command sent by full stick deflection of RC sticks | 0.0 | 9.42477796077
-    init_param_float(PARAM_RC_MAX_PITCHRATE, "RC_MAX_PITCHRATE", 3.14159f); // Maximum pitch command sent by full stick deflection of RC sticks | 0.0 | 3.14159
-    init_param_float(PARAM_RC_MAX_YAWRATE, "RC_MAX_YAWRATE", 0.786f); // Maximum pitch command sent by full stick deflection of RC sticks | 0.0 | 3.14159
+    init_param_float(PARAM_RC_MAX_ROLL, (char *)"RC_MAX_ROLL", 0.786f); // Maximum roll angle command sent by full deflection of RC sticks | 0.0 | 3.14159
+    init_param_float(PARAM_RC_MAX_PITCH, (char *)"RC_MAX_PITCH", 0.786f); // Maximum pitch angle command sent by full stick deflection of RC sticks | 0.0 | 3.14159
+    init_param_float(PARAM_RC_MAX_ROLLRATE, (char *)"RC_MAX_ROLLRATE", 3.14159f); // Maximum roll rate command sent by full stick deflection of RC sticks | 0.0 | 9.42477796077
+    init_param_float(PARAM_RC_MAX_PITCHRATE, (char *)"RC_MAX_PITCHRATE", 3.14159f); // Maximum pitch command sent by full stick deflection of RC sticks | 0.0 | 3.14159
+    init_param_float(PARAM_RC_MAX_YAWRATE, (char *)"RC_MAX_YAWRATE", 0.786f); // Maximum pitch command sent by full stick deflection of RC sticks | 0.0 | 3.14159
 
     /***************************/
     /*** FRAME CONFIGURATION ***/
     /***************************/
-    init_param_int(PARAM_MIXER, "MIXER", 1); // Which mixer to choose, 1 = QUADCOPTER_X - See Mixer documentation | 0 | 5
+    init_param_int(PARAM_MIXER, (char *)"MIXER", 1); // Which mixer to choose, 1 = QUADCOPTER_X - See Mixer documentation | 0 | 5
 
-    init_param_int(PARAM_FIXED_WING, "FIXED_WING", false); // switches on passthrough commands for fixedwing operation | 0 | 1
-    init_param_int(PARAM_ELEVATOR_REVERSE, "ELEVATOR_REV", 0); // reverses elevator servo output | 0 | 1
-    init_param_int(PARAM_AILERON_REVERSE, "AIL_REV", 0); // reverses aileron servo output | 0 | 1
-    init_param_int(PARAM_RUDDER_REVERSE, "RUDDER_REV", 0); // reverses rudder servo output | 0 | 1
+    init_param_int(PARAM_FIXED_WING, (char *)"FIXED_WING", false); // switches on passthrough commands for fixedwing operation | 0 | 1
+    init_param_int(PARAM_ELEVATOR_REVERSE, (char *)"ELEVATOR_REV", 0); // reverses elevator servo output | 0 | 1
+    init_param_int(PARAM_AILERON_REVERSE, (char *)"AIL_REV", 0); // reverses aileron servo output | 0 | 1
+    init_param_int(PARAM_RUDDER_REVERSE, (char *)"RUDDER_REV", 0); // reverses rudder servo output | 0 | 1
 
     /********************/
     /*** ARMING SETUP ***/
     /********************/
-    init_param_int(PARAM_ARM_STICKS, "ARM_STICKS", false); // use RC sticks to arm vehicle (disables arm RC switch if enabled) | 0 | 1
-    init_param_int(PARAM_ARM_CHANNEL, "ARM_CHANNEL", 8); // RC switch mapped to arm/disarm [0 -indexed] | 4 | 7
-    init_param_int(PARAM_ARM_THRESHOLD, "ARM_THRESHOLD", 150); // RC deviation from max/min in yaw and throttle for arming and disarming check (us) | 0 | 500
+    init_param_int(PARAM_ARM_STICKS, (char *)"ARM_STICKS", false); // use RC sticks to arm vehicle (disables arm RC switch if enabled) | 0 | 1
+    init_param_int(PARAM_ARM_CHANNEL, (char *)"ARM_CHANNEL", 8); // RC switch mapped to arm/disarm [0 -indexed] | 4 | 7
+    init_param_int(PARAM_ARM_THRESHOLD, (char *)"ARM_THRESHOLD", 150); // RC deviation from max/min in yaw and throttle for arming and disarming check (us) | 0 | 500
 }
 
 bool Params::read_params(void)

--- a/AirLib/include/controllers/rosflight/firmware/sensors.hpp
+++ b/AirLib/include/controllers/rosflight/firmware/sensors.hpp
@@ -78,7 +78,7 @@ private:
     vector_t calib_gyro_sum = { 0.0f, 0.0f, 0.0f };
     uint16_t calib_accel_count = 0;
     vector_t calib_accel_sum = { 0.0f, 0.0f, 0.0f };
-    static constexpr vector_t gravity = { 0.0f, 0.0f, 9.80665f };
+    vector_t gravity = { 0.0f, 0.0f, 9.80665f };
     float acc_temp_sum = 0.0f;
 };
 

--- a/Unreal/Plugins/AirSim/Source/MultiRotorConnector.cpp
+++ b/Unreal/Plugins/AirSim/Source/MultiRotorConnector.cpp
@@ -21,7 +21,7 @@ void MultiRotorConnector::initialize(AFlyingPawn* vehicle_pawn, MultiRotorConnec
         vehicle_params_.reset(new msr::airlib::RosFlightQuadX());
         break;
     default:
-        throw std::exception("ConfigType is not supported in MultiRotorConnector::initialize");
+        throw std::runtime_error("ConfigType is not supported in MultiRotorConnector::initialize");
     }
 
     //init physics vehicle


### PR DESCRIPTION
But this still doesn't get it working in Linux. It compiles however when I call unreal engine with the project's uproject file.
```
[2017.04.01-02.02.16:907][  0]LogLinux:Warning: dlopen failed: /home/vaibhav/Documents/Unreal_Projects/airsim_ue/Plugins/AirSim/Binaries/Linux/libUE4Editor-AirSim.so: undefined symbol: _ZN9rosflight7Sensors7gravityE
[2017.04.01-02.02.16:907][  0]LogModuleManager:Warning: ModuleManager: Unable to load module '/home/vaibhav/Documents/Unreal_Projects/airsim_ue/Plugins/AirSim/Binaries/Linux/libUE4Editor-AirSim.so' because the file couldn't be loaded by the OS.
[2017.04.01-02.02.25:956][  0]LogExit: Preparing to exit.
[2017.04.01-02.02.27:069][  0]LogObj: Freed 0b from 0 cluster array pools.
[2017.04.01-02.02.27:069][  0]LogExit: Object subsystem successfully closed.
[2017.04.01-02.02.27:107][  0]LogModuleManager: Shutting down and abandoning module HotReload (181)
``` 
