### PR TITLE
Fixes issue #1279

### DIFF
--- a/AirLib/include/common/VectorMath.hpp
+++ b/AirLib/include/common/VectorMath.hpp
@@ -502,7 +502,7 @@ public:
 
         RealT dot = VectorMathT::front().dot(toVector);
         dot = Utils::clip<RealT>(dot, -1, 1);
-        RealT ang = std::acosf(dot);
+        RealT ang = acosf(dot);
 
         Vector3T axis = VectorMathT::front().cross(toVector);
         if (axis == Vector3T::Zero())


### PR DESCRIPTION
This fixes an issue I ran into when compiling the Airsim libraries with g++-6. It seems acosf was not being included in the std name-space unless I compiled with Clang and its headers. I was also able to resolve this by including `<cmath>` to `VectorMath.hpp`, but I opted for this solution as math.h's ascof is already available in the global name-space.