### PR TITLE
Fixing a race condition in MultiRotorConnector with reset()

### DIFF
--- a/Unreal/Plugins/AirSim/Source/Multirotor/MultiRotorConnector.h
+++ b/Unreal/Plugins/AirSim/Source/Multirotor/MultiRotorConnector.h
@@ -113,6 +113,7 @@ private:
 
     //reset must happen while World is locked so its async task initiated from API thread
     bool reset_pending_;
+    bool did_reset_;
     std::packaged_task<void()> reset_task_;
 
     Pose last_pose_; //for trace lines showing vehicle path


### PR DESCRIPTION
The reset function in MultiRotorConnector can sometimes be skipped over if the reset task is created in between the updateRenderedState and updateRendering function calls. This causes the client to timeout as in #665 