### PR TITLE
Implement interface function printLogMessage to fix #645

### DIFF
--- a/AirLib/include/vehicles/multirotor/controllers/RealMultirotorConnector.hpp
+++ b/AirLib/include/vehicles/multirotor/controllers/RealMultirotorConnector.hpp
@@ -70,6 +70,12 @@ public:
         throw std::logic_error("getSegmentationObjectID() call is only supported for simulation");
     }
 
+    virtual void printLogMessage(const std::string& message, std::string message_param = "", unsigned char severity = 0)  override
+    {
+        unused(message);
+        unused(message_param);
+        unused(severity);
+    }
 
 private:
     VehicleControllerBase* controller_;


### PR DESCRIPTION
Fix build error (issue #645) introduced by [commit: added simPrintLogMessage API, #635](https://github.com/Microsoft/AirSim/commit/f0e83c29e7685e1021185e3c95bfdaffb6cb85dc).
Abstract function printLogMessage was not implemented.