### PR TITLE
Link against correct dependencies when packaging on Linux

### DIFF
--- a/Unreal/Plugins/AirSim/Source/AirSim.Build.cs
+++ b/Unreal/Plugins/AirSim/Source/AirSim.Build.cs
@@ -101,6 +101,13 @@ public class AirSim : ModuleRules
             PublicAdditionalLibraries.Add("dinput8.lib");
             PublicAdditionalLibraries.Add("dxguid.lib");
         }
+
+		if (Target.Platform == UnrealTargetPlatform.Linux)
+		{
+			// needed when packaging
+			PublicAdditionalLibraries.Add("stdc++");
+			PublicAdditionalLibraries.Add("supc++");
+		}
     }
 
     static void CopyFileIfNewer(string srcFilePath, string destFolder)


### PR DESCRIPTION
This solved #601 for me; it appears this fix has essentially the same effect as modifying the Unreal Build Tool, but is likely preferable for two reasons:

1. It only applies to this plugin and doesn't have any effect on anything else that gets packaged.
3. It won't have any effect if you're building for Windows, so it should be ok to merge this without fear of breaking anyone else's builds.

@mitchellspryn @AloshkaD would you be able to test if this fix works for you? I'm developing on Linux, so I haven't been able to test if it causes any issues when developing on Windows, or works when packaging for Linux from Windows.