### PR TITLE
fix default initialization of an object of const type error for GeoPoint

### DIFF
--- a/AirLib/include/vehicles/multirotor/firmwares/simple_flight/firmware/interfaces/CommonStructs.hpp
+++ b/AirLib/include/vehicles/multirotor/firmwares/simple_flight/firmware/interfaces/CommonStructs.hpp
@@ -177,6 +177,8 @@ struct GeoPoint {
     double longitude = std::numeric_limits<double>::quiet_NaN(); 
     float altiude = std::numeric_limits<float>::quiet_NaN();
 
+    GeoPoint() {}
+
     static const GeoPoint& nan()
     {
         const static GeoPoint val;


### PR DESCRIPTION
Building Block Environment on Ubuntu 16.04 get error


"default initialization of an object of const type 'const
      simple_flight::GeoPoint' without a user-provided default constructor"