### PR TITLE
Fix build.sh clang paths for Mac

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -49,8 +49,8 @@ else
     if [ "$(uname)" == "Darwin" ]; then
         CMAKE="$(greadlink -f cmake_build/bin/cmake)"
 
-        export CC=/usr/local/opt/llvm\@5.0/bin/clang
-        export CXX=/usr/local/opt/llvm\@5.0/bin/clang++
+        export CC=/usr/local/opt/llvm-5.0/bin/clang-5.0
+        export CXX=/usr/local/opt/llvm-5.0/bin/clang++-5.0
     else
         CMAKE="$(readlink -f cmake_build/bin/cmake)"
 


### PR DESCRIPTION
When running **build.sh** on Mac from a freshly cloned repo (7/6/18), I got the following error:
```
  Could not find compiler set in environment variable CC:

  /usr/local/opt/llvm@5.0/bin/clang.
```

In previous PR #1124, **setup.sh** was updated to fix the clang compiler paths to change from:
```
export C_COMPILER=/usr/local/opt/llvm\@5.09/bin/clang
export COMPILER=/usr/local/opt/llvm\@5.0/bin/clang++
```
to:
```
export C_COMPILER=/usr/local/opt/llvm-5.0/bin/clang-5.0
export COMPILER=/usr/local/opt/llvm-5.0/bin/clang++-5.0
```

Applying the same clang paths to **build.sh** fixes the issue and then I could successfully build.

My environment (for reference):
- macOS High Sierra 10.13.5
- Xcode 9.4.1
- Clang 5.0.1 (installed by setup.sh)
- UE Editor 4.18.3 (installed from Mac Epic Games Launcher)
