### PR TITLE
add AIRSIM_API macro to NedTransform class

### DIFF
--- a/Unreal/Plugins/AirSim/Source/NedTransform.h
+++ b/Unreal/Plugins/AirSim/Source/NedTransform.h
@@ -18,7 +18,7 @@
     Vehicles are spawned at position specified in settings in global NED
 */
 
-class NedTransform
+class AIRSIM_API NedTransform
 {
 public:
     typedef msr::airlib::Vector3r Vector3r;


### PR DESCRIPTION
Class NedTransform is public accessible via ASimModeBase::getGlobalNedTransform(), which is exposed by AIRSIM_API. Therefore, this class should be also exposed to external code.