### PR TITLE
Time delta calculation bug fix

### DIFF
--- a/AirLib/include/vehicles/multirotor/firmwares/simple_flight/firmware/PidController.hpp
+++ b/AirLib/include/vehicles/multirotor/firmwares/simple_flight/firmware/PidController.hpp
@@ -91,7 +91,7 @@ public:
         const T error = goal_ - measured_;
 
         float dt = clock_ == nullptr ? 1 :
-            (static_cast<float>(clock_->millis()) - last_time_)
+            (clock_->millis() - last_time_)
             * config_.time_scale;
 
         float pterm = error * config_.kp;


### PR DESCRIPTION
Fixes issue #918

Removes a static cast to fix a bug in how the time delta is calculated.

The static_cast is causing a loss of precision since clock->millis() and last_time_ are both uint64_t. Here are some example of clock->millis(), last_time_, and what numbers they get casted to as floats:
clock->millis(), last_time_, static_cast(clock->millis()), static_cast(last_time_)
1522772381699, 1522772381696, 1522772344832, 1522772344832
1522772381702, 1522772381699, 1522772344832, 1522772344832

Since the current and last time are getting cast to the same values dt is 0. In the code, dt must be above a threshold for the I and D terms to get applied. Eventually both the current and last time will not get cast to the same value, which causes dt to be large and the I term gets clipped to its max value.