### PR TITLE
Add MeshNamingMethod segmentation setting

### DIFF
--- a/AirLib/include/common/AirSimSettings.hpp
+++ b/AirLib/include/common/AirSimSettings.hpp
@@ -117,8 +117,13 @@ public: //types
             None, CommonObjectsRandomIDs
         };
 
+        enum class MeshNamingMethodType {
+            OwnerName, StaticMeshName
+        };
+
         InitMethodType init_method = InitMethodType::CommonObjectsRandomIDs;
         bool override_existing = false;
+        MeshNamingMethodType mesh_naming_method = MeshNamingMethodType::OwnerName;
     };
 
 private: //fields
@@ -398,6 +403,14 @@ private:
                 throw std::invalid_argument(std::string("SegmentationSettings init_method has invalid value in settings ") + init_method);
 
             segmentation_settings.override_existing = json_parent.getBool("OverrideExisting", false);
+
+            std::string mesh_naming_method = Utils::toLower(json_parent.getString("MeshNamingMethod", ""));
+            if (mesh_naming_method == "" || mesh_naming_method == "ownername")
+                segmentation_settings.mesh_naming_method = SegmentationSettings::MeshNamingMethodType::OwnerName;
+            else if (mesh_naming_method == "staticmeshname")
+                segmentation_settings.mesh_naming_method = SegmentationSettings::MeshNamingMethodType::StaticMeshName;
+            else
+                throw std::invalid_argument(std::string("SegmentationSettings MeshNamingMethod has invalid value in settings ") + mesh_naming_method);
         }
     }
 

--- a/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
+++ b/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
@@ -11,6 +11,7 @@
 #include "Components/StaticMeshComponent.h"
 #include "EngineUtils.h"
 #include "Runtime/Landscape/Classes/LandscapeComponent.h"
+#include "Runtime/Engine/Classes/Engine/StaticMesh.h"
 #include "UObjectIterator.h"
 //#include "Runtime/Foliage/Public/FoliageType.h"
 #include "Kismet/KismetStringLibrary.h"
@@ -26,6 +27,8 @@ parameters -> camel_case
 
 
 bool UAirBlueprintLib::log_messages_hidden = false;
+msr::airlib::AirSimSettings::SegmentationSettings::MeshNamingMethodType UAirBlueprintLib::mesh_naming_method =
+    msr::airlib::AirSimSettings::SegmentationSettings::MeshNamingMethodType::OwnerName;
 
 void UAirBlueprintLib::LogMessageString(const std::string &prefix, const std::string &suffix, LogDebugLevel level, float persist_sec)
 {
@@ -212,10 +215,21 @@ void UAirBlueprintLib::SetObjectStencilID(ALandscapeProxy* mesh, int object_id)
 template<class T>
 std::string UAirBlueprintLib::GetMeshName(T* mesh)
 {
-    if (mesh->GetOwner())
-        return std::string(TCHAR_TO_UTF8(*(mesh->GetOwner()->GetName())));
-    else
-        return ""; // std::string(TCHAR_TO_UTF8(*(UKismetSystemLibrary::GetDisplayName(mesh))));
+    switch(mesh_naming_method)
+    {
+    case msr::airlib::AirSimSettings::SegmentationSettings::MeshNamingMethodType::OwnerName:
+        if (mesh->GetOwner())
+            return std::string(TCHAR_TO_UTF8(*(mesh->GetOwner()->GetName())));
+        else
+            return ""; // std::string(TCHAR_TO_UTF8(*(UKismetSystemLibrary::GetDisplayName(mesh))));
+    case msr::airlib::AirSimSettings::SegmentationSettings::MeshNamingMethodType::StaticMeshName:
+        if (mesh->GetStaticMesh())
+            return std::string(TCHAR_TO_UTF8(*(mesh->GetStaticMesh()->GetName())));
+        else
+            return "";
+    default:
+        return "";
+    }
 }
 
 std::string UAirBlueprintLib::GetMeshName(ALandscapeProxy* mesh)

--- a/Unreal/Plugins/AirSim/Source/AirBlueprintLib.h
+++ b/Unreal/Plugins/AirSim/Source/AirBlueprintLib.h
@@ -13,6 +13,7 @@
 #include "Kismet/KismetMathLibrary.h"
 #include "Components/MeshComponent.h"
 #include "LandscapeProxy.h"
+#include "common/AirSimSettings.hpp"
 #include "AirBlueprintLib.generated.h"
 
 
@@ -91,6 +92,10 @@ public:
     {
         log_messages_hidden = is_hidden;
     }
+    static void SetMeshNamingMethod(msr::airlib::AirSimSettings::SegmentationSettings::MeshNamingMethodType method)
+    {
+        mesh_naming_method = method;
+    }
 
 private:
     template<typename T>
@@ -108,5 +113,6 @@ private:
 
 private:
     static bool log_messages_hidden;
+    static msr::airlib::AirSimSettings::SegmentationSettings::MeshNamingMethodType mesh_naming_method;
 };
 

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
@@ -33,6 +33,8 @@ void ASimModeBase::BeginPlay()
 
 void ASimModeBase::setStencilIDs()
 {
+    UAirBlueprintLib::SetMeshNamingMethod(getSettings().segmentation_settings.mesh_naming_method);
+
     if (getSettings().segmentation_settings.init_method ==
         AirSimSettings::SegmentationSettings::InitMethodType::CommonObjectsRandomIDs) {
      

--- a/docs/image_apis.md
+++ b/docs/image_apis.md
@@ -244,6 +244,8 @@ If you don't know how to open Unreal Environment in Unreal Editor then try follo
 
 Once you decide on the meshes you are interested, note down their names and use above API to set their object IDs.
 
+Alternatively, the `MeshNamingMethod` can be switched to "StaticMeshName" in the [settings](settings.md). In this case, the static mesh name as shown in the content browser in the Unreal Editor is used to refer to meshes. Note that it is not possible to tell individual instances of the same static mesh apart this way, but the names are often more intuitive.
+
 #### Changing Colors for Object IDs
 At present color for each object ID is fixed as in [this pallet](../Unreal/Plugins/AirSim/Content/HUDAssets/seg_color_pallet.png). We will be adding ability to change colors for object IDs to desired values shortly. In the mean time it might be easier just to open the segmentation image in some image editor and get the RGB values you are interested in. 
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -97,6 +97,9 @@ Below are complete list of settings available along with their default values. I
     },
     "ApiServerPort": 41451
   },
+  "SegmentationSettings": {
+    "MeshNamingMethod": "OwnerName"
+  },
   "PX4": {
     "FirmwareName": "PX4",
     "LogViewerHostIp": "127.0.0.1",


### PR DESCRIPTION
This allows to refer to meshes by their static mesh name instead of the
owner name in the segmentation APIs and the initial object ID assignments. Note that it is not possible to tell individual instances of the same static mesh apart this way, but the names are often more intuitive, and it allows to tell apart some instances such as spline mesh components from other instances of different types or the landscape. See #776.