### PR TITLE
tweak build.cmd

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,7 +1,7 @@
 @echo off
 REM //---------- set up variable ----------
 setlocal
-set ROOT_DIR=%CD%
+set ROOT_DIR=%~dp0
 
 REM // Check command line arguments
 set "noFullPolyCar="
@@ -129,4 +129,4 @@ goto :eof
 
 :cmakefailed
 echo CMake install failed, please install cmake manually from https://cmake.org/ 1>&2
-exit 1
+exit /b 1


### PR DESCRIPTION
hi, I have modified build.cmd file to improve usability while using VS2015 Native tools command.

1) ROOT_DIR is set as the path of the batch file, instead of %CD%. If current directory is wrong and this modification avoid making trouble, like creating files some wrong directory.
2) "exit" command of the batch file is now using /b option. If error was occured and this modification avoid force to close command prompt window.