### PR TITLE
Look for settings.json in multiple places

### DIFF
--- a/AirLib/include/common/common_utils/FileSystem.hpp
+++ b/AirLib/include/common/common_utils/FileSystem.hpp
@@ -46,6 +46,8 @@ public:
 
     static std::string getUserDocumentsFolder();
 
+	static std::string getExecutableFolder();
+
     static std::string getAppDataFolder() {
         return ensureFolder(combine(getUserDocumentsFolder(), ProductFolderName));
     }

--- a/AirLib/include/controllers/Settings.hpp
+++ b/AirLib/include/controllers/Settings.hpp
@@ -40,11 +40,17 @@ public:
 
     std::string getFileName() { return file_; }
 
-    static std::string getFullPath(std::string fileName)
-    {
-        std::string path = common_utils::FileSystem::getAppDataFolder();
-        return common_utils::FileSystem::combine(path, fileName);
-    }
+	static std::string getUserDirectoryFullPath(std::string fileName)
+	{
+		std::string path = common_utils::FileSystem::getAppDataFolder();
+		return common_utils::FileSystem::combine(path, fileName);
+	}
+
+	static std::string getExecutableFullPath(std::string fileName)
+	{
+		std::string path = common_utils::FileSystem::getExecutableFolder();
+		return common_utils::FileSystem::combine(path, fileName);
+	}
 
     static Settings& loadJSonString(const std::string& json_str)
     {
@@ -72,7 +78,7 @@ public:
     static Settings& loadJSonFile(std::string fileName)
     {
         std::lock_guard<std::mutex> guard(getFileAccessMutex());
-        std::string path = getFullPath(fileName);
+        std::string path = getUserDirectoryFullPath(fileName);
         singleton().file_ = fileName;
 
         singleton().load_success_ = false;
@@ -100,7 +106,7 @@ public:
     void saveJSonFile(std::string fileName)
     {
         std::lock_guard<std::mutex> guard(getFileAccessMutex());
-        std::string path = getFullPath(fileName);
+        std::string path = getUserDirectoryFullPath(fileName);
         std::ofstream s;
         common_utils::FileSystem::createTextFile(path, s);
         s << std::setw(2) << doc_ << std::endl;

--- a/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.h
+++ b/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.h
@@ -11,7 +11,7 @@
 UENUM(BlueprintType)
 enum class ESimulatorMode : uint8
 {
-    SIM_MODE_HIL 	UMETA(DisplayName="Hardware-in-loop")
+    SIM_MODE_HIL 	UMETA(DisplayName = "Hardware-in-loop")
 };
 
 UCLASS()
@@ -39,11 +39,11 @@ public:
     void setSubwindowCamera(int window_index, APIPCamera* camera);
     bool getSubwindowVisible(int window_index);
     void setSubwindowVisible(int window_index, bool is_visible);
-        
+
     ASimHUD();
     virtual void BeginPlay() override;
     virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
-    virtual void Tick( float DeltaSeconds ) override;
+    virtual void Tick(float DeltaSeconds) override;
 
     static ASimHUD* GetInstance() {
         return instance_;
@@ -60,6 +60,10 @@ private:
     void initializeSettings();
     void initializeSubWindows();
     void createSimMode();
+
+    bool getSettingsText(std::string& settingsText);
+    bool getSettingsTextFromCommandLine(std::string& settingsText);
+    bool readSettingsTextFromFile(FString fileName, std::string& settingsText);
 
 private:
     typedef common_utils::Utils Utils;


### PR DESCRIPTION
Currently, AirSim looks for the settings.json in the user's documents folder. As detailed in [this issue](https://github.com/Microsoft/AirSim/issues/712), this can cause problems in some situations. Introduce two new ways of specifying the settings file (listed in the order of priority):

1) Command line. When using the AirSim plugin, specify the settings with the --settings command line option. For example:

`> AirSimApp.exe my_awesome_map --settings "{\"SettingsVersion\": 1.0, \"SimMode\": \"Car\"}"`

2) In the directory of the executable. If the settings.json exists in the directory of the running executable, then it will be used. 

If the --settings flag is not specified and the settings.json does not exist in the executable directory, then the settings.json in the user's documents directory is used. If it does not exist there, then AirSim will attempt to create the settings.json in the documents directory (as before).
