### PR TITLE
Fix compiler warnings

### DIFF
--- a/AirLib/include/common/StateReporter.hpp
+++ b/AirLib/include/common/StateReporter.hpp
@@ -52,7 +52,7 @@ public:
 
     //write APIs - heading
     //TODO: need better line end handling
-    void startHeading(string heading, uint heading_size, uint columns = 20)
+    void startHeading(string heading, uint /*heading_size*/, uint /*columns*/ = 20)
     {
         ss_ << "\n";
         ss_ << heading;

--- a/AirLib/include/common/UpdatableObject.hpp
+++ b/AirLib/include/common/UpdatableObject.hpp
@@ -16,7 +16,7 @@ public:
     virtual void update() = 0;
     virtual ~UpdatableObject() = default;
 
-    virtual void reportState(StateReporter& reporter)
+    virtual void reportState(StateReporter& /*reporter*/)
     {
         //default implementation doesn't do anything
     }

--- a/AirLib/include/common/VectorMath.hpp
+++ b/AirLib/include/common/VectorMath.hpp
@@ -141,9 +141,8 @@ public:
         return v.norm();
     }
     
-    static Vector3T rotateVector(const Vector3T& v, const QuaternionT& q, bool assume_unit_quat)
+    static Vector3T rotateVector(const Vector3T& v, const QuaternionT& q, bool /*assume_unit_quat*/)
     {
-        assume_unit_quat; // stop warning: unused parameter.
         //More performant method is at http://gamedev.stackexchange.com/a/50545/20758
         //QuaternionT vq(0, v.x(), v.y(), v.z());
         //QuaternionT qi = assume_unit_quat ? q.conjugate() : q.inverse();

--- a/AirLib/include/common/common_utils/AsyncTasker.hpp
+++ b/AirLib/include/common/common_utils/AsyncTasker.hpp
@@ -10,7 +10,7 @@
 class AsyncTasker {
 public:
     AsyncTasker(unsigned int thread_count = 4)
-        : threads_(thread_count), error_handler_([](std::exception e) {})
+        : threads_(thread_count), error_handler_([](std::exception /*e*/) {})
     {
     }
 
@@ -25,7 +25,7 @@ public:
 
         if (iterations == 1)
         {
-            threads_.push([=](int i) {
+            threads_.push([=](int /*i*/) {
                 try {
                     func();
                 }
@@ -35,7 +35,7 @@ public:
             });
         }
         else {
-            threads_.push([=](int i) {
+            threads_.push([=](int /*i*/) {
                 try {
                     for (unsigned int itr = 0; itr < iterations; ++itr) {
                         func();

--- a/AirLib/include/controllers/ControllerBase.hpp
+++ b/AirLib/include/controllers/ControllerBase.hpp
@@ -28,7 +28,7 @@ public:
 	virtual real_T getVertexControlSignal(unsigned int rotor_index) = 0;
     virtual size_t getVertexCount() = 0;
     
-    virtual void getStatusMessages(std::vector<std::string>& messages)
+    virtual void getStatusMessages(std::vector<std::string>& /*messages*/)
     {
         //default implementation
     }
@@ -44,7 +44,7 @@ public:
         //clean up any resources
     }
 
-    virtual void reportTelemetry(float renderTime)
+    virtual void reportTelemetry(float /*renderTime*/)
     {
         //no default action
     }

--- a/AirLib/include/controllers/rosflight/AirSimRosFlightBoard.hpp
+++ b/AirLib/include/controllers/rosflight/AirSimRosFlightBoard.hpp
@@ -84,7 +84,7 @@ public:
         }
     }
 
-    virtual void pwmInit(bool useCPPM, bool usePwmFilter, bool fastPWM, uint32_t motorPwmRate, uint16_t idlePulseUsec) override 
+    virtual void pwmInit(bool /*useCPPM*/, bool /*usePwmFilter*/, bool /*fastPWM*/, uint32_t /*motorPwmRate*/, uint16_t /*idlePulseUsec*/) override
     {
         for (uint i = 0; i < OutputMotorCount; ++i)
             motors_pwm_[i] = 1000;
@@ -106,12 +106,12 @@ public:
             throw std::runtime_error("cannot write motor output for index > motor count");
     }
 
-    virtual void set_led(uint8_t index, bool is_on) override 
+    virtual void set_led(uint8_t /*index*/, bool /*is_on*/) override
     {
         //ignored for now
     }
 
-    virtual void toggle_led(uint8_t index) override 
+    virtual void toggle_led(uint8_t /*index*/) override
     {
         //ignored for now
     }
@@ -126,12 +126,12 @@ public:
         return false;
     }
 
-    virtual bool write_params(bool blink_led) override 
+    virtual bool write_params(bool /*blink_led*/) override
     {
         return false;
     }
 
-    virtual void init_imu(uint16_t& acc1G, float& gyroScale, int boardVersion) override 
+    virtual void init_imu(uint16_t& acc1G, float& gyroScale, int /*boardVersion*/) override
     {
         //same as mpu6050_init
         acc1G = kAccelAdcBits;
@@ -171,7 +171,7 @@ public:
         temperature = 25.0f;
     }
 
-    virtual void read_diff_pressure(float& differential_pressure, float& temp, float& velocity) override 
+    virtual void read_diff_pressure(float& /*differential_pressure*/, float& /*temp*/, float& /*velocity*/) override
     {
         throw std::runtime_error("Diff pressure sensor is not available");
     }
@@ -200,7 +200,7 @@ public:
         sleep(static_cast<float>(ms));
     }
 
-    virtual void system_reset(bool toBootloader) override 
+    virtual void system_reset(bool /*toBootloader*/) override
     {
         //no internal state to reset
     }

--- a/AirLib/include/controllers/rosflight/AirSimRosFlightCommLink.hpp
+++ b/AirLib/include/controllers/rosflight/AirSimRosFlightCommLink.hpp
@@ -34,19 +34,19 @@ public: // implement CommLink interface
     {
     }
 
-    virtual void set_sys_id(int32_t sys_id)
+    virtual void set_sys_id(int32_t /*sys_id*/)
     {
     }
 
-    virtual void set_streaming_rate(uint16_t param_id, int32_t rate)
+    virtual void set_streaming_rate(uint16_t /*param_id*/, int32_t /*rate*/)
     {
     }
 
-    virtual void notify_param_change(uint16_t param_id, int32_t value)
+    virtual void notify_param_change(uint16_t /*param_id*/, int32_t /*value*/)
     {
     }
 
-    virtual void log_message(const char* message, uint8_t error_level)
+    virtual void log_message(const char* message, uint8_t /*error_level*/)
     {
         messages_.push_back(std::string(message));
     }

--- a/AirLib/include/vehicles/MultiRotor.hpp
+++ b/AirLib/include/vehicles/MultiRotor.hpp
@@ -165,7 +165,7 @@ private: //methods
         params.getSensors().reportState(reporter);
     }
 
-    void updateSensors(MultiRotorParams& params, const Kinematics::State& state, const Environment& environment)
+    void updateSensors(MultiRotorParams& params, const Kinematics::State& /*state*/, const Environment& /*environment*/)
     {
         params.getSensors().update();
     }

--- a/AirLib/include/vehicles/MultiRotorParams.hpp
+++ b/AirLib/include/vehicles/MultiRotorParams.hpp
@@ -92,7 +92,7 @@ public: //interface
     }
 
     //below method is needed to support firmwares without state estimation. In future, we should probably remove this support.
-    virtual void initializePhysics(const Environment* environment, const Kinematics::State* kinematics)
+    virtual void initializePhysics(const Environment* /*environment*/, const Kinematics::State* /*kinematics*/)
     {
         //by default don't use it. If derived class needs this, it should override.
     }

--- a/AirLib/src/controllers/DroneControllerBase.cpp
+++ b/AirLib/src/controllers/DroneControllerBase.cpp
@@ -28,7 +28,7 @@ float DroneControllerBase::getAutoLookahead(float velocity, float adaptive_looka
     return lookahead;
 }
 
-float DroneControllerBase::getObsAvoidanceVelocity(float risk_dist, float max_obs_avoidance_vel)
+float DroneControllerBase::getObsAvoidanceVelocity(float /*risk_dist*/, float max_obs_avoidance_vel)
 {
     return max_obs_avoidance_vel;
 }
@@ -603,7 +603,7 @@ void DroneControllerBase::adjustYaw(float x, float y, DrivetrainType drivetrain,
     adjustYaw(Vector3r(x, y, 0), drivetrain, yaw_mode);
 }
 
-void DroneControllerBase::moveToPathPosition(const Vector3r& dest, float velocity, DrivetrainType drivetrain, /* pass by value */ YawMode yaw_mode, float last_z)
+void DroneControllerBase::moveToPathPosition(const Vector3r& dest, float velocity, DrivetrainType drivetrain, /* pass by value */ YawMode yaw_mode, float /*last_z*/)
 {
     //validate dest
     if (dest.hasNaN())

--- a/AirLib/src/controllers/MavLinkDroneController.cpp
+++ b/AirLib/src/controllers/MavLinkDroneController.cpp
@@ -43,7 +43,7 @@ public:
     MavLinkLogViewerLog(std::shared_ptr<mavlinkcom::MavLinkNode> proxy) {
         proxy_ = proxy;
     }
-    void write(const mavlinkcom::MavLinkMessage& msg, uint64_t timestamp = 0) override {
+    void write(const mavlinkcom::MavLinkMessage& msg, uint64_t /*timestamp*/ = 0) override {
         MavLinkMessage copy;
         ::memcpy(&copy, &msg, sizeof(MavLinkMessage));
         proxy_->sendMessage(copy);
@@ -145,14 +145,14 @@ struct MavLinkDroneController::impl {
             is_controls_0_1_ = true;
             Utils::setValue(rotor_controls_, 0.0f);
             //TODO: main_node_->setMessageInterval(...);
-            connection_->subscribe([=](std::shared_ptr<MavLinkConnection> connection, const MavLinkMessage& msg){
+            connection_->subscribe([=](std::shared_ptr<MavLinkConnection> /*connection*/, const MavLinkMessage& msg){
                 processMavMessages(msg);
             });
 
             // listen to the other mavlink connection also
             auto mavcon = mav_vehicle_->getConnection();
             if (mavcon != connection_) {
-                mavcon->subscribe([=](std::shared_ptr<MavLinkConnection> connection, const MavLinkMessage& msg) {
+                mavcon->subscribe([=](std::shared_ptr<MavLinkConnection> /*connection*/, const MavLinkMessage& msg) {
                     processMavMessages(msg);
                 });
             }
@@ -216,7 +216,7 @@ struct MavLinkDroneController::impl {
                 qgc_proxy_ = nullptr;
             }
             else {
-                connection->subscribe([=](std::shared_ptr<MavLinkConnection> connection_val, const MavLinkMessage& msg){
+                connection->subscribe([=](std::shared_ptr<MavLinkConnection> /*connection_val*/, const MavLinkMessage& msg){
                     processQgcMessages(msg);
                 });
             }
@@ -797,7 +797,7 @@ struct MavLinkDroneController::impl {
 
     //administrative
 
-    bool armDisarm(bool arm, CancelableBase& cancelable_action)
+    bool armDisarm(bool arm, CancelableBase& /*cancelable_action*/)
     {
         bool rc = false;
         mav_vehicle_->armDisarm(arm).wait(10000, &rc);
@@ -836,7 +836,7 @@ struct MavLinkDroneController::impl {
         is_simulation_mode_ = is_set;
     }
 
-    bool takeoff(float max_wait_seconds, CancelableBase& cancelable_action)
+    bool takeoff(float max_wait_seconds, CancelableBase& /*cancelable_action*/)
     {
         bool rc = false;
         auto vec = getPosition();
@@ -869,7 +869,7 @@ struct MavLinkDroneController::impl {
         return rc;
     }
 
-    bool land(CancelableBase& cancelable_action)
+    bool land(CancelableBase& /*cancelable_action*/)
     {
         // bugbug: really need a downward pointing distance to ground sensor to do this properly, for now
         // we assume the ground is relatively flat an we are landing roughly at the home altitude.
@@ -903,7 +903,7 @@ struct MavLinkDroneController::impl {
         return true;
     }
 
-    bool goHome(CancelableBase& cancelable_action)
+    bool goHome(CancelableBase& /*cancelable_action*/)
     {
         bool rc = false;
         if (!mav_vehicle_->returnToHome().wait(10000, &rc)) {
@@ -946,12 +946,12 @@ struct MavLinkDroneController::impl {
         throw VehicleCommandNotImplementedException("getRCData() function is not yet implemented");
     }
 
-    void setRCData(const RCData& rcData)
+    void setRCData(const RCData& /*rcData*/)
     {
         //TODO: use RC data to control MavLink drone
     }
 
-    bool validateRCData(const RCData& rc_data)
+    bool validateRCData(const RCData& /*rc_data*/)
     {
         return true;
     }

--- a/DroneShell/include/SimpleShell.hpp
+++ b/DroneShell/include/SimpleShell.hpp
@@ -128,7 +128,7 @@ public:
         virtual bool execute(const ShellCommandParameters&) { return false; };
     private:
         ShellCommand(){}
-        ShellCommand(ShellCommand& other){
+        ShellCommand(ShellCommand& /*other*/){
         }
     };
 
@@ -202,7 +202,7 @@ public: //default commands
         {
         }
 
-        bool execute(const ShellCommandParameters& params) 
+        bool execute(const ShellCommandParameters& /*params*/)
         {
             return false;
         }
@@ -216,7 +216,7 @@ public: //default commands
         {
         }
 
-        bool execute(const ShellCommandParameters& params) 
+        bool execute(const ShellCommandParameters& /*params*/) 
         {
             return true;
         }

--- a/Unreal/Plugins/AirSim/Source/RecordingThread.cpp
+++ b/Unreal/Plugins/AirSim/Source/RecordingThread.cpp
@@ -92,7 +92,7 @@ uint32 FRecordingThread::Run()
             RenderStatus = TGraphTask<FNullGraphTask>::CreateTask(NULL).ConstructAndDispatchWhenReady(GET_STATID(STAT_FNullGraphTask_CheckRenderStatus), ENamedThreads::RenderThread);
         }				
 
-        if (imageColor.Num() > 0 && bReadPixelsStarted && !RenderStatus.GetReference() || RenderStatus->IsComplete()) {
+        if ((imageColor.Num() > 0 && bReadPixelsStarted && !RenderStatus.GetReference()) || RenderStatus->IsComplete()) {
             bReadPixelsStarted = false;
             RenderStatus = NULL;
 


### PR DESCRIPTION
Basically took it from here http://stackoverflow.com/questions/3417837/what-is-the-best-way-to-supress-unused-variable-x-warning

The 3 ways of silencing the unused param warnings are:
1. (What I did) Not giving a name to the parameter. We can keep it as a comment though for documentation purposes. 
2. [Define a template function that does nothing](https://herbsutter.com/2009/10/18/mailbag-shutting-up-compiler-warnings/) `template<class T> void ignore( const T& ) { }`
3. Cast to void (and maybe define a macro do to is). `(void)variable;`

The change to `RecordingThread.cpp` is for a warning about having `&&` in a `||`.

Edit: Looking at the Travis log it looks like I missed some, but its a start!