### PR TITLE
Allow to configure additional drone cameras

### DIFF
--- a/AirLib/include/common/AirSimSettings.hpp
+++ b/AirLib/include/common/AirSimSettings.hpp
@@ -63,6 +63,16 @@ public: //types
         }
     };
 
+    struct AdditionalCameraSetting {
+        // Additional camera positions
+        float x = 0.5f;
+        float y = 0.0f;
+        float z = 0.0f;
+        float yaw = 0.0f;
+        float pitch = 0.0f;
+        float roll = 0.0f;
+    };
+
     struct CaptureSetting {
         //below settinsg are obtained by using Unreal console command (press ~):
         // ShowFlag.VisualizeHDR 1.
@@ -146,6 +156,7 @@ public: //fields
 
     std::vector<SubwindowSetting> subwindow_settings;
 
+    std::vector<AdditionalCameraSetting> additional_camera_settings;
     std::map<int, CaptureSetting> capture_settings;
     std::map<int, NoiseSetting>  noise_settings;
 
@@ -194,6 +205,7 @@ public: //methods
         loadSubWindowsSettings(settings);
         loadViewModeSettings(settings);
         loadRecordingSettings(settings);
+        loadAdditionalCameraSettings(settings);
         loadCaptureSettings(settings);
         loadCameraNoiseSettings(settings);
         loadSegmentationSettings(settings);
@@ -461,6 +473,26 @@ private:
         noise_setting.HorzNoiseLinesDensityXY = settings.getFloat("HorzNoiseLinesDensityXY", noise_setting.HorzNoiseLinesDensityXY);
         noise_setting.HorzDistortionStrength = settings.getFloat("HorzDistortionStrength", noise_setting.HorzDistortionStrength);
         noise_setting.HorzDistortionContrib = settings.getFloat("HorzDistortionContrib", noise_setting.HorzDistortionContrib);
+    }
+
+    void loadAdditionalCameraSettings(const Settings& settings)
+    {
+        Settings json_parent;
+        if (settings.getChild("AdditionalCameras", json_parent)) {
+            for (size_t child_index = 0; child_index < json_parent.size(); ++child_index) {
+                Settings additional_camera_setting;
+                if (json_parent.getChild(child_index, additional_camera_setting)) {
+                    AdditionalCameraSetting setting;
+                    setting.x = additional_camera_setting.getFloat("X", setting.x);
+                    setting.y = additional_camera_setting.getFloat("Y", setting.y);
+                    setting.z = additional_camera_setting.getFloat("Z", setting.z);
+                    setting.yaw = additional_camera_setting.getFloat("Yaw", setting.yaw);
+                    setting.pitch = additional_camera_setting.getFloat("Pitch", setting.pitch);
+                    setting.roll = additional_camera_setting.getFloat("Roll", setting.roll);
+                    additional_camera_settings.push_back(setting);
+                }
+            }
+        }
     }
 
     void createCaptureSettings(const msr::airlib::Settings& settings, CaptureSetting& capture_setting)

--- a/Unreal/Plugins/AirSim/Source/Multirotor/FlyingPawn.h
+++ b/Unreal/Plugins/AirSim/Source/Multirotor/FlyingPawn.h
@@ -19,15 +19,17 @@ public:
     float RotatorFactor = 1.0f;
 
     void setRotorSpeed(int rotor_index, float radsPerSec);
-    void initializeForBeginPlay();
+    void initializeForBeginPlay(const std::vector<msr::airlib::AirSimSettings::AdditionalCameraSetting>& additionalCameras);
     VehiclePawnWrapper* getVehiclePawnWrapper();
 
     virtual void NotifyHit(class UPrimitiveComponent* MyComp, class AActor* Other, class UPrimitiveComponent* OtherComp, bool bSelfMoved, FVector HitLocation,
         FVector HitNormal, FVector NormalImpulse, const FHitResult& Hit) override;
 private: //methods
