### PR TITLE
Hotfix/segment more than static meshes

### DIFF
--- a/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
+++ b/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
@@ -330,6 +330,27 @@ std::string UAirBlueprintLib::GetMeshName(T* mesh)
     }
 }
 
+template<>
+std::string UAirBlueprintLib::GetMeshName<USkinnedMeshComponent>(USkinnedMeshComponent* mesh)
+{
+  switch(mesh_naming_method)
+  {
+    case msr::airlib::AirSimSettings::SegmentationSettings::MeshNamingMethodType::OwnerName:
+      if (mesh->GetOwner())
+        return std::string(TCHAR_TO_UTF8(*(mesh->GetOwner()->GetName())));
+      else
+        return ""; // std::string(TCHAR_TO_UTF8(*(UKismetSystemLibrary::GetDisplayName(mesh))));
+    case msr::airlib::AirSimSettings::SegmentationSettings::MeshNamingMethodType::StaticMeshName:
+      if (mesh->SkeletalMesh)
+        return std::string(TCHAR_TO_UTF8(*(mesh->SkeletalMesh->GetName())));
+      else
+        return "";
+    default:
+      return "";
+  }
+}
+
+
 std::string UAirBlueprintLib::GetMeshName(ALandscapeProxy* mesh)
 {
     return std::string(TCHAR_TO_UTF8(*(mesh->GetName())));
@@ -338,6 +359,10 @@ std::string UAirBlueprintLib::GetMeshName(ALandscapeProxy* mesh)
 void UAirBlueprintLib::InitializeMeshStencilIDs(bool ignore_existing)
 {
     for (TObjectIterator<UStaticMeshComponent> comp; comp; ++comp)
+    {
+        InitializeObjectStencilID(*comp, ignore_existing);
+    }
+    for (TObjectIterator<USkinnedMeshComponent> comp; comp; ++comp)
     {
         InitializeObjectStencilID(*comp, ignore_existing);
     }
@@ -375,6 +400,10 @@ bool UAirBlueprintLib::SetMeshStencilID(const std::string& mesh_name, int object
 
     int changes = 0;
     for (TObjectIterator<UStaticMeshComponent> comp; comp; ++comp)
+    {
+        SetObjectStencilIDIfMatch(*comp, object_id, mesh_name, is_name_regex, name_regex, changes);
+    }
+    for (TObjectIterator<USkinnedMeshComponent> comp; comp; ++comp)
     {
         SetObjectStencilIDIfMatch(*comp, object_id, mesh_name, is_name_regex, name_regex, changes);
     }


### PR DESCRIPTION
This fix allows to change the Segmentation Index of Skeletal and Skinned meshes as per [issue #900](https://github.com/Microsoft/AirSim/issues/900)

However, this is by far a perfect solution:
   - `UAirBlueprintLib::GetMeshName` is not a clean template anymore as the interface to getting the name of the mesh is different for `UStaticMesh` and `USkinnedMesh`
  - More serious: One can still not access things such as Landscape Splines - I don't even see a name to identify them by in the editor...,
  - Further, note that the default setting for segmentation is "owner" so the segmentation IDs are generated from the actor names. Set `"MeshNamingMethod": "StaticMeshName"` if you want to segment by the name of the mesh used. The name is now confusing, as it also works for `SkeletalMesh`es...