### PR TITLE
Reset pending_pose_status after setting pose for Mulitrotor

### DIFF
--- a/Unreal/Plugins/AirSim/Source/Multirotor/MultiRotorConnector.cpp
+++ b/Unreal/Plugins/AirSim/Source/Multirotor/MultiRotorConnector.cpp
@@ -157,8 +157,10 @@ void MultiRotorConnector::updateRenderedState(float dt)
         vehicle_.setPose(pose);
     }
 
-    if (pending_pose_status_ == PendingPoseStatus::RenderStatePending)
+    if (pending_pose_status_ == PendingPoseStatus::RenderStatePending) {
         vehicle_.setPose(pending_pose_);
+        pending_pose_status_ = PendingPoseStatus::NonePending;
+    }
         
     last_pose_ = vehicle_.getPose();
     


### PR DESCRIPTION
After calling set pose the pending_pose_status is never set to NonePending so vehicle_.setPose keeps being called. I am not sure if this is the way to correct it, but it seems to solve this #1113 at least.