### PR TITLE
Override printLogMessage RealMultirotorConnector

### DIFF
--- a/AirLib/include/vehicles/multirotor/controllers/RealMultirotorConnector.hpp
+++ b/AirLib/include/vehicles/multirotor/controllers/RealMultirotorConnector.hpp
@@ -68,6 +68,9 @@ public:
     {
         throw std::logic_error("getSegmentationObjectID() call is only supported for simulation");
     }
+    virtual void printLogMessage(const std::string& message, std::string message_param = "", unsigned char severity = 0) override
+    {   
+    }
 
 
 private:


### PR DESCRIPTION
Override printLogMessage so that RealMultirotorConnector is not abstract and project can successfully build. Otherwise get the error: 
airsim\droneserver\main.cpp(80): error C2259: 'msr::airlib::RealMultirotorConnector': cannot instantiate abstract class [c:\Program Files\AirSim\DroneServer\DroneServer.vcxproj] 
From issue #635