### PR TITLE
Make custom stencil changes to the Landscape take effect immediately

### DIFF
--- a/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
+++ b/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
@@ -10,6 +10,7 @@
 #include "common/common_utils/Utils.hpp"
 #include "Components/StaticMeshComponent.h"
 #include "EngineUtils.h"
+#include "Runtime/Landscape/Classes/LandscapeComponent.h"
 #include "UObjectIterator.h"
 //#include "Runtime/Foliage/Public/FoliageType.h"
 #include "Kismet/KismetStringLibrary.h"
@@ -176,6 +177,15 @@ void UAirBlueprintLib::SetObjectStencilID(ALandscapeProxy* mesh, int object_id)
 {
     mesh->CustomDepthStencilValue = object_id;
     mesh->bRenderCustomDepth = true;
+
+    // Explicitly set the custom depth state on the components so the
+    // render state is marked dirty and the update actually takes effect
+    // immediately.
+    for (ULandscapeComponent* comp : mesh->LandscapeComponents)
+    {
+        comp->SetCustomDepthStencilValue(object_id);
+        comp->SetRenderCustomDepth(true);
+    }
 }
 
 template<class T>


### PR DESCRIPTION
Mark the render state dirty for all landscape components. Otherwise the change
does not take effect until returning to the editor.

The problem can easily be reproduced by running this from Python in the Neighbourhood environment:

```
client.simSetSegmentationObjectID('Landscape_0', 50)
```

which does not have any effect on the segmentation image. With this patch applied, it changes the landscape segmentation ID as desired.

Tested with the version of the Unreal Engine as suggested in the [Linux build docs](https://github.com/Microsoft/AirSim/blob/master/docs/build_linux.md#install-and-build), i.e. commit `af96417313a908b20621a443175ba91683c238c8 `.