### PR TITLE
Reduced header file includes in CarPawn

### DIFF
--- a/Unreal/Plugins/AirSim/Source/Car/CarPawn.cpp
+++ b/Unreal/Plugins/AirSim/Source/Car/CarPawn.cpp
@@ -1,18 +1,15 @@
 #include "CarPawn.h"
-#include "Engine/SkeletalMesh.h"
-#include "GameFramework/Controller.h"
+#include "UObject/ConstructorHelpers.h"
+#include "AirBlueprintLib.h"
+#include "CarWheelFront.h"
+#include "CarWheelRear.h"
+#include "WheeledVehicleMovementComponent4W.h"
+#include "VehiclePawnWrapper.h"
+#include "Components/SkeletalMeshComponent.h"
 #include "Components/TextRenderComponent.h"
 #include "Components/AudioComponent.h"
 #include "Sound/SoundCue.h"
-#include "WheeledVehicleMovementComponent4W.h"
-
-#include "CarWheelFront.h"
-#include "CarWheelRear.h"
-#include "AirBlueprintLib.h"
-#include "PIPCamera.h"
-#include <vector>
-#include "common/common_utils/Utils.hpp"
-#include "common/ClockFactory.hpp"
+#include "PhysicalMaterials/PhysicalMaterial.h"
 
 
 #define LOCTEXT_NAMESPACE "VehiclePawn"

--- a/Unreal/Plugins/AirSim/Source/Car/CarPawn.h
+++ b/Unreal/Plugins/AirSim/Source/Car/CarPawn.h
@@ -2,22 +2,10 @@
 
 #include "CoreMinimal.h"
 #include "WheeledVehicle.h"
-#include "physics/Kinematics.hpp"
 #include "CarPawnApi.h"
 #include "SimJoyStick/SimJoyStick.h"
-#include "UObject/ConstructorHelpers.h"
-#include "Components/SkeletalMeshComponent.h"
-#include "PhysicalMaterials/PhysicalMaterial.h"
-#include "common/AirSimSettings.hpp"
-#include "AirBlueprintLib.h"
 #include "CarPawn.generated.h"
 
-class UPhysicalMaterial;
-class UCameraComponent;
-class USpringArmComponent;
-class UTextRenderComponent;
-class UInputComponent;
-class UAudioComponent;
 
 UCLASS(config = Game)
 class ACarPawn : public AWheeledVehicle
@@ -38,27 +26,27 @@ class ACarPawn : public AWheeledVehicle
 
     /** Camera component for the In-Car view */
     UPROPERTY(Category = Camera, VisibleDefaultsOnly, BlueprintReadOnly, meta = (AllowPrivateAccess = "true"))
-    APIPCamera* InternalCamera1;
+    class APIPCamera* InternalCamera1;
     UPROPERTY(Category = Camera, VisibleDefaultsOnly, BlueprintReadOnly, meta = (AllowPrivateAccess = "true"))
-    APIPCamera* InternalCamera2;
+    class APIPCamera* InternalCamera2;
     UPROPERTY(Category = Camera, VisibleDefaultsOnly, BlueprintReadOnly, meta = (AllowPrivateAccess = "true"))
-    APIPCamera* InternalCamera3;
+    class APIPCamera* InternalCamera3;
     UPROPERTY(Category = Camera, VisibleDefaultsOnly, BlueprintReadOnly, meta = (AllowPrivateAccess = "true"))
-    APIPCamera* InternalCamera4;
+    class APIPCamera* InternalCamera4;
     UPROPERTY(Category = Camera, VisibleDefaultsOnly, BlueprintReadOnly, meta = (AllowPrivateAccess = "true"))
-    APIPCamera* InternalCamera5;
+    class APIPCamera* InternalCamera5;
 
     /** Text component for the In-Car speed */
     UPROPERTY(Category = Display, VisibleDefaultsOnly, BlueprintReadOnly, meta = (AllowPrivateAccess = "true"))
-    UTextRenderComponent* InCarSpeed;
+    class UTextRenderComponent* InCarSpeed;
 
     /** Text component for the In-Car gear */
     UPROPERTY(Category = Display, VisibleDefaultsOnly, BlueprintReadOnly, meta = (AllowPrivateAccess = "true"))
-    UTextRenderComponent* InCarGear;
+    class UTextRenderComponent* InCarGear;
 
     /** Audio component for the engine sound */
     UPROPERTY(Category = Display, VisibleDefaultsOnly, BlueprintReadOnly, meta = (AllowPrivateAccess = "true"))
-    UAudioComponent* EngineSoundComponent;
+    class UAudioComponent* EngineSoundComponent;
 
 public:
     ACarPawn();
@@ -85,7 +73,7 @@ public:
     virtual void Tick(float Delta) override;
     virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 
-    VehiclePawnWrapper* getVehiclePawnWrapper();
+    class VehiclePawnWrapper* getVehiclePawnWrapper();
     void initializeForBeginPlay(bool engine_sound);
 
     virtual void NotifyHit(class UPrimitiveComponent* MyComp, class AActor* Other, class UPrimitiveComponent* OtherComp, bool bSelfMoved, FVector HitLocation,
@@ -148,7 +136,7 @@ private:
     /* Are we on a 'slippery' surface */
     bool is_low_friction_;
     /** Slippery Material instance */
-    UPhysicalMaterial* slippery_mat_;
+    class UPhysicalMaterial* slippery_mat_;
     /** Non Slippery Material instance */
-    UPhysicalMaterial* non_slippery_mat_;
+    class UPhysicalMaterial* non_slippery_mat_;
 };


### PR DESCRIPTION
Reduced CarPawn.h header file includes, by moving the majority of includes to CarPawn.cpp. Made class forward declarations consistent, using format "class UClass* MyClass". Also removed redundant header includes in CarPawn.cpp.

This pull request is part of my initial #1038 Issue. I have identified other files which can benefit from header reduction, so I will continue work on this branch if pull request is accepted. 
