### PR TITLE
Fixes client's simGetCollision call to match server base

### DIFF
--- a/AirLib/src/api/RpcLibClientBase.cpp
+++ b/AirLib/src/api/RpcLibClientBase.cpp
@@ -170,7 +170,7 @@ int RpcLibClientBase::simGetSegmentationObjectID(const std::string& mesh_name) c
 
 CollisionInfo RpcLibClientBase::simGetCollisionInfo(const std::string& vehicle_name) const
 {
-    return pimpl_->client.call("getCollisionInfo", vehicle_name).as<RpcLibAdapatorsBase::CollisionInfo>().to();
+    return pimpl_->client.call("simGetCollisionInfo", vehicle_name).as<RpcLibAdapatorsBase::CollisionInfo>().to();
 }
 
 


### PR DESCRIPTION
Fixes this error when calling `someVechicleClient.simGetCollisionInfo()` with the cpp apis
```
rpclib: server could not find function 'getCollisionInfo' with argument count 1.
```
This pr makes the binding match the server:
```
pimpl_->server.bind("simGetCollisionInfo", [&](const std::string& vehicle_name) -> RpcLibAdapatorsBase::CollisionInfo {
        const auto& collision_info = getVehicleSimApi(vehicle_name)->getCollisionInfo(); 
        return RpcLibAdapatorsBase::CollisionInfo(collision_info);
});
```
Hope this is helpful