### PR TITLE
Add projection mode for capture settings

### DIFF
--- a/AirLib/include/common/AirSimSettings.hpp
+++ b/AirLib/include/common/AirSimSettings.hpp
@@ -86,6 +86,9 @@ public: //types
         float auto_exposure_histogram_log_max = Utils::nan<float>(); // 4;
         float motion_blur_amount = Utils::nan<float>();
         float target_gamma = Utils::nan<float>(); //1.0f; //This would be reset to kSceneTargetGamma for scene as default
+        int projection_mode = 0; // ECameraProjectionMode::Perspective
+        float ortho_width = Utils::nan<float>();
+
     };
 
     struct NoiseSetting {
@@ -449,6 +452,16 @@ private:
         capture_setting.image_type = settings.getInt("ImageType", 0);
         capture_setting.target_gamma = settings.getFloat("TargetGamma", 
             capture_setting.image_type == 0 ? CaptureSetting::kSceneTargetGamma : Utils::nan<float>());
+
+        std::string projection_mode = Utils::toLower(settings.getString("ProjectionMode", ""));
+        if (projection_mode == "" || projection_mode == "perspective")
+            capture_setting.projection_mode = 0; // Perspective
+        else if (projection_mode == "orthographic")
+            capture_setting.projection_mode = 1; // Orthographic
+        else
+            throw std::invalid_argument(std::string("CaptureSettings projection_mode has invalid value in settings ") + projection_mode);
+
+        capture_setting.ortho_width = settings.getFloat("OrthoWidth", capture_setting.ortho_width);
     }
 
     void loadSubWindowsSettings(const Settings& settings)

--- a/Unreal/Plugins/AirSim/Source/NedTransform.cpp
+++ b/Unreal/Plugins/AirSim/Source/NedTransform.cpp
@@ -29,6 +29,11 @@ float NedTransform::toNedMeters(float length)
     return length / world_to_meters_;
 }
 
+float NedTransform::toNeuUU(float length)
+{
+    return length * world_to_meters_;
+}
+
 NedTransform::Vector3r NedTransform::toNedMeters(const FVector& position, bool use_offset)
 {
     return NedTransform::toVector3r(position - (use_offset ? offset_ : FVector::ZeroVector), 1 / world_to_meters_, true);

--- a/Unreal/Plugins/AirSim/Source/NedTransform.h
+++ b/Unreal/Plugins/AirSim/Source/NedTransform.h
@@ -20,6 +20,7 @@ public:
     static FQuat toFQuat(const Quaternionr& q, bool convert_from_ned);
     static Quaternionr toQuaternionr(const FQuat& q, bool convert_to_ned);
     static float toNedMeters(float length);
+    static float toNeuUU(float length);
 
     //TODO: make below private
     static FVector toFVector(const Vector3r& vec, float scale, bool convert_from_ned);

--- a/Unreal/Plugins/AirSim/Source/PIPCamera.cpp
+++ b/Unreal/Plugins/AirSim/Source/PIPCamera.cpp
@@ -7,6 +7,7 @@
 #include "Materials/MaterialInstanceDynamic.h"
 #include "AirBlueprintLib.h"
 #include "ImageUtils.h"
+#include "NedTransform.h"
 
 
 APIPCamera::APIPCamera()
@@ -145,7 +146,7 @@ void APIPCamera::updateCaptureComponentSetting(USceneCaptureComponent2D* capture
     if (!std::isnan(setting.fov_degrees))
         capture->FOVAngle = setting.fov_degrees;
     if (!std::isnan(setting.ortho_width))
-        capture->OrthoWidth = setting.ortho_width * 100.0f;
+        capture->OrthoWidth = NedTransform::toNeuUU(setting.ortho_width);
 
     updateCameraPostProcessingSetting(capture->PostProcessSettings, setting);
 }
@@ -160,7 +161,7 @@ void APIPCamera::updateCameraSetting(UCameraComponent* camera, const CaptureSett
     if (!std::isnan(setting.fov_degrees))
         camera->SetFieldOfView(setting.fov_degrees);
     if (!std::isnan(setting.ortho_width))
-        camera->SetOrthoWidth(setting.ortho_width * 100.0f);
+        camera->SetOrthoWidth(NedTransform::toNeuUU(setting.ortho_width));
 
     updateCameraPostProcessingSetting(camera->PostProcessSettings, setting);
 }

--- a/Unreal/Plugins/AirSim/Source/PIPCamera.cpp
+++ b/Unreal/Plugins/AirSim/Source/PIPCamera.cpp
@@ -140,8 +140,12 @@ void APIPCamera::updateCaptureComponentSetting(USceneCaptureComponent2D* capture
     if (!std::isnan(setting.target_gamma))
         render_target->TargetGamma = setting.target_gamma;
 
+    capture->ProjectionType = static_cast<ECameraProjectionMode::Type>(setting.projection_mode);
+
     if (!std::isnan(setting.fov_degrees))
         capture->FOVAngle = setting.fov_degrees;
+    if (!std::isnan(setting.ortho_width))
+        capture->OrthoWidth = setting.ortho_width * 100.0f;
 
     updateCameraPostProcessingSetting(capture->PostProcessSettings, setting);
 }
@@ -151,8 +155,12 @@ void APIPCamera::updateCameraSetting(UCameraComponent* camera, const CaptureSett
     //if (!std::isnan(setting.target_gamma))
     //    camera-> = setting.target_gamma;
 
+    camera->SetProjectionMode(static_cast<ECameraProjectionMode::Type>(setting.projection_mode));
+
     if (!std::isnan(setting.fov_degrees))
         camera->SetFieldOfView(setting.fov_degrees);
+    if (!std::isnan(setting.ortho_width))
+        camera->SetOrthoWidth(setting.ortho_width * 100.0f);
 
     updateCameraPostProcessingSetting(camera->PostProcessSettings, setting);
 }

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -56,7 +56,9 @@ Below are complete list of settings available along with their default values. I
       "AutoExposureMaxBrightness": 0.64,
       "AutoExposureMinBrightness": 0.03,
       "MotionBlurAmount": 0,
-      "TargetGamma": 1.0
+      "TargetGamma": 1.0,
+      "ProjectionMode": "perspective",
+      "OrthoWidth": 5.12
     }
   ],
   "NoiseSettings": [


### PR DESCRIPTION
This allows to switch to orthographic projection mode. It can be used to create a "map" of an environment by taking overhead orthographic pictures in segmentation view.