### PR TITLE
Enabling multi-drone control

### DIFF
--- a/Unreal/Plugins/AirSim/Source/Multirotor/SimModeWorldMultiRotor.cpp
+++ b/Unreal/Plugins/AirSim/Source/Multirotor/SimModeWorldMultiRotor.cpp
@@ -23,16 +23,16 @@ void ASimModeWorldMultiRotor::BeginPlay()
     Super::BeginPlay();
 
     if (fpv_vehicle_connector_.Num() >0) {
-		//create its control server
-		for (std::shared_ptr<VehicleConnectorBase> vehicle_connector_ : fpv_vehicle_connector_) {
-			try {
-				vehicle_connector_->startApiServer();
-			}
-			catch (std::exception& ex) {
-				UAirBlueprintLib::LogMessageString("Cannot start RpcLib Server", ex.what(), LogDebugLevel::Failure);
-			}
-		}
+	//create its control server
+        for (std::shared_ptr<VehicleConnectorBase> vehicle_connector_ : fpv_vehicle_connector_) {
+	    try {
+	        vehicle_connector_->startApiServer();
+	    }
+	    catch (std::exception& ex) {
+		UAirBlueprintLib::LogMessageString("Cannot start RpcLib Server", ex.what(), LogDebugLevel::Failure);
+	    }
 	}
+    }
 
 }
 
@@ -42,10 +42,10 @@ void ASimModeWorldMultiRotor::EndPlay(const EEndPlayReason::Type EndPlayReason)
     stopAsyncUpdator();
 
     if (fpv_vehicle_connector_.Num() > 0) {
-		for (std::shared_ptr<VehicleConnectorBase> vehicle_connector_ : fpv_vehicle_connector_) {
-			vehicle_connector_->stopApiServer();
-		}
+        for (std::shared_ptr<VehicleConnectorBase> vehicle_connector_ : fpv_vehicle_connector_) {
+	    vehicle_connector_->stopApiServer();
 	}
+    }
 
     //for (AActor* actor : spawned_actors_) {
     //    actor->Destroy();

--- a/Unreal/Plugins/AirSim/Source/Multirotor/SimModeWorldMultiRotor.cpp
+++ b/Unreal/Plugins/AirSim/Source/Multirotor/SimModeWorldMultiRotor.cpp
@@ -22,15 +22,17 @@ void ASimModeWorldMultiRotor::BeginPlay()
 {
     Super::BeginPlay();
 
-    if (fpv_vehicle_connector_ != nullptr) {
-        //create its control server
-        try {
-            fpv_vehicle_connector_->startApiServer();
-        }
-        catch (std::exception& ex) {
-            UAirBlueprintLib::LogMessageString("Cannot start RpcLib Server", ex.what(), LogDebugLevel::Failure);
-        }
-    }
+    if (fpv_vehicle_connector_.Num() >0) {
+		//create its control server
+		for (std::shared_ptr<VehicleConnectorBase> vehicle_connector_ : fpv_vehicle_connector_) {
+			try {
+				vehicle_connector_->startApiServer();
+			}
+			catch (std::exception& ex) {
+				UAirBlueprintLib::LogMessageString("Cannot start RpcLib Server", ex.what(), LogDebugLevel::Failure);
+			}
+		}
+	}
 
 }
 
@@ -39,10 +41,11 @@ void ASimModeWorldMultiRotor::EndPlay(const EEndPlayReason::Type EndPlayReason)
     //stop physics thread before we dismental
     stopAsyncUpdator();
 
-    if (fpv_vehicle_connector_ != nullptr) {
-        fpv_vehicle_connector_->stopApiServer();
-        fpv_vehicle_pawn_wrapper_ = nullptr;
-    }
+    if (fpv_vehicle_connector_.Num() > 0) {
+		for (std::shared_ptr<VehicleConnectorBase> vehicle_connector_ : fpv_vehicle_connector_) {
+			vehicle_connector_->stopApiServer();
+		}
+	}
 
     //for (AActor* actor : spawned_actors_) {
     //    actor->Destroy();
@@ -133,9 +136,7 @@ void ASimModeWorldMultiRotor::setupVehiclesAndCamera(std::vector<VehiclePtr>& ve
             VehiclePtr vehicle = createVehicle(wrapper);
             if (vehicle != nullptr) {
                 vehicles.push_back(vehicle);
-
-                if (fpv_vehicle_pawn_wrapper_ == wrapper)
-                    fpv_vehicle_connector_ = vehicle;
+                fpv_vehicle_connector_.Add(vehicle);
             }
             //else we don't have vehicle for this pawn
         }
