### PR TITLE
Enable recording from multiple cameras and views

### DIFF
--- a/Unreal/Plugins/AirSim/Source/Recording/RecordingFile.cpp
+++ b/Unreal/Plugins/AirSim/Source/Recording/RecordingFile.cpp
@@ -11,31 +11,36 @@ RecordingFile::RecordingFile(std::vector <std::string> columns)
 {
     this->columns = columns;
 }
-void RecordingFile::appendRecord(TArray<uint8>& image_data, VehiclePawnWrapper* wrapper)
+void RecordingFile::appendRecord(TArray<uint8>& image_data, VehiclePawnWrapper* wrapper,
+    const std::string& camera_name, const std::string& img_type_name, const std::string& img_name)
 {
     if (image_data.Num() == 0)
         return;
 
-    bool imageSavedOk = false;
-    FString filePath;
+    std::string filename = img_name + ".png";
 
-    std::string filename = std::string("img_").append(std::to_string(images_saved_)).append(".png");
+    if (img_type_name != "")
+    {
+        filename = common_utils::FileSystem::combine(img_type_name, filename);
+    }
 
-    try {    
-        filePath = FString(common_utils::FileSystem::combine(image_path_, filename).c_str());
-        imageSavedOk = FFileHelper::SaveArrayToFile(image_data, *filePath);
+    if (camera_name != "")
+    {
+        filename = common_utils::FileSystem::combine(camera_name, filename);
     }
-    catch(std::exception& ex) {
-        UAirBlueprintLib::LogMessage(TEXT("Image file save failed"), FString(ex.what()), LogDebugLevel::Failure);        
-    }
+
+    FString filePath = FString(common_utils::FileSystem::combine(image_path_, filename).c_str());
+    bool imageSavedOk = FFileHelper::SaveArrayToFile(image_data, *filePath);
+
     // If render command is complete, save image along with position and orientation
-
     if (imageSavedOk) {
         writeString(wrapper->getLogLine().append(filename).append("\n"));
-
-        //UAirBlueprintLib::LogMessage(TEXT("Screenshot saved to:"), filePath, LogDebugLevel::Success);
-        images_saved_++;
+        UAirBlueprintLib::LogMessage(TEXT("Camera image saved to:"), filePath, LogDebugLevel::Success);
     }
+    else {
+        UAirBlueprintLib::LogMessage(TEXT("Failed to save camera image to:"), filePath, LogDebugLevel::Failure);
+    }
+
 }
 
 void RecordingFile::appendColumnHeader(std::vector <std::string> columns)

--- a/Unreal/Plugins/AirSim/Source/Recording/RecordingFile.h
+++ b/Unreal/Plugins/AirSim/Source/Recording/RecordingFile.h
@@ -13,7 +13,7 @@ public:
     RecordingFile(std::vector <std::string> columns);
     ~RecordingFile();
 
-    void appendRecord(TArray<uint8>& compressedPng, VehiclePawnWrapper* wrapper);
+    void appendRecord(TArray<uint8>& compressedPng, VehiclePawnWrapper* wrapper, const std::string& camera_name, const std::string& img_type_name, const std::string& img_name);
     void appendColumnHeader(std::vector <std::string> columns);
     void startRecording();
     void stopRecording(bool ignore_if_stopped);
@@ -29,7 +29,6 @@ private:
 
 private:
     std::string record_filename = "airsim_rec";     
-    unsigned int images_saved_ = 0;
     std::string image_path_;
     bool is_recording_ = false;
     IFileHandle* log_file_handle_ = nullptr;

--- a/Unreal/Plugins/AirSim/Source/Recording/RecordingThread.h
+++ b/Unreal/Plugins/AirSim/Source/Recording/RecordingThread.h
@@ -16,7 +16,8 @@ class FRecordingThread : public FRunnable
 public:
     FRecordingThread();
     virtual ~FRecordingThread();
-    static void startRecording(msr::airlib::VehicleCameraBase* camera, const msr::airlib::Kinematics::State* kinematics, const RecordingSettings& settings, std::vector <std::string> columns, VehiclePawnWrapper* wrapper);
+    static void startRecording(const std::vector<msr::airlib::VehicleCameraBase*>& cameras, const std::vector<int>& image_type_ids, 
+        const msr::airlib::Kinematics::State* kinematics, const RecordingSettings& settings, std::vector <std::string> columns, VehiclePawnWrapper* wrapper);
     static void stopRecording(); 
     static bool isRecording();
 
@@ -38,7 +39,9 @@ private:
     std::unique_ptr<FRunnableThread> thread_;
 
     RecordingSettings settings_;
-    msr::airlib::VehicleCameraBase* camera_;
+    int img_count = 0;
+    std::vector<msr::airlib::VehicleCameraBase*> cameras_;
+    std::vector<int> image_type_ids_;
     std::unique_ptr<RecordingFile> recording_file_;
     const msr::airlib::Kinematics::State* kinematics_;
     VehiclePawnWrapper* wrapper_;

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.h
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.h
@@ -67,6 +67,8 @@ protected: //settings
     std::vector <std::string> columns;
 
     float clock_speed;
+    std::unordered_set<int> record_with_cameras;
+    std::unordered_set<int> record_image_types;
 
 private:
     void readSettings();


### PR DESCRIPTION
https://github.com/Microsoft/AirSim/issues/644

Currently only one camera and one view can be recording.
This change enable the user to specify the cameras and views to be captured.
To specify the cameras and views, in settings.js, add the following two entries like this:
```
{
  ...
  "RecordWithCameras": "0, 2",
  "RecordImageTypes": "0, 1, 5",
  ...
}
```
For "RecordWithCameras", the number corresponds to the cameras specified in ACarPawn::ACarPawn() in "AirSim\Unreal\Environments\Blocks\Plugins\AirSim\Source\Car\CarPawn.cpp".
Currently, the numbers specifies the following cameras:
```
  0: center
  1: left
  2: right
  3: driver
  4: rear
```

For "RecordImageTypes", the number corresponds to the image types in the order specified in "AirSim\Source\AirLib\include\controllers\VehicleCameraBase.hpp":

```
  enum class ImageType : uint { //this indexes to array
        Scene = 0, 
        DepthPlanner, 
        DepthPerspective,
        DepthVis, 
        DisparityNormalized,
        Segmentation,
        SurfaceNormals,
        Count //must be last
    };
```

If the number is invalid or does not exist, we simply ignore it. 
By default, camera 0 and image type 0 is used.