### PR TITLE
Corrected trig function in toEulerianAngle

### DIFF
--- a/PythonClient/PythonClient.py
+++ b/PythonClient/PythonClient.py
@@ -114,7 +114,7 @@ class AirSimClient:
                 t2 = 1
             if (t2 < -1.0):
                 t2 = -1.0
-            pitch = math.sin(t2)
+            pitch = math.asin(t2)
 
             # yaw (z-axis rotation)
             t3 = +2.0* (y * z + w * x);


### PR DESCRIPTION
Changed trig function from sin to asin in calculating pitch angle from quaternion in 'toEulerianAngle' in PythonClient.py. This is now consistent with [AirSim/AirLib/include/common/VectorMath.hpp](https://github.com/Microsoft/AirSim/blob/74b476dd881ebf819a8327fdeb0c8329ae170bc8/AirLib/include/common/VectorMath.hpp#L236)