### PR TITLE
Removed python 3 function annotation

### DIFF
--- a/PythonClient/AirSimClient.py
+++ b/PythonClient/AirSimClient.py
@@ -528,7 +528,7 @@ class MultirotorClient(AirSimClientBase, object):
 
         
     # query vehicle state
-    def getMultirotorState(self) -> MultirotorState:
+    def getMultirotorState(self):
         return MultirotorState.from_msgpack(self.client.call('getMultirotorState'))
     def getPosition(self):
         return Vector3r.from_msgpack(self.client.call('getPosition'))

--- a/PythonClient/AirSimClient.py
+++ b/PythonClient/AirSimClient.py
@@ -530,6 +530,7 @@ class MultirotorClient(AirSimClientBase, object):
     # query vehicle state
     def getMultirotorState(self):
         return MultirotorState.from_msgpack(self.client.call('getMultirotorState'))
+    getMultirotorState.__annotations__ = {'return': MultirotorState}
     def getPosition(self):
         return Vector3r.from_msgpack(self.client.call('getPosition'))
     def getVelocity(self):


### PR DESCRIPTION
One line of AirSimClient.py contains a Python 3 function annotation, which doesn't seem to change any functionality. I've removed the annotation to restore compatibility with Python 2.

Created issue #1083.