### PR TITLE
Fix spelling of "Lambdas" in coding_guidelines.md

### DIFF
--- a/docs/coding_guidelines.md
+++ b/docs/coding_guidelines.md
@@ -1,6 +1,6 @@
 # Modern C++ Coding Guidelines
 
-We are using Modern C++11. Smart pointers, Lamdas, and C++11 multithreading primitives are your friend.
+We are using Modern C++11. Smart pointers, Lambdas, and C++11 multithreading primitives are your friend.
 
 ## Quick Note
 


### PR DESCRIPTION
Corrected spelling of Lambdas