@@ -196,7 +197,7 @@ ASimModeWorldBase::VehiclePtr ASimModeWorldMultiRotor::createVehicle(VehiclePawn
 
     std::shared_ptr<MultiRotorConnector> vehicle = std::make_shared<MultiRotorConnector>(
         wrapper, vehicle_params_.back().get(), enable_rpc, api_server_address,
-        vehicle_params_.back()->getParams().api_server_port, manual_pose_controller);
+        vehicle_params_.back()->getParams().api_server_port + vehicle_params_.size() - 1, manual_pose_controller);
 
     if (vehicle->getPhysicsBody() != nullptr)
         wrapper->setKinematics(&(static_cast<PhysicsBody*>(vehicle->getPhysicsBody())->getKinematics()));

--- a/Unreal/Plugins/AirSim/Source/Multirotor/SimModeWorldMultiRotor.cpp
+++ b/Unreal/Plugins/AirSim/Source/Multirotor/SimModeWorldMultiRotor.cpp
@@ -118,6 +118,8 @@ void ASimModeWorldMultiRotor::setupVehiclesAndCamera(std::vector<VehiclePtr>& ve
             pawns.Add(spawned_pawn);
         }
 
+        unsigned int vehicle_id = 0;
+
         //set up vehicle pawns
         for (AActor* pawn : pawns)
         {
@@ -127,6 +129,9 @@ void ASimModeWorldMultiRotor::setupVehiclesAndCamera(std::vector<VehiclePtr>& ve
 
             //chose first pawn as FPV if none is designated as FPV
             VehiclePawnWrapper* wrapper = vehicle_pawn->getVehiclePawnWrapper();
+
+            wrapper->getConfig().vehicle_config_name = default_vehicle_config + "_" + std::to_string(vehicle_id);
+
             if (enable_collision_passthrough)
                 wrapper->getConfig().enable_passthrough_on_collisions = true;
             if (wrapper->getConfig().is_fpv_vehicle || fpv_vehicle_pawn_wrapper_ == nullptr)
@@ -137,6 +142,7 @@ void ASimModeWorldMultiRotor::setupVehiclesAndCamera(std::vector<VehiclePtr>& ve
             if (vehicle != nullptr) {
                 vehicles.push_back(vehicle);
                 fpv_vehicle_connector_.Add(vehicle);
+                vehicle_id++;
             }
             //else we don't have vehicle for this pawn
         }
@@ -197,7 +203,7 @@ ASimModeWorldBase::VehiclePtr ASimModeWorldMultiRotor::createVehicle(VehiclePawn
 
     std::shared_ptr<MultiRotorConnector> vehicle = std::make_shared<MultiRotorConnector>(
         wrapper, vehicle_params_.back().get(), enable_rpc, api_server_address,
-        vehicle_params_.back()->getParams().api_server_port + vehicle_params_.size() - 1, manual_pose_controller);
+        vehicle_params_.back()->getParams().api_server_port, manual_pose_controller);
 
     if (vehicle->getPhysicsBody() != nullptr)
         wrapper->setKinematics(&(static_cast<PhysicsBody*>(vehicle->getPhysicsBody())->getKinematics()));

--- a/Unreal/Plugins/AirSim/Source/Multirotor/SimModeWorldMultiRotor.h
+++ b/Unreal/Plugins/AirSim/Source/Multirotor/SimModeWorldMultiRotor.h
@@ -44,5 +44,5 @@ private:
     TArray<AActor*> spawned_actors_;
 
     VehiclePawnWrapper* fpv_vehicle_pawn_wrapper_;
-    std::shared_ptr<VehicleConnectorBase> fpv_vehicle_connector_;
+    TArray <std::shared_ptr<VehicleConnectorBase> > fpv_vehicle_connector_;
 };


### PR DESCRIPTION
This PR attempts to fix the issue with multi-vehicle control for multirotors (P0 issue on https://trello.com/b/1t2qCeaA/todo) by inserting each `VehicleConnector` pointer into an array, thereby converting `fpv_vehicle_connector_` into a TArray. This lets us map individual API ports to each drone and control them independently, and with a few more extensions, allows for image capture from multiple drones.

As to the port numbers themselves, the code in `SimModeWorldMultiRotor.cpp` keeps track of the number of drones in the world and adds sequential IDs to the vehicle config name (i.e. SimpleFlight_0, SimpleFlight_1 etc.) and then `MultiRotorParamsFactory.hpp` parses settings.json as usual and assigns the corresponding port numbers. The settings.json list also needs to reflect the same names: i.e., _VEHICLETYPE_ID_. This change was added because the VehicleConfig property in Unreal blueprints doesn't exist anymore. Happy to hear any suggestions to make the change cleaner/more effective!