### PR TITLE
Python Car Client AttributeError Bugfix

### DIFF
--- a/PythonClient/AirSimClient.py
+++ b/PythonClient/AirSimClient.py
@@ -161,7 +161,6 @@ class CarState(MsgpackMixin):
     collision = CollisionInfo()
     kinematics_true = KinematicsState()
 
-
 class MultirotorState(MsgpackMixin):
     collision = CollisionInfo();
     kinematics_estimated = KinematicsState()

--- a/PythonClient/AirSimClient.py
+++ b/PythonClient/AirSimClient.py
@@ -39,7 +39,7 @@ class AirSimImageType:
 
 class DrivetrainType:
     MaxDegreeOfFreedom = 0
-    ForwardOnly = 1
+    ForwardOnly = 1 
     
 class LandedState:
     Landed = 0
@@ -158,6 +158,9 @@ class CarState(MsgpackMixin):
     position = Vector3r()
     velocity = Vector3r()
     orientation = Quaternionr()
+    collision = CollisionInfo()
+    kinematics_true = KinematicsState()
+
 
 class MultirotorState(MsgpackMixin):
     collision = CollisionInfo();

--- a/PythonClient/hello_car.py
+++ b/PythonClient/hello_car.py
@@ -1,4 +1,5 @@
 from AirSimClient import *
+import tempfile
 
 # connect to the AirSim simulator 
 client = CarClient()
@@ -49,10 +50,18 @@ for idx in range(3):
         ImageRequest(1, AirSimImageType.DepthPerspective, True), #depth in perspective projection
         ImageRequest(1, AirSimImageType.Scene), #scene vision image in png format
         ImageRequest(1, AirSimImageType.Scene, False, False)])  #scene vision image in uncompressed RGBA array
-    print('Retrieved images: %d', len(responses))
+    print('Retrieved images: %d' % len(responses))
+    
+    tmp_dir = os.path.join(tempfile.gettempdir(), "airsim_car")
+    print ("Saving images to %s" % tmp_dir)
+    try:
+        os.makedirs(tmp_dir)
+    except OSError:
+        if not os.path.isdir(tmp_dir):
+            raise
 
     for response in responses:
-        filename = 'c:/temp/py' + str(idx)
+        filename = os.path.join(tmp_dir, str(idx))
 
         if response.pixels_as_float:
             print("Type %d, size %d" % (response.image_type, len(response.image_data_float)))


### PR DESCRIPTION
I had two issues with the python client for the car control, I got `AttributeError`'s for the `getCarState` function in the CarClient class in `AirSimClient.py`, and I had the same temp folder issue that I ran into in #695 

I fixed the attribute error by adding the `collision` and `kinematics_true`, and setting them to the same function used for the `MultirotorState` class. Used the same tempfolder approach here from the drone control PR mentioned above.