### PR TITLE
Exception setting now required on Linux

### DIFF
--- a/Unreal/Plugins/AirSim/Source/AirSim.Build.cs
+++ b/Unreal/Plugins/AirSim/Source/AirSim.Build.cs
@@ -74,9 +74,7 @@ public class AirSim : ModuleRules
         //bEnforceIWYU = true; //to support 4.16
         PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 
-        //for some reason this is required on Windows but not on Linux
-        if (Target.Platform == UnrealTargetPlatform.Win64)
-            bEnableExceptions = true;
+        bEnableExceptions = true;
 
         PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "ImageWrapper", "RenderCore", "RHI", "PhysXVehicles", "PhysXVehicleLib", "PhysX", "APEX", "Landscape" });
         PrivateDependencyModuleNames.AddRange(new string[] { "UMG", "Slate", "SlateCore" });


### PR DESCRIPTION
The `bEnableExceptions = true;` line in the `Build.cs` file that was previously only included if compiled on Windows is now also required on Linux in order to successfully package an application with this plugin. Without this line, packaging errors out with many instances of `error: cannot use 'throw' with exceptions disabled`.