### PR TITLE
Update xbox_controller.md

### DIFF
--- a/docs/xbox_controller.md
+++ b/docs/xbox_controller.md
@@ -1,12 +1,58 @@
 # XBox Controller
 
-To use an XBox controller with AirSim follow these steps:
+To use an XBox Controller with AirSim follow these steps:
 
 1. Connect XBox controller so it shows up in your PC Game Controllers:
 
 ![Gamecontrollers](images/game_controllers.png)
 
-2. Launch QGroundControl and you should see a new Joystick tab under stettings:
+2. Launch PX4 SITL in a terminal, it will wait for a UDP connection on a certain port.
+
+3. Launch Unreal Editor and open the project which has the AirSim plugin and an environemnt of your preference.
+
+ __Note:__ Ensure that you have the gameMode as AirSimGameMode in the World Seetings
+ 
+4. Press play so that the quad spawns into the scene at the player start actor. Once this is done, a connection would be made to px4 SITL which will unblock the autopilot and start executing. The log would appear similar to this:
+
+```
+| ___ \ \ \ / /   /   |
+| |_/ /  \ V /   / /| |
+|  __/   /   \  / /_| |
+| |     / /^\ \ \___  |
+\_|     \/   \/     |_/
+
+px4 starting.
+
+INFO  [dataman] Unkown restart, data manager file 'rootfs/fs/microsd/dataman' size is 11797680 bytes
+INFO  [platforms__posix__drivers__ledsim] LED::init
+INFO  [platforms__posix__drivers__ledsim] LED::init
+INFO  [simulator] Waiting for initial data on UDP port 14560. Please start the flight simulator to proceed..
+INFO  [simulator] Got initial simulation data, running sim..
+INFO  [pwm_out_sim] MODE_8PWM
+INFO  [mavlink] mode: Normal, data rate: 4000000 B/s on udp port 14556 remote port 14550
+INFO  [mavlink] mode: Onboard, data rate: 4000000 B/s on udp port 14557 remote port 14540
+INFO  [mavlink] MAVLink only on localhost (set param MAV_BROADCAST = 1 to enable network)
+INFO  [logger] logger started (mode=all)
+pxh> INFO  [logger] Start file log
+INFO  [logger] Opened log file: rootfs/fs/microsd/log/2017-05-16/02_57_46.ulg
+INFO  [tone_alarm] startup
+INFO  [mavlink] partner IP: 127.0.0.1
+INFO  [lib__ecl] EKF aligned, (pressure height, IMU buf: 17, OBS buf: 16)
+INFO  [lib__ecl] EKF GPS checks passed (WGS-84 origin set)
+INFO  [lib__ecl] EKF commencing GPS fusion
+INFO  [commander] home: 47.6414680, -122.1401669, 102.07
+INFO  [tone_alarm] home_set
+```
+
+__Note:__ It is imporant to check the ~/Documents/AirSim/settings.json file and should be similar to the one shown [here](https://github.com/Microsoft/AirSim/blob/master/docs/settings.md).
+
+
+5. Launch QGroundControl and follow the following steps
+i. Click the white/purple Q in the top right to open the settings.
+ii. Add a UDP comm link on port 14540 with the localhost ip (127.0.0.1)
+iii. Connect using that link. You should see at the top the sattelite count become valid and the battery voltage too. If you don't see this, then stop now because the Mavlink connection is invalid.
+iv. Click the gears icon next to the Q icon and you should get a bunch of menus including the joystick configuration menu as shown below.
+v. Under the joystick mode, click calibrate and follow the instructions on the screen.
 
 ![Gamecontrollers](images/qgc_joystick.png)
 
@@ -19,21 +65,6 @@ small movements.]
 QGroundControl will find your Pixhawk via the UDP proxy port 14550 setup by MavLinkTest above.
 AirSim will find your Pixhawk via the other UDP server port 14570 also setup by MavLinkTest above.
 You can also use all the QGroundControl controls for autonomous flying at this point too.
-
-
-3. Connect to Pixhawk serial port using MavLinkTest.exe like this:
-````
-MavLinkTest.exe -serial:*,115200 -proxy:127.0.0.1:14550 -server:127.0.0.1:14570
-````
-
-4. Run AirSim Unreal simulator with these `~/Documents/AirSim/settings.json` settings:
-````
-    "SitlIp": "",
-    "SitlPort": 14560,
-    "UdpIp": "127.0.0.1",
-    "UdpPort": 14570,
-    "UseSerial": false,
-````
 
 ## Advanced
 

--- a/docs/xbox_controller.md
+++ b/docs/xbox_controller.md
@@ -48,10 +48,15 @@ __Note:__ It is imporant to check the ~/Documents/AirSim/settings.json file and 
 
 
 5. Launch QGroundControl and follow the following steps
+
 i. Click the white/purple Q in the top right to open the settings.
+
 ii. Add a UDP comm link on port 14540 with the localhost ip (127.0.0.1)
+
 iii. Connect using that link. You should see at the top the sattelite count become valid and the battery voltage too. If you don't see this, then stop now because the Mavlink connection is invalid.
+
 iv. Click the gears icon next to the Q icon and you should get a bunch of menus including the joystick configuration menu as shown below.
+
 v. Under the joystick mode, click calibrate and follow the instructions on the screen.
 
 ![Gamecontrollers](images/qgc_joystick.png)

--- a/docs/xbox_controller.md
+++ b/docs/xbox_controller.md
@@ -44,20 +44,20 @@ INFO  [commander] home: 47.6414680, -122.1401669, 102.07
 INFO  [tone_alarm] home_set
 ```
 
-__Note:__ It is imporant to check the ~/Documents/AirSim/settings.json file and should be similar to the one shown [here](https://github.com/Microsoft/AirSim/blob/master/docs/settings.md).
+ __Note:__ It is imporant to check the ~/Documents/AirSim/settings.json file and should be similar to the one shown [here](https://github.com/Microsoft/AirSim/blob/master/docs/settings.md).
 
 
 5. Launch QGroundControl and follow the following steps
 
-i. Click the white/purple Q in the top right to open the settings.
+ i. Click the white/purple Q in the top right to open the settings.
 
-ii. Add a UDP comm link on port 14540 with the localhost ip (127.0.0.1)
+ ii. Add a UDP comm link on port 14540 with the localhost ip (127.0.0.1)
 
-iii. Connect using that link. You should see at the top the sattelite count become valid and the battery voltage too. If you don't see this, then stop now because the Mavlink connection is invalid.
+ iii. Connect using that link. You should see at the top the sattelite count become valid and the battery voltage too. If you don't see this, then stop now because the Mavlink connection is invalid.
 
-iv. Click the gears icon next to the Q icon and you should get a bunch of menus including the joystick configuration menu as shown below.
+ iv. Click the gears icon next to the Q icon and you should get a bunch of menus including the joystick configuration menu as shown below.
 
-v. Under the joystick mode, click calibrate and follow the instructions on the screen.
+ v. Under the joystick mode, click calibrate and follow the instructions on the screen.
 
 ![Gamecontrollers](images/qgc_joystick.png)
 


### PR DESCRIPTION
* Adding more description to how to use the contoller as shown in issue #[212](https://github.com/Microsoft/AirSim/issues/212)
* For HIL, you don't need a PX4 connected to the serial port which is a bit confusing as the MavLinktest step is redundant for that. The PX4 SITL works fine. 
*  The XBox360ce might need to be checked.