### PR TITLE
Allow user to specify timeout for Python clients

### DIFF
--- a/PythonClient/AirSimClient.py
+++ b/PythonClient/AirSimClient.py
@@ -211,8 +211,8 @@ class CameraInfo(MsgpackMixin):
     fov = -1
 
 class AirSimClientBase:
-    def __init__(self, ip, port):
-        self.client = msgpackrpc.Client(msgpackrpc.Address(ip, port), timeout = 3600, pack_encoding = 'utf-8', unpack_encoding = 'utf-8')
+    def __init__(self, ip, port, timeout_value = 3600):
+        self.client = msgpackrpc.Client(msgpackrpc.Address(ip, port), timeout = timeout_value, pack_encoding = 'utf-8', unpack_encoding = 'utf-8')
         
     @staticmethod
     def stringToUint8Array(bstr):
@@ -509,10 +509,10 @@ class AirSimClientBase:
 
 # -----------------------------------  Multirotor APIs ---------------------------------------------
 class MultirotorClient(AirSimClientBase, object):
-    def __init__(self, ip = ""):
+    def __init__(self, ip = "", timeout = 3600):
         if (ip == ""):
             ip = "127.0.0.1"
-        super(MultirotorClient, self).__init__(ip, 41451)
+        super(MultirotorClient, self).__init__(ip, 41451, timeout_value = timeout)
 
     def takeoff(self, max_wait_seconds = 15):
         return self.client.call('takeoff', max_wait_seconds)
@@ -604,10 +604,10 @@ class MultirotorClient(AirSimClientBase, object):
 
 # -----------------------------------  Car APIs ---------------------------------------------
 class CarClient(AirSimClientBase, object):
-    def __init__(self, ip = ""):
+    def __init__(self, ip = "", timeout = 3600):
         if (ip == ""):
             ip = "127.0.0.1"
-        super(CarClient, self).__init__(ip, 42451)
+        super(CarClient, self).__init__(ip, 42451, timeout_value = timeout)
 
     def setCarControls(self, controls):
         self.client.call('setCarControls', controls)


### PR DESCRIPTION
Currently the Python clients (`AirSimClientBase`, and therefore its children `MultirotorClient` and `CarClient`) set the timeout for their `msgpackrpc.Client`s to 3600 seconds (1 hour), and do not allow the user to specify an alternate timeout value. This PR adds an optional argument `timeout` to `MultirotorClient.__init__` and `CarClient.__init__` with a default value of 3600, such that the default behaviour remains unchanged but a user can choose to provide a different timeout value.