### PR TITLE
Some small gcc/linux build fixes

### DIFF
--- a/AirLib/include/common/VectorMath.hpp
+++ b/AirLib/include/common/VectorMath.hpp
@@ -227,18 +227,18 @@ public:
         // roll (x-axis rotation)
         RealT t0 = +2.0f * (q.w() * q.x() + q.y() * q.z());
         RealT t1 = +1.0f - 2.0f * (q.x() * q.x() + ysqr);
-        roll = std::atan2f(t0, t1);
+        roll = std::atan2(t0, t1);
 
         // pitch (y-axis rotation)
         RealT t2 = +2.0f * (q.w() * q.y() - q.z() * q.x());
         t2 = ((t2 > 1.0f) ? 1.0f : t2);
         t2 = ((t2 < -1.0f) ? -1.0f : t2);
-        pitch = std::asinf(t2);
+        pitch = std::asin(t2);
 
         // yaw (z-axis rotation)
         RealT t3 = +2.0f * (q.w() * q.z() + q.x() * q.y());
         RealT t4 = +1.0f - 2.0f * (ysqr + q.z() * q.z());  
-        yaw = std::atan2f(t3, t4);
+        yaw = std::atan2(t3, t4);
     }
 
     static Vector3T toAngularVelocity(const QuaternionT& start, const QuaternionT& end, RealT dt)

--- a/AirLib/include/common/common_utils/Utils.hpp
+++ b/AirLib/include/common/common_utils/Utils.hpp
@@ -23,6 +23,9 @@
 #include <queue>
 #include "type_utils.hpp"
 
+#ifndef _WIN32
+#include <limits.h> // needed for CHAR_BIT used below
+#endif
 
 #define _USE_MATH_DEFINES
 #include <cmath>


### PR DESCRIPTION
common_utils/Utils.hpp has a missing include of limits.h, I copied the
fix from MavLinkCom/common_utils/Utils.hpp.

VectorMath.hpp uses std::atan2f, which I don't think exists in the standard.
std::atan2 is overloaded for floats, or atan2f (the C version) exists outside
the `std::` namespace.