### PR TITLE
read_pfm required 're' regular expression library

### DIFF
--- a/PythonClient/AirSimClient.py
+++ b/PythonClient/AirSimClient.py
@@ -8,6 +8,7 @@ import sys
 import os
 import inspect
 import types
+import re
 
 
 class MsgpackMixin:


### PR DESCRIPTION
added 'import re' to fix missing library error