### PR TITLE
Add setting to disable rendering of main viewport

### DIFF
--- a/AirLib/include/common/AirSimSettings.hpp
+++ b/AirLib/include/common/AirSimSettings.hpp
@@ -167,7 +167,6 @@ public: //fields
     float clock_speed;
     bool engine_sound;
     bool log_messages_visible;
-    bool main_viewport_visible;
     HomeGeoPoint origin_geopoint;
 
 public: //methods
@@ -227,7 +226,6 @@ public: //methods
         clock_speed = 1.0f;
         engine_sound = true;     
         log_messages_visible = true;
-        main_viewport_visible = true;
         //0,0,0 in Unreal is mapped to this GPS coordinates
         origin_geopoint = HomeGeoPoint(GeoPoint(47.641468, -122.140165, 122)); 
     }
@@ -554,7 +552,6 @@ private:
 
         enable_collision_passthrough = settings.getBool("EnableCollisionPassthrogh", false);
         log_messages_visible = settings.getBool("LogMessagesVisible", true);
-        main_viewport_visible = settings.getBool("MainViewportVisible", true);
 
         {   //load origin geopoint
             Settings origin_geopoint_json;

--- a/AirLib/include/common/AirSimSettings.hpp
+++ b/AirLib/include/common/AirSimSettings.hpp
@@ -167,6 +167,7 @@ public: //fields
     float clock_speed;
     bool engine_sound;
     bool log_messages_visible;
+    bool main_viewport_visible;
     HomeGeoPoint origin_geopoint;
 
 public: //methods
@@ -226,6 +227,7 @@ public: //methods
         clock_speed = 1.0f;
         engine_sound = true;     
         log_messages_visible = true;
+        main_viewport_visible = true;
         //0,0,0 in Unreal is mapped to this GPS coordinates
         origin_geopoint = HomeGeoPoint(GeoPoint(47.641468, -122.140165, 122)); 
     }
@@ -552,6 +554,7 @@ private:
 
         enable_collision_passthrough = settings.getBool("EnableCollisionPassthrogh", false);
         log_messages_visible = settings.getBool("LogMessagesVisible", true);
+        main_viewport_visible = settings.getBool("MainViewportVisible", true);
 
         {   //load origin geopoint
             Settings origin_geopoint_json;

--- a/Unreal/Plugins/AirSim/Source/CameraDirector.h
+++ b/Unreal/Plugins/AirSim/Source/CameraDirector.h
@@ -18,8 +18,8 @@ enum class ECameraDirectorMode : uint8
     CAMERA_DIRECTOR_MODE_FLY_WITH_ME = 3	UMETA(DisplayName = "FlyWithMe"),
     CAMERA_DIRECTOR_MODE_MANUAL = 4	UMETA(DisplayName = "Manual"),
     CAMERA_DIRECTOR_MODE_SPRINGARM_CHASE = 5	UMETA(DisplayName = "SpringArmChase"),
-    CAMREA_DIRECTOR_MODE_BACKUP = 6     UMETA(DisplayName = "Backup"),
-    CAMREA_DIRECTOR_MODE_NODISPLAY = 7      UMETA(DisplayName = "No Display")
+    CAMERA_DIRECTOR_MODE_BACKUP = 6     UMETA(DisplayName = "Backup"),
+    CAMERA_DIRECTOR_MODE_NODISPLAY = 7      UMETA(DisplayName = "No Display")
 };
 
 UCLASS()

--- a/Unreal/Plugins/AirSim/Source/RenderRequest.cpp
+++ b/Unreal/Plugins/AirSim/Source/RenderRequest.cpp
@@ -69,22 +69,25 @@ void RenderRequest::getScreenshot(std::shared_ptr<RenderParams> params[], std::v
     for (unsigned int i = 0; i < req_size; ++i) {
         if (! params[i]->pixels_as_float) {
             if (results[i]->width != 0 && results[i]->height != 0) {
+                results[i]->image_data_uint8.SetNumUninitialized(results[i]->width * results[i]->height * 4, false);
                 if (params[i]->compress)
                     FImageUtils::CompressImageArray(results[i]->width, results[i]->height, results[i]->bmp, results[i]->image_data_uint8);
                 else {
+                    uint8* ptr = results[i]->image_data_uint8.GetData();
                     for (const auto& item : results[i]->bmp) {
-                        results[i]->image_data_uint8.Add(item.R);
-                        results[i]->image_data_uint8.Add(item.G);
-                        results[i]->image_data_uint8.Add(item.B);
-                        results[i]->image_data_uint8.Add(item.A);
+                        *ptr++ = item.R;
+                        *ptr++ = item.G;
+                        *ptr++ = item.B;
+                        *ptr++ = item.A;
                     }
                 }
             }
         }
         else {
+            results[i]->image_data_float.SetNumUninitialized(results[i]->width * results[i]->height);
+            float* ptr = results[i]->image_data_float.GetData();
             for (const auto& item : results[i]->bmp_float) {
-                float fval = item.R.GetFloat();
-                results[i]->image_data_float.Add(fval);
+                *ptr++ = item.R.GetFloat();
             }
         }
     }

--- a/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
@@ -4,7 +4,6 @@
 #include "Car/SimModeCar.h"
 #include "common/AirSimSettings.hpp"
 #include "Kismet/KismetSystemLibrary.h"
-#include "Runtime/Engine/Public/Slate/SceneViewport.h"
 
 #include <stdexcept>
 
@@ -205,24 +204,6 @@ void ASimHUD::setUnrealEngineSettings()
     //we get error that GameThread has timed out after 30 sec waiting on render thread
     static const auto render_timeout_var = IConsoleManager::Get().FindConsoleVariable(TEXT("g.TimeoutForBlockOnRenderFence"));
     render_timeout_var->Set(300000);
-
-    const bool main_viewport_visible = AirSimSettings::singleton().main_viewport_visible;
-
-    if (!main_viewport_visible) {
-        // This disables rendering of the main viewport in the same way as the
-        // console command "show rendering" would do.
-        GetWorld()->GetGameViewport()->EngineShowFlags.SetRendering(false);
-
-        // When getting an image through the API, the image is produced after the render
-        // thread has finished rendering the current and the subsequent frame. This means
-        // that the frame rate for obtaining images through the API is only half as high as
-        // it could be, since only every other image is actually captured. We work around
-        // this by telling the viewport to flush the rendering queue at the end of each
-        // drawn frame so that it executes our render request at that point already.
-        // Do this only if the main viewport is not being rendered anyway in case there are
-        // any adverse performance effects during main rendering.
-        GetWorld()->GetGameViewport()->GetGameViewport()->IncrementFlushOnDraw();
-    }
 }
 
 void ASimHUD::setupInputBindings()

