### PR TITLE
Fix OSX specific UDP socket issue

### DIFF
--- a/MavLinkCom/src/serial_com/UdpClientPort.cpp
+++ b/MavLinkCom/src/serial_com/UdpClientPort.cpp
@@ -157,7 +157,11 @@ public:
 		}
 
 		socklen_t addrlen = sizeof(sockaddr_in);
+		#if defined (__APPLE__)
+		int hr = ::write(sock, reinterpret_cast<const char*>(ptr), count);
+		#else
 		int hr = sendto(sock, reinterpret_cast<const char*>(ptr), count, 0, reinterpret_cast<sockaddr*>(&remoteaddr), addrlen);
+		#endif
 		if (hr == SOCKET_ERROR)
 		{
 			hr = WSAGetLastError();
@@ -175,18 +179,22 @@ public:
 
 		int bytesRead = 0;
 		// try and receive something, up until port is closed anyway.
-		
+
 		while (!closed_)
 		{
 			socklen_t addrlen = sizeof(sockaddr_in);
+			#if defined (__APPLE__)
+			int rc = ::read(sock, reinterpret_cast<char*>(result), bytesToRead);
+			#else
 			int rc = recvfrom(sock, reinterpret_cast<char*>(result), bytesToRead, 0, reinterpret_cast<sockaddr*>(&other), &addrlen);
+			#endif
 			if (rc < 0)
 			{
 				int hr = WSAGetLastError();
 #ifdef _WIN32
 				if (hr == WSAEMSGSIZE)
 				{
-					// message was too large for the buffer, no problem, return what we have.					
+					// message was too large for the buffer, no problem, return what we have.
 				}
 				else if (hr == WSAECONNRESET || hr == ERROR_IO_PENDING)
 				{


### PR DESCRIPTION
This solves Issue #252.

The main problem here was that when the socket is created, it is connected to the server through the `connect()` function. Since UDP is a connectionless protocol the connect() step is not needed for client sockets, and there are specific functions for sending and receiving messages (`sendto()` and `recvfrom()`). In those functions the address of the destination socket is declared since in the nominal case no connection has been made before between the client and the server, so the client does not know to whom it has to send the message. 
In the case of AirSim, I guess the connection is mandatory in order to create the `hil_node_` as far as I have understood from the `MavLinkDroneController.cpp` file where the connection to PX4 is made. So if we are running PX4 in SITL mode , we need to connect to it through UDP in order to be able to send/receive the MavLink HIL messages. Nevertheless OSX does not like having a UDP client socket already connected to the server and then trying to send/receive information through it using the UDP-specific functions `sendto()` and `recvfrom()`, it issues error 56 that according to [this page](https://www.ibm.com/support/knowledgecenter/SSLTBW_1.13.0/com.ibm.zos.r13.cs3cod0/syserret.htm) it means that the socket is being connected two times. 
This does not happen in Linux nor Windows, so I guess (and this is only a guess) that Linux and Windows have a check on the `recvfrom()` and `sendto()` functions to check if the socket is already connected, and if it is they do not try to connect it again. OSX does not seem to have this check and so if the socket is already connected, then by using `sendto` and `recvfrom` what we are doing is that we are connecting again a socket which is already connected to the server, thus resulting in a socket error.
I have solved this by modifying the the UDP client port in MavLinkCom to use the classic TCP `write()` and `read()` functions instead of `sendto()` and `recvfrom()` when we are running the code on OSX.

I have successfully tested the MavLinkTest program on OSX, on Windows and Linux nothing should be changed but a double check for sanity reasons would be nice.

Cheers, 

Nacho.