-    void setupComponentReferences();
+    void setupComponentReferences(const std::vector<msr::airlib::AirSimSettings::AdditionalCameraSetting>& additionalCameras);
 
 private: //variables
+    UPROPERTY() UClass* pip_camera_class_;
+
          //Unreal components
     static constexpr size_t rotor_count = 4;
     UPROPERTY() APIPCamera* fpv_camera_front_left_;
@@ -37,6 +39,8 @@ private: //variables
     UPROPERTY() APIPCamera* fpv_camera_bottom_center_;
 
     UPROPERTY() URotatingMovementComponent* rotating_movements_[rotor_count];
+
+    UPROPERTY() TArray<APIPCamera*> AdditionalCameras;
 
     std::unique_ptr<VehiclePawnWrapper> wrapper_;
 };

--- a/Unreal/Plugins/AirSim/Source/Multirotor/SimModeWorldMultiRotor.cpp
+++ b/Unreal/Plugins/AirSim/Source/Multirotor/SimModeWorldMultiRotor.cpp
@@ -117,7 +117,7 @@ void ASimModeWorldMultiRotor::setupVehiclesAndCamera(std::vector<VehiclePtr>& ve
         {
             //initialize each vehicle pawn we found
             TMultiRotorPawn* vehicle_pawn = static_cast<TMultiRotorPawn*>(pawn);
-            vehicle_pawn->initializeForBeginPlay();
+            vehicle_pawn->initializeForBeginPlay(getSettings().additional_camera_settings);
 
             //chose first pawn as FPV if none is designated as FPV
             VehiclePawnWrapper* wrapper = vehicle_pawn->getVehiclePawnWrapper();

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -116,6 +116,9 @@ Below are complete list of settings available along with their default values. I
       "HorzDistortionStrength": 0.002
     }
   ],
+  "AdditionalCameras": [
+    { "X": 0.00, "Y": 0.5, "Z": 0.0, "Roll": 0.0, "Pitch": 0.0, "Yaw": 90.0 }
+  ],
   "PX4": {
     "FirmwareName": "PX4",
     "LogViewerHostIp": "127.0.0.1",
@@ -254,3 +257,10 @@ This adds regions of noise on horizontal lines.
 This adds fluctuations on horizontal line.
 * `HorzDistortionContrib`: This determines blend ratio of noise pixel with image pixel, 0 means no noise and 1 means only noise.
 * `HorzDistortionStrength`: This determines how large is the distortion.
+
+### Additional Camera Settings
+This allows to configure cameras in addition to the [standard ones](image_apis.md#available-cameras). This is only implemented in the multirotor drone at the moment.
+The X, Y and Z fields specify the location of the new camera in the body frame, where X points forward, Y points to the right, and Z points downwards, and the values are given
+in SI units (meters). Yaw, Pitch, and Roll specify the orientation of the camera, where Yaw denotes rotation around the Z axis, Pitch rotation around the Y axis and Roll rotation around the X axis.
+
+This particular example adds a camera that is mounted on the right side of the drone, pointed to the right.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -263,4 +263,4 @@ This allows to configure cameras in addition to the [standard ones](image_apis.m
 The X, Y and Z fields specify the location of the new camera in the body frame, where X points forward, Y points to the right, and Z points downwards, and the values are given
 in SI units (meters). Yaw, Pitch, and Roll specify the orientation of the camera, where Yaw denotes rotation around the Z axis, Pitch rotation around the Y axis and Roll rotation around the X axis.
 
-This particular example adds a camera that is mounted on the right side of the drone, pointed to the right.
+This particular example adds a camera that is mounted on the right side of the drone, pointed to the right. The camera indices of the additional cameras are subsequent to the default ones, so camera index 5 is the first additional camera, camera index 6 the second additional camera, and so on.


### PR DESCRIPTION
This allows to configure additional cameras on the multirotor vehicle in the JSON settings. It can be useful to explore different possible camera configurations. See also #840. The camera indices of the additional cameras are subsequent to the default ones, so camera index 5 is the first additional camera, camera index 6 the second additional camera, and so on.