--- a/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
@@ -205,6 +205,13 @@ void ASimHUD::setUnrealEngineSettings()
     static const auto render_timeout_var = IConsoleManager::Get().FindConsoleVariable(TEXT("g.TimeoutForBlockOnRenderFence"));
     render_timeout_var->Set(300000);
 
+    const bool main_viewport_visible = AirSimSettings::singleton().main_viewport_visible;
+
+    if (!main_viewport_visible) {
+        // This disables rendering of the main viewport in the same way as the
+        // console command "show rendering" would do.
+        GetWorld()->GetGameViewport()->EngineShowFlags.SetRendering(false);
+    }
 }
 
 void ASimHUD::setupInputBindings()

--- a/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
@@ -4,6 +4,7 @@
 #include "Car/SimModeCar.h"
 #include "common/AirSimSettings.hpp"
 #include "Kismet/KismetSystemLibrary.h"
+#include "Runtime/Engine/Public/Slate/SceneViewport.h"
 
 #include <stdexcept>
 
@@ -211,6 +212,16 @@ void ASimHUD::setUnrealEngineSettings()
         // This disables rendering of the main viewport in the same way as the
         // console command "show rendering" would do.
         GetWorld()->GetGameViewport()->EngineShowFlags.SetRendering(false);
+
+        // When getting an image through the API, the image is produced after the render
+        // thread has finished rendering the current and the subsequent frame. This means
+        // that the frame rate for obtaining images through the API is only half as high as
+        // it could be, since only every other image is actually captured. We work around
+        // this by telling the viewport to flush the rendering queue at the end of each
+        // drawn frame so that it executes our render request at that point already.
+        // Do this only if the main viewport is not being rendered anyway in case there are
+        // any adverse performance effects during main rendering.
+        GetWorld()->GetGameViewport()->GetGameViewport()->IncrementFlushOnDraw();
     }
 }
 


### PR DESCRIPTION
I spent some time optimizing the frame rate at which I am able to obtain images through the API, by just requesting images in a loop in Python. Unsurprisingly, it turned out that when getting uncompressed images the frame rate is higher than getting compressed images. Also unsurprisingly, it turned out that the frame rate is higher when not rendering the actual main viewport that is displayed on the screen, which can be disabled by running the command `show rendering` in the Unreal console.

So, this PR adds a setting that allows to disable the rendering of the main viewport in the same way, for cases where it is not needed and instead a high frame rate of images to be obtained through the API is desirable. In that case it also makes sure that the graphics pipeline is flushed after every frame has been drawn, because otherwise the API image request only gets scheduled to execute only after every other frame has actually been rendered. This effectively doubles the frame rate.

To test these tweaks I set up a particular scene in the neighbourhood environment at which I was getting about 18 FPS when rendered onscreen. When running my Python loop to get images through the API, images were coming in at about 3 FPS, then with main viewport rendering disabled around 7 FPS and with the pipeline flush tweak about 12 FPS. Given that the on-screen framerate I observed was 18 FPS there might be more improvements possible, but this seems like a good start and fairly low-hanging fruit.

I also realized that the loop that copies the image into the results after it was captured took about 10ms on my machine for a 512x512 image. I have optimized this so that it takes less than 1ms, but did this did not improve the total frame rate, probably because the GPU was already busy rendering the next frame at this point. I still thought it's a worthwhile contribution, though.

Would it make more sense to use a new ViewMode enumerat instead of a boolean "MainViewportVisible" setting for this? Although the view mode already has a "NoDisplay" setting that seems to do something different, so it might be confusing.