### PR TITLE
Fix missing collision attribute of CarState

### DIFF
--- a/PythonClient/AirSimClient.py
+++ b/PythonClient/AirSimClient.py
@@ -158,6 +158,7 @@ class CarState(MsgpackMixin):
     position = Vector3r()
     velocity = Vector3r()
     orientation = Quaternionr()
+    #collision = CollisionInfo()
 
 class MultirotorState(MsgpackMixin):
     collision = CollisionInfo();


### PR DESCRIPTION
Added collision attribute, to allow hello_car to run - simple, but demo wouldn't run without it...