### PR TITLE
Add missing  include for unused() function, Fixes #1201

### DIFF
--- a/Unreal/Plugins/AirSim/Source/SimJoyStick/SimJoyStick.h
+++ b/Unreal/Plugins/AirSim/Source/SimJoyStick/SimJoyStick.h
@@ -7,6 +7,8 @@
 #include <memory>
 #include <string>
 
+ #include "common/Common.hpp"
+
 class SimJoyStick
 {
 public:


### PR DESCRIPTION
Compiler complains about undefined function "unused()" without this include