### PR TITLE
Front camera

### DIFF
--- a/AirLib/include/common/AirSimSettings.hpp
+++ b/AirLib/include/common/AirSimSettings.hpp
@@ -370,6 +370,8 @@ private:
             initial_view_mode = 6; // ECameraDirectorMode::CAMREA_DIRECTOR_MODE_BACKUP;
         else if (view_mode_string == "NoDisplay")
             initial_view_mode = 7; // ECameraDirectorMode::CAMREA_DIRECTOR_MODE_NODISPLAY;
+        else if (view_mode_string == "Front")
+			initial_view_mode = 8; // ECameraDirectorMode::CAMREA_DIRECTOR_MODE_FRONT;
         else
             warning_messages.push_back("ViewMode setting is not recognized: " + view_mode_string);
     }

--- a/Unreal/Plugins/AirSim/Source/CameraDirector.cpp
+++ b/Unreal/Plugins/AirSim/Source/CameraDirector.cpp
@@ -78,6 +78,7 @@ void ACameraDirector::setCameras(APIPCamera* external_camera, VehiclePawnWrapper
     external_camera_ = external_camera;
     follow_actor_ = vehicle_pawn_wrapper->getPawn();
     fpv_camera_ = vehicle_pawn_wrapper->getCameraCount() > fpv_camera_index_ ? vehicle_pawn_wrapper->getCamera(fpv_camera_index_) : nullptr;
+	front_camera_ = vehicle_pawn_wrapper->getCameraCount() > front_camera_index_ ? vehicle_pawn_wrapper->getCamera(front_camera_index_) : nullptr;
     backup_camera_ = backup_camera_index_ >= 0 && vehicle_pawn_wrapper->getCameraCount() > backup_camera_index_ ? vehicle_pawn_wrapper->getCamera(backup_camera_index_) : nullptr;
     camera_start_location_ = external_camera_->GetActorLocation();
     camera_start_rotation_ = external_camera_->GetActorRotation();
@@ -94,6 +95,7 @@ void ACameraDirector::setCameras(APIPCamera* external_camera, VehiclePawnWrapper
     case ECameraDirectorMode::CAMERA_DIRECTOR_MODE_SPRINGARM_CHASE: inputEventSpringArmChaseView(); break;
     case ECameraDirectorMode::CAMERA_DIRECTOR_MODE_BACKUP: inputEventBackupView(); break;
     case ECameraDirectorMode::CAMERA_DIRECTOR_MODE_NODISPLAY: inputEventNoDisplayView(); break;
+	case ECameraDirectorMode::CAMERA_DIRECTOR_MODE_FRONT: inputEventFrontView(); break;
     default:
         throw std::out_of_range("Unsupported view mode specified in CameraDirector::initializeForBeginPlay");
     }
@@ -199,6 +201,7 @@ void ACameraDirector::setupInputBindings()
     UAirBlueprintLib::BindActionToKey("inputEventSpringArmChaseView", EKeys::Slash, this, &ACameraDirector::inputEventSpringArmChaseView);
     UAirBlueprintLib::BindActionToKey("inputEventBackupView", EKeys::K, this, &ACameraDirector::inputEventBackupView);
     UAirBlueprintLib::BindActionToKey("inputEventNoDisplayView", EKeys::Hyphen, this, &ACameraDirector::inputEventNoDisplayView);
+	UAirBlueprintLib::BindActionToKey("inputEventFrontView", EKeys::I, this, &ACameraDirector::inputEventFrontView);
 }
 
 
@@ -210,6 +213,16 @@ void ACameraDirector::inputEventFpvView()
         backup_camera_->disableMain();
     if (fpv_camera_)
         fpv_camera_->showToScreen();
+}
+
+void ACameraDirector::inputEventFrontView()
+{
+	setMode(ECameraDirectorMode::CAMERA_DIRECTOR_MODE_FRONT);
+	external_camera_->disableMain();
+	if (backup_camera_)
+		backup_camera_->disableMain();
+	if (front_camera_)
+		front_camera_->showToScreen();
 }
 
 void ACameraDirector::inputEventSpringArmChaseView()

--- a/Unreal/Plugins/AirSim/Source/CameraDirector.h
+++ b/Unreal/Plugins/AirSim/Source/CameraDirector.h
@@ -19,7 +19,8 @@ enum class ECameraDirectorMode : uint8
     CAMERA_DIRECTOR_MODE_MANUAL = 4	UMETA(DisplayName = "Manual"),
     CAMERA_DIRECTOR_MODE_SPRINGARM_CHASE = 5	UMETA(DisplayName = "SpringArmChase"),
     CAMERA_DIRECTOR_MODE_BACKUP = 6     UMETA(DisplayName = "Backup"),
-    CAMERA_DIRECTOR_MODE_NODISPLAY = 7      UMETA(DisplayName = "No Display")
+    CAMERA_DIRECTOR_MODE_NODISPLAY = 7      UMETA(DisplayName = "No Display"),
+	CAMERA_DIRECTOR_MODE_FRONT = 8	UMETA(DisplayName = "Front")
 };
 
 UCLASS()
@@ -40,6 +41,7 @@ public:
     void inputEventSpringArmChaseView();
     void inputEventBackupView();
     void inputEventNoDisplayView();
+	void inputEventFrontView();
 
 public:
     ACameraDirector();
@@ -81,6 +83,7 @@ private:
     APIPCamera* fpv_camera_;
     APIPCamera* backup_camera_;
     APIPCamera* external_camera_;
+	APIPCamera* front_camera_;
     AActor* follow_actor_;
 
     USceneComponent* last_parent_ = nullptr;
@@ -96,4 +99,5 @@ private:
     bool camera_rotation_lag_enabled_;
     int fpv_camera_index_;
     int backup_camera_index_ = 4;
+	int front_camera_index_ = 0;
 };


### PR DESCRIPTION
Added front camera view option. You can switch to the center-front camera with 'I', useful for cars if you wish to see the scene without the windshield.

settings.json support also added.

Relevant issue: #925 
