### PR TITLE
Fixup so it compiles in Unreal 4.19

### DIFF
--- a/Unreal/Plugins/AirSim/Source/Car/SimModeCar.cpp
+++ b/Unreal/Plugins/AirSim/Source/Car/SimModeCar.cpp
@@ -54,7 +54,7 @@ void ASimModeCar::setupVehiclesAndCamera(std::vector<VehiclePtr>& vehicles)
 {
     //get player controller
     APlayerController* player_controller = this->GetWorld()->GetFirstPlayerController();
-    FTransform actor_transform = player_controller->GetActorTransform();
+    FTransform actor_transform = player_controller->GetViewTarget()->GetActorTransform();
     //put camera little bit above vehicle
     FTransform camera_transform(actor_transform.GetLocation() + FVector(follow_distance_, 0, 400));
 

--- a/Unreal/Plugins/AirSim/Source/Multirotor/SimModeWorldMultiRotor.cpp
+++ b/Unreal/Plugins/AirSim/Source/Multirotor/SimModeWorldMultiRotor.cpp
@@ -62,7 +62,7 @@ void ASimModeWorldMultiRotor::setupVehiclesAndCamera(std::vector<VehiclePtr>& ve
 {
     //get player controller
     APlayerController* player_controller = this->GetWorld()->GetFirstPlayerController();
-    FTransform actor_transform = player_controller->GetActorTransform();
+    FTransform actor_transform = player_controller->GetViewTarget()->GetActorTransform();
     //put camera little bit above vehicle
     FTransform camera_transform(actor_transform.GetLocation() + FVector(-300, 0, 200));
 


### PR DESCRIPTION
GetActorTransform() is private for AController and its children, so we need to access the transform via the GetViewTarget() - I've tested it in Unreal 4.19, Blocks environment, Mac OS X, High Sierra, MacBook Pro