### PR TITLE
Update build_windows.md

### DIFF
--- a/docs/build_windows.md
+++ b/docs/build_windows.md
@@ -36,7 +36,7 @@ Known working config is:
 ````
 Windows 10 (Education) x64
 VS2015 update 3 (x86) with VC++
-Cmake 3.7 (x86)
+Cmake 3.9 (x86)
 ````
 Even though cmake 3.7 says it added support for VS 2017 folks are reporting build issues with that.
 


### PR DESCRIPTION
Run AirSim build.cmd, says:
Newer AirSim requires cmake verion "   3.   9" but you have "   3.   7" which is older.