### PR TITLE
ArduCopterSolo support

### DIFF
--- a/AirLib/AirLib.vcxproj
+++ b/AirLib/AirLib.vcxproj
@@ -86,6 +86,8 @@
     <ClInclude Include="include\vehicles\multirotor\api\MultirotorRpcLibAdapators.hpp" />
     <ClInclude Include="include\vehicles\multirotor\api\MultirotorRpcLibClient.hpp" />
     <ClInclude Include="include\vehicles\multirotor\api\MultirotorRpcLibServer.hpp" />
+    <ClInclude Include="include\vehicles\multirotor\firmwares\mavlink\ArduCopterSoloApi.hpp" />
+    <ClInclude Include="include\vehicles\multirotor\firmwares\mavlink\ArduCopterSoloParams.hpp" />
     <ClInclude Include="include\vehicles\multirotor\firmwares\simple_flight\AirSimSimpleFlightBoard.hpp" />
     <ClInclude Include="include\vehicles\multirotor\firmwares\simple_flight\AirSimSimpleFlightCommLink.hpp" />
     <ClInclude Include="include\vehicles\multirotor\firmwares\simple_flight\AirSimSimpleFlightEstimator.hpp" />
@@ -170,6 +172,7 @@
   <ItemGroup>
     <ClCompile Include="src\api\RpcLibClientBase.cpp" />
     <ClCompile Include="src\api\RpcLibServerBase.cpp" />
+    <ClCompile Include="src\vehicles\multirotor\MultiRotorParamsFactory.cpp" />
     <ClCompile Include="src\vehicles\multirotor\api\MultirotorApiBase.cpp" />
     <ClCompile Include="src\safety\ObstacleMap.cpp" />
     <ClCompile Include="src\safety\SafetyEval.cpp" />

--- a/AirLib/AirLib.vcxproj.filters
+++ b/AirLib/AirLib.vcxproj.filters
@@ -447,6 +447,12 @@
     <ClInclude Include="include\common\common_utils\ColorUtils.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\vehicles\multirotor\firmwares\mavlink\ArduCopterSoloApi.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\vehicles\multirotor\firmwares\mavlink\ArduCopterSoloParams.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\safety\ObstacleMap.cpp">
@@ -477,6 +483,12 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\vehicles\multirotor\api\MultirotorApiBase.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\vehicles\multirotor\MultiRotorParamsFactory.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\vehicles\MultiRotorParamsFactory.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/AirLib/include/common/AirSimSettings.hpp
+++ b/AirLib/include/common/AirSimSettings.hpp
@@ -23,7 +23,8 @@ private:
 public: //types
     static constexpr int kSubwindowCount = 3; //must be >= 3 for now
     static constexpr char const * kVehicleTypePX4 = "px4multirotor";
-    static constexpr char const * kVehicleTypeSimpleFlight = "simpleflight";
+	static constexpr char const * kVehicleTypeArduCopterSolo = "arducoptersolo";
+	static constexpr char const * kVehicleTypeSimpleFlight = "simpleflight";
     static constexpr char const * kVehicleTypePhysXCar = "physxcar";
     static constexpr char const * kVehicleTypeComputerVision = "computervision";
 
@@ -242,13 +243,9 @@ public: //types
         std::string model = "Generic";
     };
 
-    struct PX4VehicleSetting : public VehicleSetting {
-        MavLinkConnectionInfo connection_info;
-    };
-
-    struct SimpleFlightVehicleSetting : public VehicleSetting {
-        MavLinkConnectionInfo connection_info;
-    };
+	struct MavLinkVehicleSetting : public VehicleSetting {
+		MavLinkConnectionInfo connection_info;
+	};
 
     struct SegmentationSetting {
         enum class InitMethodType {
@@ -570,11 +567,11 @@ private:
         }
     }
 
-    static std::unique_ptr<VehicleSetting> createPX4VehicleSetting(const Settings& settings_json) 
+    static std::unique_ptr<VehicleSetting> createMavLinkVehicleSetting(const Settings& settings_json) 
     {
         //these settings_json are expected in same section, not in another child
-        std::unique_ptr<VehicleSetting> vehicle_setting_p = std::unique_ptr<VehicleSetting>(new PX4VehicleSetting());
-        PX4VehicleSetting* vehicle_setting = static_cast<PX4VehicleSetting*>(vehicle_setting_p.get());
+        std::unique_ptr<VehicleSetting> vehicle_setting_p = std::unique_ptr<VehicleSetting>(new MavLinkVehicleSetting());
+		MavLinkVehicleSetting* vehicle_setting = static_cast<MavLinkVehicleSetting*>(vehicle_setting_p.get());
 
         //TODO: we should be selecting remote if available else keyboard
         //currently keyboard is not supported so use rc as default
@@ -632,8 +629,8 @@ private:
         auto vehicle_type = Utils::toLower(settings_json.getString("VehicleType", ""));
 
         std::unique_ptr<VehicleSetting> vehicle_setting;
-        if (vehicle_type == kVehicleTypePX4)
-            vehicle_setting = createPX4VehicleSetting(settings_json);
+        if (vehicle_type == kVehicleTypePX4 || vehicle_type == kVehicleTypeArduCopterSolo)
+            vehicle_setting = createMavLinkVehicleSetting(settings_json);
         //for everything else we don't need derived class yet
         else {
             vehicle_setting = std::unique_ptr<VehicleSetting>(new VehicleSetting());

--- a/AirLib/include/common/CommonStructs.hpp
+++ b/AirLib/include/common/CommonStructs.hpp
@@ -166,7 +166,7 @@ struct GeoPoint {
         return os << "[" << g.latitude << ", " << g.longitude << ", " << g.altitude << "]";
     }
 
-    std::string to_string()
+    std::string to_string() const
     {
         return std::to_string(latitude) + string(", ") + std::to_string(longitude) + string(", ") + std::to_string(altitude);
     }

--- a/AirLib/include/physics/FastPhysicsEngine.hpp
+++ b/AirLib/include/physics/FastPhysicsEngine.hpp
@@ -100,7 +100,15 @@ private:
         body.setKinematics(next);
         body.setWrench(next_wrench);
         body.kinematicsUpdated();
-    }
+
+
+		////// (FIXME this is from PhysicsBody, where it's commented out - it appears that we need it here to ensure that GPS sensing functions properly)
+		//TODO: this is now being done in PawnSimApi::update. We need to re-think this sequence
+		body.getEnvironment().setPosition(next.pose.position);
+		body.getEnvironment().update();
+		////// (End FIXME)
+		
+	}
 
     static void updateCollisionResponseInfo(const CollisionInfo& collision_info, const Kinematics::State& next, 
         bool is_collision_response, CollisionResponse& collision_response)

--- a/AirLib/include/vehicles/multirotor/MultiRotorParamsFactory.hpp
+++ b/AirLib/include/vehicles/multirotor/MultiRotorParamsFactory.hpp
@@ -4,35 +4,26 @@
 #ifndef msr_airlib_vehicles_MultiRotorParamsFactory_hpp
 #define msr_airlib_vehicles_MultiRotorParamsFactory_hpp
 
-#include "vehicles/multirotor/firmwares/mavlink/MavLinkMultirotorApi.hpp"
-#include "vehicles/multirotor/firmwares/mavlink/Px4MultiRotorParams.hpp"
-#include "vehicles/multirotor/firmwares/simple_flight/SimpleFlightQuadXParams.hpp"
+#include "vehicles/multirotor/MultiRotorParams.hpp"
+#include "common/AirSimSettings.hpp"
+#include "sensors/SensorFactory.hpp"
 
 
 namespace msr { namespace airlib {
 
 class MultiRotorParamsFactory {
 public:
-    static std::unique_ptr<MultiRotorParams> createConfig(const AirSimSettings::VehicleSetting* vehicle_setting, 
-        std::shared_ptr<const SensorFactory> sensor_factory)
-    {
-        std::unique_ptr<MultiRotorParams> config;
 
-        if (vehicle_setting->vehicle_type == AirSimSettings::kVehicleTypePX4) {
-            config.reset(new Px4MultiRotorParams(* static_cast<const AirSimSettings::PX4VehicleSetting*>(vehicle_setting),
-                sensor_factory));
-        } else if (vehicle_setting->vehicle_type == "" || //default config
-            vehicle_setting->vehicle_type == AirSimSettings::kVehicleTypeSimpleFlight) {
-            config.reset(new SimpleFlightQuadXParams(vehicle_setting, sensor_factory));
-        } else
-            throw std::runtime_error(Utils::stringf(
-                "Cannot create vehicle config because vehicle name '%s' is not recognized", 
-                vehicle_setting->vehicle_name.c_str()));
+	static void reset();
 
-        config->initialize();
+	static std::unique_ptr<MultiRotorParams> createConfig(const AirSimSettings::VehicleSetting* vehicle_setting,
+		std::shared_ptr<const SensorFactory> sensor_factory);
 
-        return config;
-    }
+private:
+
+	// Simple zero-based ID for ArduCopterSolo vehicles
+	static int next_solo_id_;
+
 };
 
 }} //namespace

--- a/AirLib/include/vehicles/multirotor/firmwares/mavlink/ArduCopterSoloApi.hpp
+++ b/AirLib/include/vehicles/multirotor/firmwares/mavlink/ArduCopterSoloApi.hpp
@@ -1,0 +1,221 @@
+#ifndef msr_airlib_ArduCopterSoloApi_h
+#define msr_airlib_ArduCopterSoloApi_h
+
+#include "AdHocConnection.hpp"
+#include "vehicles/multirotor/MultiRotor.hpp"
+#include "vehicles/multirotor/firmwares/mavlink/MavLinkMultirotorApi.hpp"
+
+namespace msr { namespace airlib {
+
+
+class ArduCopterSoloApi : public MavLinkMultirotorApi
+{
+public:
+	virtual ~ArduCopterSoloApi()
+	{
+		closeAllConnection();
+	}
+
+	virtual void update()
+	{
+		if (sensors_ == nullptr)
+			return;
+
+		// send GPS and other sensor updates
+		const auto gps = getGps();
+		if (gps != nullptr) {
+			const auto& gps_output = gps->getOutput();
+			const auto& imu_output = getImu()->getOutput();
+			//                    const auto& mag_output = getMagnetometer()->getOutput();
+			//                    const auto& baro_output = getBarometer()->getOutput();
+
+			SensorMessage packet;
+			packet.timestamp = Utils::getTimeSinceEpochNanos() / 1000;
+			packet.latitude = gps_output.gnss.geo_point.latitude;
+			packet.longitude = gps_output.gnss.geo_point.longitude;
+			packet.altitude = gps_output.gnss.geo_point.altitude;
+
+			common_utils::Utils::log("Current LLA: " + gps_output.gnss.geo_point.to_string(), common_utils::Utils::kLogLevelInfo);
+
+			packet.speedN = gps_output.gnss.velocity[0];
+			packet.speedE = gps_output.gnss.velocity[1];
+			packet.speedD = gps_output.gnss.velocity[2];
+
+			packet.xAccel = imu_output.linear_acceleration[0];
+			packet.yAccel = imu_output.linear_acceleration[1];
+			packet.zAccel = imu_output.linear_acceleration[2];
+
+			float yaw;
+			float pitch;
+			float roll;
+			VectorMath::toEulerianAngle(imu_output.orientation, pitch, roll, yaw);
+			packet.yawDeg = yaw * 180.0 / M_PI;
+			packet.pitchDeg = pitch * 180.0 / M_PI;
+			packet.rollDeg = roll * 180.0 / M_PI;
+
+			Vector3r bodyRPY(roll, pitch, yaw);
+
+			// In the Unreal world, yaw is rotation around Z, so this seems to be RPY, like PySim
+			Vector3r bodyVelocityRPY(imu_output.angular_velocity[0], imu_output.angular_velocity[1], imu_output.angular_velocity[2]);
+			Vector3r earthRPY = bodyAnglesToEarthAngles(bodyRPY, bodyVelocityRPY);
+
+			packet.rollRate = earthRPY[0] * 180.0 / M_PI;
+			packet.pitchRate = earthRPY[1] * 180.0 / M_PI;
+			packet.yawRate = earthRPY[2] * 180.0 / M_PI;
+
+			// Heading appears to be unused by AruPilot.  But use yaw for now
+			packet.heading = yaw;
+
+			packet.airspeed = std::sqrt(
+				packet.speedN * packet.speedN
+				+ packet.speedE * packet.speedE
+				+ packet.speedD * packet.speedD);
+
+			packet.magic = 0x4c56414f;
+
+			if (udpSocket_ != nullptr)
+			{
+				std::vector<uint8_t> msg(sizeof(packet));
+				memcpy(msg.data(), &packet, sizeof(packet));
+				udpSocket_->sendMessage(msg);
+			}
+		}
+	}
+
+	virtual void close()
+	{
+		MavLinkMultirotorApi::close();
+
+		if (udpSocket_ != nullptr) {
+			udpSocket_->close();
+			udpSocket_->unsubscribe(rotorSubscriptionId_);
+			udpSocket_ = nullptr;
+		}
+	}
+
+protected:
+	virtual void connect()
+	{
+		if (!is_simulation_mode_) {
+
+			MavLinkMultirotorApi::connect();
+		}
+		else {
+			const std::string& ip = connection_info_.ip_address;
+			int port = connection_info_.ip_port;
+
+			close();
+
+			if (ip == "") {
+				throw std::invalid_argument("UdpIp setting is invalid.");
+			}
+
+			if (port == 0) {
+				throw std::invalid_argument("UdpPort setting has an invalid value.");
+			}
+
+			Utils::log(Utils::stringf("Using UDP port %d, local IP %s, remote IP %s for sending sensor data", port, connection_info_.local_host_ip.c_str(), ip.c_str()), Utils::kLogLevelInfo);
+			Utils::log(Utils::stringf("Using UDP port %d for receiving rotor power", connection_info_.sitl_ip_port, connection_info_.local_host_ip.c_str(), ip.c_str()), Utils::kLogLevelInfo);
+
+			udpSocket_ = mavlinkcom::AdHocConnection::connectLocalUdp("ArduCopterSoloConnector", ip, connection_info_.sitl_ip_port);
+			mavlinkcom::AdHocMessageHandler handler = [this](std::shared_ptr<mavlinkcom::AdHocConnection> connection, const std::vector<uint8_t> &msg) {
+				this->rotorPowerMessageHandler(connection, msg);
+			};
+
+			rotorSubscriptionId_ = udpSocket_->subscribe(handler);
+		}
+}
+
+private:
+#ifdef __linux__
+	struct __attribute__((__packed__)) SensorMessage {
+#else
+#pragma pack(push,1)
+	struct SensorMessage {
+#endif
+		// this is the packet sent by the simulator
+		// to the APM executable to update the simulator state
+		// All values are little-endian
+		uint64_t timestamp;
+		double latitude, longitude; // degrees
+		double altitude;  // MSL
+		double heading;   // degrees
+		double speedN, speedE, speedD; // m/s
+		double xAccel, yAccel, zAccel;       // m/s/s in body frame
+		double rollRate, pitchRate, yawRate; // degrees/s/s in earth frame
+		double rollDeg, pitchDeg, yawDeg;    // euler angles, degrees
+		double airspeed; // m/s
+		uint32_t magic; // 0x4c56414f
+	};
+#ifndef __linux__
+#pragma pack(pop)
+#endif
+
+	static const int kArduCopterRotorControlCount = 11;
+
+	struct RotorControlMessage {
+		// ArduPilot Solo rotor control datagram format
+		uint16_t pwm[kArduCopterRotorControlCount];
+		uint16_t speed, direction, turbulance;
+	};
+
+	std::shared_ptr<mavlinkcom::AdHocConnection> udpSocket_;
+	int rotorSubscriptionId_;
+
+	virtual void normalizeRotorControls()
+	{
+		// change 1000-2000 to 0-1.
+		for (size_t i = 0; i < Utils::length(rotor_controls_); ++i) {
+			rotor_controls_[i] = (rotor_controls_[i] - 1000.0f) / 1000.0f;
+		}
+	}
+
+	void rotorPowerMessageHandler(std::shared_ptr<mavlinkcom::AdHocConnection> connection, const std::vector<uint8_t> &msg)
+	{
+		if (msg.size() != sizeof(RotorControlMessage))
+		{
+			Utils::log("Got rotor control message of size " + std::to_string(msg.size()) + " when we were expecting size " + std::to_string(sizeof(RotorControlMessage)), Utils::kLogLevelError);
+			return;
+		}
+
+		RotorControlMessage rotorControlMessage;
+		memcpy(&rotorControlMessage, msg.data(), sizeof(RotorControlMessage));
+
+		std::lock_guard<std::mutex> guard_actuator(hil_controls_mutex_);    //use same mutex as HIL_CONTROl
+
+		for (auto i = 0; i < RotorControlsCount && i < kArduCopterRotorControlCount; ++i) {
+			rotor_controls_[i] = rotorControlMessage.pwm[i];
+		}
+
+		normalizeRotorControls();
+	}
+
+	Vector3r bodyAnglesToEarthAngles(Vector3r bodyRPY, Vector3r bodyVelocityRPY)
+	{
+		float p = bodyVelocityRPY[0];
+		float q = bodyVelocityRPY[1];
+		float r = bodyVelocityRPY[2];
+
+		// Roll, pitch, yaw
+		float phi = bodyRPY[0];
+		float theta = bodyRPY[1];
+
+		float phiDot = p + tan(theta)*(q*sin(phi) + r * cos(phi));
+
+		float thetaDot = q * cos(phi) - r * sin(phi);
+		if (fabs(cos(theta)) < 1.0e-20)
+		{
+			theta += 1.0e-10f;
+		}
+
+		float psiDot = (q*sin(phi) + r * cos(phi)) / cos(theta);
+
+		return Vector3r(phiDot, thetaDot, psiDot);
+	}
+
+};
+
+}
+} //namespace
+
+#endif

--- a/AirLib/include/vehicles/multirotor/firmwares/mavlink/ArduCopterSoloParams.hpp
+++ b/AirLib/include/vehicles/multirotor/firmwares/mavlink/ArduCopterSoloParams.hpp
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef msr_airlib_vehicles_ArduCopterSolo_hpp
+#define msr_airlib_vehicles_ArduCopterSolo_hpp
+
+#include "vehicles/multirotor/firmwares/mavlink/ArduCopterSoloApi.hpp"
+
+namespace msr { namespace airlib {
+
+
+		class ArduCopterSoloParams : public MultiRotorParams {
+
+		public:
+			ArduCopterSoloParams(const AirSimSettings::MavLinkVehicleSetting& vehicle_settings, std::shared_ptr<const SensorFactory> sensor_factory, int instance_id)
+				: sensor_factory_(sensor_factory)
+			{
+				connection_info_ = getConnectionInfo(vehicle_settings, instance_id);
+			}
+
+			virtual ~ArduCopterSoloParams() = default;
+
+			virtual std::unique_ptr<MultirotorApiBase> createMultirotorApi() override
+			{
+				unique_ptr<MultirotorApiBase> api(new ArduCopterSoloApi());
+				auto api_ptr = static_cast<ArduCopterSoloApi*>(api.get());
+				api_ptr->initialize(connection_info_, &getSensors(), true);
+
+				return api;
+			}
+
+			virtual void setupParams() override
+			{
+				// TODO consider whether we want to make us of the 'connection_info_.model' field (perhaps to indicate different sensor configs, say?  not sure...)
+
+				auto& params = getParams();
+
+				setupSolo(params);
+			}
+
+		private:
+			void setupSolo(Params& params)
+			{
+				//set up arm lengths
+				//dimensions are for F450 frame: http://artofcircuits.com/product/quadcopter-frame-hj450-with-power-distribution
+				params.rotor_count = 4;
+
+				// This is in meters (3DR spec indicates that motor-to-motor is 18.1 inches, so we're just dividing that by 2, which looks about right in real life)
+				std::vector<real_T> arm_lengths(params.rotor_count, 0.22987f);
+
+				// Takeoff mass, in kilograms (this is from the 3DR spec with no camera)
+				//params.mass = 1.5f; 
+				// And this is what works currently - TODO sort out why ArduPilot isn't providing sufficient rotor power for default Solo weight - presumably some param setting?
+				params.mass = 0.8f;
+
+				// Mass in kg - can't find a 3DR spec on this, so we'll guess they're the same 55g as the DJI F450's motors
+				real_T motor_assembly_weight = 0.055f;
+				real_T box_mass = params.mass - params.rotor_count * motor_assembly_weight;
+
+				// using rotor_param default, but if you want to change any of the rotor_params, call calculateMaxThrust() to recompute the max_thrust
+				// given new thrust coefficients, motor max_rpm and propeller diameter.
+				params.rotor_params.calculateMaxThrust();
+
+				// Dimensions of core body box or abdomen, in meters (not including arms).  KM measures the Solo at 9.5" x 4.5" x 3"
+				params.body_box.x() = 0.2413f; params.body_box.y() = 0.1143f; params.body_box.z() = 0.0762f;
+
+				// Meters up from center of box mass - KM measures at about 3"
+				real_T rotor_z = 0.0762f;
+
+				//computer rotor poses
+				initializeRotorQuadX(params.rotor_poses, params.rotor_count, arm_lengths.data(), rotor_z);
+
+				//compute inertia matrix
+				computeInertiaMatrix(params.inertia, params.body_box, params.rotor_poses, box_mass, motor_assembly_weight);
+			}
+
+			static const AirSimSettings::MavLinkConnectionInfo getConnectionInfo(const AirSimSettings::MavLinkVehicleSetting& vehicle_setting, int instance_id)
+			{
+				AirSimSettings::MavLinkConnectionInfo result = vehicle_setting.connection_info;
+
+				result.sitl_ip_port += 10 * instance_id;
+				result.ip_port += 10 * instance_id;
+
+				return result;
+			}
+
+		protected:
+			virtual std::unique_ptr<SensorBase> createSensor(SensorBase::SensorType sensor_type) override
+			{
+				return sensor_factory_->createSensor(sensor_type);
+			}
+
+		private:
+			AirSimSettings::MavLinkConnectionInfo connection_info_;
+			std::shared_ptr<const SensorFactory> sensor_factory_;
+		};
+
+	}
+} //namespace
+#endif

--- a/AirLib/include/vehicles/multirotor/firmwares/mavlink/Px4MultiRotorParams.hpp
+++ b/AirLib/include/vehicles/multirotor/firmwares/mavlink/Px4MultiRotorParams.hpp
@@ -13,7 +13,7 @@ namespace msr { namespace airlib {
 
 class Px4MultiRotorParams : public MultiRotorParams {
 public:
-    Px4MultiRotorParams(const AirSimSettings::PX4VehicleSetting& vehicle_setting, std::shared_ptr<const SensorFactory> sensor_factory)
+    Px4MultiRotorParams(const AirSimSettings::MavLinkVehicleSetting& vehicle_setting, std::shared_ptr<const SensorFactory> sensor_factory)
         : sensor_factory_(sensor_factory)
     {
         connection_info_ = getConnectionInfo(vehicle_setting);
@@ -243,7 +243,7 @@ private:
     }
 
 
-    static const AirSimSettings::MavLinkConnectionInfo& getConnectionInfo(const AirSimSettings::PX4VehicleSetting& vehicle_setting)
+    static const AirSimSettings::MavLinkConnectionInfo& getConnectionInfo(const AirSimSettings::MavLinkVehicleSetting& vehicle_setting)
     {
         return vehicle_setting.connection_info;
     }

--- a/AirLib/src/vehicles/multirotor/MultiRotorParamsFactory.cpp
+++ b/AirLib/src/vehicles/multirotor/MultiRotorParamsFactory.cpp
@@ -1,0 +1,47 @@
+//in header only mode, control library is not available
+#ifndef AIRLIB_HEADER_ONLY
+
+#include "vehicles/multirotor/MultiRotorParamsFactory.hpp"
+#include "vehicles/multirotor/firmwares/mavlink/ArduCopterSoloParams.hpp"
+#include "vehicles/multirotor/firmwares/mavlink/Px4MultiRotorParams.hpp"
+#include "vehicles/multirotor/firmwares/simple_flight/SimpleFlightQuadXParams.hpp"
+
+namespace msr { namespace airlib {
+
+		int MultiRotorParamsFactory::next_solo_id_ = 0;
+
+		void MultiRotorParamsFactory::reset()
+		{
+			next_solo_id_ = 0;
+		}
+
+		std::unique_ptr<MultiRotorParams> MultiRotorParamsFactory::createConfig(const AirSimSettings::VehicleSetting* vehicle_setting,
+			std::shared_ptr<const SensorFactory> sensor_factory)
+		{
+			std::unique_ptr<MultiRotorParams> config;
+
+			if (vehicle_setting->vehicle_type == AirSimSettings::kVehicleTypePX4) {
+				config.reset(new Px4MultiRotorParams(*static_cast<const AirSimSettings::MavLinkVehicleSetting*>(vehicle_setting),
+					sensor_factory));
+			}
+			else if (vehicle_setting->vehicle_type == AirSimSettings::kVehicleTypeArduCopterSolo) {
+				config.reset(new ArduCopterSoloParams(*static_cast<const AirSimSettings::MavLinkVehicleSetting*>(vehicle_setting), sensor_factory, next_solo_id_));
+				next_solo_id_++;
+			}
+			else if (vehicle_setting->vehicle_type == "" || //default config
+				vehicle_setting->vehicle_type == AirSimSettings::kVehicleTypeSimpleFlight) {
+				config.reset(new SimpleFlightQuadXParams(vehicle_setting, sensor_factory));
+			}
+			else
+				throw std::runtime_error(Utils::stringf(
+					"Cannot create vehicle config because vehicle name '%s' is not recognized",
+					vehicle_setting->vehicle_name.c_str()));
+
+			config->initialize();
+
+			return config;
+		}
+	}
+}
+
+#endif  /* AIRLIB_HEADER_ONLY */

--- a/MavLinkCom/MavLinkCom.vcxproj
+++ b/MavLinkCom/MavLinkCom.vcxproj
@@ -345,6 +345,8 @@
   <ItemGroup>
     <ClCompile Include="common_utils\FileSystem.cpp" />
     <ClCompile Include="common_utils\ThreadUtils.cpp" />
+    <ClCompile Include="src\AdHocConnection.cpp" />
+    <ClCompile Include="src\impl\AdHocConnectionImpl.cpp" />
     <ClCompile Include="src\impl\MavLinkFtpClientImpl.cpp" />
     <ClCompile Include="src\impl\MavLinkNodeImpl.cpp" />
     <ClCompile Include="src\impl\MavLinkTcpServerImpl.cpp" />
@@ -374,6 +376,7 @@
     <ClInclude Include="common_utils\json.hpp" />
     <ClInclude Include="common_utils\StrictMode.hpp" />
     <ClInclude Include="common_utils\ThreadUtils.hpp" />
+    <ClInclude Include="include\AdHocConnection.hpp" />
     <ClInclude Include="include\AsyncResult.hpp" />
     <ClInclude Include="common_utils\EnumFlags.hpp" />
     <ClInclude Include="common_utils\ExceptionUtils.hpp" />
@@ -384,6 +387,7 @@
     <ClInclude Include="common_utils\type_utils.hpp" />
     <ClInclude Include="common_utils\Utils.hpp" />
     <ClInclude Include="include\Semaphore.hpp" />
+    <ClInclude Include="src\impl\AdHocConnectionImpl.hpp" />
     <ClInclude Include="src\impl\MavLinkFtpClientImpl.hpp" />
     <ClInclude Include="src\impl\MavLinkNodeImpl.hpp" />
     <ClInclude Include="src\impl\MavLinkTcpServerImpl.hpp" />

--- a/MavLinkCom/MavLinkCom.vcxproj.filters
+++ b/MavLinkCom/MavLinkCom.vcxproj.filters
@@ -76,6 +76,8 @@
     <ClCompile Include="src\impl\windows\WindowsFindSerialPorts.cpp">
       <Filter>src\impl\windows</Filter>
     </ClCompile>
+    <ClCompile Include="src\impl\AdHocConnectionImpl.cpp" />
+    <ClCompile Include="src\AdHocConnection.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="mavlink\checksum.h">
@@ -213,6 +215,8 @@
     <ClInclude Include="src\impl\MavLinkFtpClientImpl.hpp">
       <Filter>src\impl</Filter>
     </ClInclude>
+    <ClInclude Include="include\AdHocConnection.hpp" />
+    <ClInclude Include="src\impl\AdHocConnectionImpl.hpp" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Mavlink">

--- a/MavLinkCom/include/AdHocConnection.hpp
+++ b/MavLinkCom/include/AdHocConnection.hpp
@@ -1,0 +1,81 @@
+#ifndef MavLinkCom_AdHocConnection_hpp
+#define MavLinkCom_AdHocConnection_hpp
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#ifndef ONECORE
+#if defined(_WIN32) && defined(_MSC_VER )
+#pragma comment( lib, "Setupapi.lib" )
+#pragma comment( lib, "Cfgmgr32.lib" )
+#endif
+#endif
+
+class Port;
+
+namespace mavlinkcom_impl {
+    class AdHocConnectionImpl;
+}
+
+namespace mavlinkcom {
+
+    class AdHocConnection;
+
+    // This callback is invoked when a MavLink message is read from the connection.
+    typedef std::function<void(std::shared_ptr<AdHocConnection> connection, const std::vector<uint8_t>& msg)> AdHocMessageHandler;
+
+    // This class represents a single connection to a remote non-mavlink node connected either over UDP, TCP or Serial port.
+    // You can use this connection to send a message directly to that node, and start listening to messages 
+    // from that remote node.  You can handle those messages directly using subscribe.
+    class AdHocConnection : public std::enable_shared_from_this<AdHocConnection>
+    {
+    public:
+        AdHocConnection();
+
+        // Start listening on a specific local port for packets from any remote computer.  Once a packet is received
+        // it will remember the remote address of the sender so that subsequend sendMessage calls will go back to that sender.
+        // This is useful if the remote sender already knows which local port you plan to listen on.
+        // The localAddr can also a specific local ip address if you need to specify which
+        // network interface to use, for example, a corporate wired ethernet usually does not transmit UDP packets
+        // to a wifi connected device, so in that case the localAddress needs to be the IP address of a specific wifi internet 
+        // adapter rather than 127.0.0.1.
+        static std::shared_ptr<AdHocConnection>  connectLocalUdp(const std::string& nodeName, std::string localAddr, int localPort);
+
+        // Connect to a specific remote machine that is already listening on a specific port for messages from any computer.
+        // This will use any free local port that is available.
+        // The localAddr can also a specific local ip address if you need to specify which
+        // network interface to use, for example, a corporate wired ethernet usually does not transmit UDP packets
+        // to a wifi connected device, so in that case the localAddress needs to be the IP address of a specific wifi internet 
+        // adapter rather than 127.0.0.1.
+        static std::shared_ptr<AdHocConnection>  connectRemoteUdp(const std::string& nodeName, std::string localAddr, std::string remoteAddr, int remotePort);
+
+        // instance methods
+        bool isOpen();
+        void close();
+
+        // provide a callback function that will be called for every message "received" from the remote mavlink node.
+        int subscribe(AdHocMessageHandler handler);
+        void unsubscribe(int id);
+
+        uint8_t getNextSequence();
+
+        // Pack and send the given message, assuming the compid and sysid have been set by the caller.
+        void sendMessage(const std::vector<uint8_t> &msg);
+
+    protected:
+        void startListening(const std::string& nodeName, std::shared_ptr<Port> connectedPort);
+
+    public:
+        //needed for piml pattern
+        ~AdHocConnection();
+        		
+    private:
+        std::unique_ptr<mavlinkcom_impl::AdHocConnectionImpl> pImpl;
+        friend class MavLinkNode;
+        friend class mavlinkcom_impl::AdHocConnectionImpl;
+    };
+}
+
+#endif

--- a/MavLinkCom/src/AdHocConnection.cpp
+++ b/MavLinkCom/src/AdHocConnection.cpp
@@ -1,0 +1,55 @@
+#include "AdHocConnection.hpp"
+#include "impl/AdHocConnectionImpl.hpp"
+
+using namespace mavlinkcom;
+using namespace mavlinkcom_impl;
+
+AdHocConnection::AdHocConnection()
+{
+    pImpl.reset(new AdHocConnectionImpl());
+}
+
+std::shared_ptr<AdHocConnection>  AdHocConnection::connectLocalUdp(const std::string& nodeName, std::string localAddr, int localPort)
+{
+    return AdHocConnectionImpl::connectLocalUdp(nodeName, localAddr, localPort);
+}
+
+std::shared_ptr<AdHocConnection>  AdHocConnection::connectRemoteUdp(const std::string& nodeName, std::string localAddr, std::string remoteAddr, int remotePort)
+{
+    return AdHocConnectionImpl::connectRemoteUdp(nodeName, localAddr, remoteAddr, remotePort);
+}
+
+void AdHocConnection::startListening(const std::string& nodeName, std::shared_ptr<Port> connectedPort)
+{
+    pImpl->startListening(shared_from_this(), nodeName, connectedPort);
+}
+
+void AdHocConnection::close()
+{
+    pImpl->close();
+}
+
+bool AdHocConnection::isOpen()
+{
+    return pImpl->isOpen();
+}
+
+void AdHocConnection::sendMessage(const std::vector<uint8_t> &msg)
+{
+    pImpl->sendMessage(msg);
+}
+
+int AdHocConnection::subscribe(AdHocMessageHandler handler)
+{
+    return pImpl->subscribe(handler);
+}
+
+void AdHocConnection::unsubscribe(int id)
+{
+    pImpl->unsubscribe(id);
+}
+
+AdHocConnection::~AdHocConnection() {
+    pImpl->close();
+    pImpl = nullptr;
+}

--- a/MavLinkCom/src/impl/AdHocConnectionImpl.cpp
+++ b/MavLinkCom/src/impl/AdHocConnectionImpl.cpp
@@ -1,0 +1,288 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "AdHocConnectionImpl.hpp"
+#include "Utils.hpp"
+#include "ThreadUtils.hpp"
+#include "../serial_com/Port.h"
+#include "../serial_com/SerialPort.hpp"
+#include "../serial_com/UdpClientPort.hpp"
+#include "../serial_com/TcpClientPort.hpp"
+
+using namespace mavlink_utils;
+using namespace mavlinkcom_impl;
+
+AdHocConnectionImpl::AdHocConnectionImpl()
+{
+    closed = true;
+    ::memset(&mavlink_intermediate_status_, 0, sizeof(mavlink_status_t));
+    ::memset(&mavlink_status_, 0, sizeof(mavlink_status_t));
+}
+std::string AdHocConnectionImpl::getName() {
+    return name;
+}
+
+AdHocConnectionImpl::~AdHocConnectionImpl()
+{
+    con_.reset();
+    close();
+}
+
+std::shared_ptr<AdHocConnection>  AdHocConnectionImpl::createConnection(const std::string& nodeName, std::shared_ptr<Port> port)
+{
+    // std::shared_ptr<MavLinkCom> owner, const std::string& nodeName
+    std::shared_ptr<AdHocConnection> con = std::make_shared<AdHocConnection>();
+    con->startListening(nodeName, port);
+    return con;
+}
+
+std::shared_ptr<AdHocConnection>  AdHocConnectionImpl::connectLocalUdp(const std::string& nodeName, std::string localAddr, int localPort)
+{
+    std::shared_ptr<UdpClientPort> socket = std::make_shared<UdpClientPort>();
+
+    socket->connect(localAddr, localPort, "", 0);
+
+    return createConnection(nodeName, socket);
+}
+
+std::shared_ptr<AdHocConnection>  AdHocConnectionImpl::connectRemoteUdp(const std::string& nodeName, std::string localAddr, std::string remoteAddr, int remotePort)
+{
+    std::string local = localAddr;
+    // just a little sanity check on the local address, if remoteAddr is localhost then localAddr must be also. 
+    if (remoteAddr == "127.0.0.1") {
+        local = "127.0.0.1";
+    }
+
+    std::shared_ptr<UdpClientPort> socket = std::make_shared<UdpClientPort>();
+
+    socket->connect(local, 0, remoteAddr, remotePort);
+
+    return createConnection(nodeName, socket);
+}
+
+std::shared_ptr<AdHocConnection>  AdHocConnectionImpl::connectTcp(const std::string& nodeName, std::string localAddr, const std::string& remoteIpAddr, int remotePort)
+{
+    std::string local = localAddr;
+    // just a little sanity check on the local address, if remoteAddr is localhost then localAddr must be also. 
+    if (remoteIpAddr == "127.0.0.1") {
+        local = "127.0.0.1";
+    }
+
+    std::shared_ptr<TcpClientPort> socket = std::make_shared<TcpClientPort>();
+
+    socket->connect(local, 0, remoteIpAddr, remotePort);
+
+    return createConnection(nodeName, socket);
+}
+
+std::shared_ptr<AdHocConnection>  AdHocConnectionImpl::connectSerial(const std::string& nodeName, std::string name, int baudRate, const std::string initString)
+{
+    std::shared_ptr<SerialPort> serial = std::make_shared<SerialPort>();
+
+    int hr = serial->connect(name.c_str(), baudRate);
+    if (hr != 0)
+        throw std::runtime_error(Utils::stringf("Could not open the serial port %s, error=%d", name.c_str(), hr));
+
+    // send this right away just in case serial link is not already configured 
+    if (initString.size() > 0) {
+        serial->write(reinterpret_cast<const uint8_t*>(initString.c_str()), static_cast<int>(initString.size()));
+    }
+
+    return createConnection(nodeName, serial);
+}
+
+void AdHocConnectionImpl::startListening(std::shared_ptr<AdHocConnection> parent, const std::string& nodeName, std::shared_ptr<Port> connectedPort)
+{
+    name = nodeName;
+    con_ = parent;
+    close();
+    closed = false;
+    port = connectedPort;
+
+    Utils::cleanupThread(read_thread);
+    read_thread = std::thread{ &AdHocConnectionImpl::readPackets, this };
+    Utils::cleanupThread(publish_thread_);
+    publish_thread_ = std::thread{ &AdHocConnectionImpl::publishPackets, this };
+}
+
+void AdHocConnectionImpl::close()
+{
+    closed = true;
+    if (port != nullptr) {
+        port->close();
+        port = nullptr;
+    }
+
+    if (read_thread.joinable()) {
+        read_thread.join();
+    }
+    if (publish_thread_.joinable()) {
+        msg_available_.post();
+        publish_thread_.join();
+    }
+}
+
+bool AdHocConnectionImpl::isOpen()
+{
+    return !closed;
+}
+
+int AdHocConnectionImpl::getTargetComponentId()
+{
+    return this->other_component_id;
+}
+int AdHocConnectionImpl::getTargetSystemId()
+{
+    return this->other_system_id;
+}
+
+void AdHocConnectionImpl::sendMessage(const std::vector<uint8_t>& msg)
+{
+    if (closed) {
+        return;
+    }
+
+    try {
+        port->write(msg.data(), static_cast<int>(msg.size()));
+    }
+    catch (std::exception& e) {
+        throw std::runtime_error(Utils::stringf("AdHocConnectionImpl: Error sending message on connection '%s', details: %s", name.c_str(), e.what()));
+    }
+}
+
+
+int AdHocConnectionImpl::subscribe(AdHocMessageHandler handler)
+{
+    MessageHandlerEntry entry = { static_cast<int>(listeners.size() + 1), handler = handler };
+    std::lock_guard<std::mutex> guard(listener_mutex);
+    listeners.push_back(entry);
+    snapshot_stale = true;
+    return entry.id;
+}
+void AdHocConnectionImpl::unsubscribe(int id)
+{
+    std::lock_guard<std::mutex> guard(listener_mutex);
+    for (auto ptr = listeners.begin(), end = listeners.end(); ptr != end; ptr++)
+    {
+        if ((*ptr).id == id)
+        {
+            listeners.erase(ptr);
+            snapshot_stale = true;
+            break;
+        }
+    }
+}
+
+void AdHocConnectionImpl::readPackets()
+{
+    //CurrentThread::setMaximumPriority();
+    std::shared_ptr<Port> safePort = this->port;
+    const int MAXBUFFER = 512;
+    uint8_t* buffer = new uint8_t[MAXBUFFER];
+    int channel = 0;
+    int hr = 0;
+    while (hr == 0 && con_ != nullptr && !closed)
+    {
+        int read = 0;
+        if (safePort->isClosed())
+        {
+            // hmmm, wait till it is opened?
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            continue;
+        }
+
+        int count = safePort->read(buffer, MAXBUFFER);
+        if (count <= 0) {
+            // error? well let's try again, but we should be careful not to spin too fast and kill the CPU
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            continue;
+        }
+
+        if (count >= MAXBUFFER) {
+
+            std::cerr << "GAH KM911 message size (" << std::to_string(count) << ") is bigger than max buffer size! Time to support frame breaks, Moffitt" << std::endl;
+
+            // error? well let's try again, but we should be careful not to spin too fast and kill the CPU
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            continue;
+        }
+
+        // queue event for publishing.
+        {
+            std::lock_guard<std::mutex> guard(msg_queue_mutex_);
+            std::vector<uint8_t> message(count);
+            memcpy(message.data(), buffer, count);
+            msg_queue_.push(message);
+        }
+
+        if (waiting_for_msg_) {
+            msg_available_.post();
+        }
+
+    } //while
+
+    delete[]  buffer;
+
+} //readPackets
+
+void AdHocConnectionImpl::drainQueue()
+{
+    std::vector<uint8_t> message;
+    bool hasMsg = true;
+    while (hasMsg) {
+        hasMsg = false;
+        {
+            std::lock_guard<std::mutex> guard(msg_queue_mutex_);
+            if (!msg_queue_.empty()) {
+                message = msg_queue_.front();
+                msg_queue_.pop();
+                hasMsg = true;
+            }
+        }
+        if (!hasMsg)
+        {
+            return;
+        }
+        // publish the message from this thread, this is safer than publishing from the readPackets thread
+        // as it ensures we don't lose messages if the listener is slow.
+        if (snapshot_stale) {
+            // this is tricky, the clear has to be done outside the lock because it is destructing the handlers
+            // and the handler might try and call unsubscribe, which needs to be able to grab the lock, otherwise
+            // we would get a deadlock.
+            snapshot.clear();
+
+            std::lock_guard<std::mutex> guard(listener_mutex);
+            snapshot = listeners;
+            snapshot_stale = false;
+        }
+        auto end = snapshot.end();
+
+        auto startTime = std::chrono::system_clock::now();
+        std::shared_ptr<AdHocConnection> sharedPtr = std::shared_ptr<AdHocConnection>(this->con_);
+        for (auto ptr = snapshot.begin(); ptr != end; ptr++)
+        {
+            try {
+                (*ptr).handler(sharedPtr, message);
+            }
+            catch (std::exception& e) {
+                Utils::log(Utils::stringf("AdHocConnectionImpl: Error handling message on connection '%s', details: %s",
+                    name.c_str(), e.what()), Utils::kLogLevelError);
+            }
+        }
+    }
+}
+
+void AdHocConnectionImpl::publishPackets()
+{
+    //CurrentThread::setMaximumPriority();
+    while (!closed) {
+
+        drainQueue();
+
+        waiting_for_msg_ = true;
+        msg_available_.wait();
+        waiting_for_msg_ = false;
+    }
+}
+
+

--- a/MavLinkCom/src/impl/AdHocConnectionImpl.hpp
+++ b/MavLinkCom/src/impl/AdHocConnectionImpl.hpp
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef MavLinkCom_AdHocConnectionImpl_hpp
+#define MavLinkCom_AdHocConnectionImpl_hpp
+
+#include <memory>
+#include <vector>
+#include <queue>
+#include <thread>
+#include <mutex>
+#include <unordered_set>
+#include "AdHocConnection.hpp"
+//#include "MavLinkMessageBase.hpp"
+#include "Semaphore.hpp"
+#include "../serial_com/TcpClientPort.hpp"
+#include "StrictMode.hpp"
+#define MAVLINK_PACKED
+
+STRICT_MODE_OFF
+#include "../mavlink/common/mavlink.h"
+#include "../mavlink/mavlink_helpers.h"
+#include "../mavlink/mavlink_types.h"
+STRICT_MODE_ON
+
+using namespace mavlinkcom;
+
+namespace mavlinkcom_impl {
+
+    // See MavLinkConnection.hpp for definitions of these methods.
+    class AdHocConnectionImpl
+    {
+    public:
+        AdHocConnectionImpl();
+        static std::shared_ptr<AdHocConnection>  connectSerial(const std::string& nodeName, std::string portName, int baudrate = 115200, const std::string initString = "");
+        static std::shared_ptr<AdHocConnection>  connectLocalUdp(const std::string& nodeName, std::string localAddr, int localPort);
+        static std::shared_ptr<AdHocConnection>  connectRemoteUdp(const std::string& nodeName, std::string localAddr, std::string remoteAddr, int remotePort);
+        static std::shared_ptr<AdHocConnection>  connectTcp(const std::string& nodeName, std::string localAddr, const std::string& remoteIpAddr, int remotePort);
+
+        std::string getName();
+        int getTargetComponentId();
+        int getTargetSystemId();
+        ~AdHocConnectionImpl();
+        void startListening(std::shared_ptr<AdHocConnection> parent, const std::string& nodeName, std::shared_ptr<Port>  connectedPort);
+        void close();
+        bool isOpen();
+        void sendMessage(const std::vector<uint8_t>& msg);
+        int subscribe(AdHocMessageHandler handler);
+        void unsubscribe(int id);
+        
+    private:
+        static std::shared_ptr<AdHocConnection> createConnection(const std::string& nodeName, std::shared_ptr<Port> port);
+        void publishPackets();
+        void readPackets();
+        void drainQueue();
+        std::string name;
+        std::shared_ptr<Port> port;
+        std::shared_ptr<AdHocConnection> con_;
+        int other_system_id = -1;
+        int other_component_id = 0;
+        std::thread read_thread;
+        std::string accept_node_name_;
+        std::shared_ptr<TcpClientPort> server_;
+
+        struct MessageHandlerEntry {
+        public:
+            int id;
+            AdHocMessageHandler handler;
+        };
+        std::vector<MessageHandlerEntry> listeners;
+        std::vector<MessageHandlerEntry> snapshot;
+        bool snapshot_stale;
+        std::mutex listener_mutex;
+        bool closed;
+        std::thread publish_thread_;
+        std::queue<std::vector<uint8_t>> msg_queue_;
+        std::mutex msg_queue_mutex_;
+        mavlink_utils::Semaphore msg_available_;
+        bool waiting_for_msg_ = false;
+        bool supports_mavlink2_ = false;
+        bool signing_ = false;
+        mavlink_status_t mavlink_intermediate_status_;
+        mavlink_status_t mavlink_status_;
+        std::mutex telemetry_mutex_;
+        std::unordered_set<uint8_t> ignored_messageids;
+    };
+}
+
+#endif

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
@@ -7,6 +7,7 @@
 #include "Kismet/GameplayStatics.h"
 #include "Misc/OutputDeviceNull.h"
 #include "Engine/World.h"
+#include "vehicles/multirotor/MultiRotorParamsFactory.hpp"
 
 #include <memory>
 #include "AirBlueprintLib.h"
@@ -432,6 +433,8 @@ void ASimModeBase::setupVehiclesAndCamera()
     FTransform camera_transform(toFRotator(camera_director_setting.rotation, FRotator::ZeroRotator), 
         camera_director_position_uu);
     initializeCameraDirector(camera_transform, camera_director_setting.follow_distance);
+
+	MultiRotorParamsFactory::reset();
 
     //find all vehicle pawns
     {

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Multirotor/SimModeWorldMultiRotor.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Multirotor/SimModeWorldMultiRotor.cpp
@@ -95,7 +95,8 @@ void ASimModeWorldMultiRotor::getExistingVehiclePawns(TArray<AActor*>& pawns) co
 bool ASimModeWorldMultiRotor::isVehicleTypeSupported(const std::string& vehicle_type) const
 {
     return ((vehicle_type == AirSimSettings::kVehicleTypeSimpleFlight) ||
-        (vehicle_type == AirSimSettings::kVehicleTypePX4));
+        (vehicle_type == AirSimSettings::kVehicleTypePX4) ||
+		(vehicle_type == AirSimSettings::kVehicleTypeArduCopterSolo));
 }
 
 std::string ASimModeWorldMultiRotor::getVehiclePawnPathName(const AirSimSettings::VehicleSetting& vehicle_setting) const

--- a/cmake/AirLib/CMakeLists.txt
+++ b/cmake/AirLib/CMakeLists.txt
@@ -19,6 +19,7 @@ file(GLOB_RECURSE ${PROJECT_NAME}_sources
   ${AIRSIM_ROOT}/${PROJECT_NAME}/src/common/common_utils/*.cpp
   ${AIRSIM_ROOT}/${PROJECT_NAME}/src/safety/*.cpp
   ${AIRSIM_ROOT}/${PROJECT_NAME}/src/vehicles/car/api/*.cpp
+  ${AIRSIM_ROOT}/${PROJECT_NAME}/src/vehicles/multirotor/*.cpp
   ${AIRSIM_ROOT}/${PROJECT_NAME}/src/vehicles/multirotor/api/*.cpp
 )
 

--- a/cmake/MavLinkCom/CMakeLists.txt
+++ b/cmake/MavLinkCom/CMakeLists.txt
@@ -16,6 +16,7 @@ include_directories(
 
 LIST(APPEND MAVLINK_SOURCES "${AIRSIM_ROOT}/MavLinkCom/common_utils/FileSystem.cpp")
 LIST(APPEND MAVLINK_SOURCES "${AIRSIM_ROOT}/MavLinkCom/common_utils/ThreadUtils.cpp")
+LIST(APPEND MAVLINK_SOURCES "${AIRSIM_ROOT}/MavLinkCom/src/AdHocConnection.cpp") 
 LIST(APPEND MAVLINK_SOURCES "${AIRSIM_ROOT}/MavLinkCom/src/MavLinkConnection.cpp") 
 LIST(APPEND MAVLINK_SOURCES "${AIRSIM_ROOT}/MavLinkCom/src/MavLinkFtpClient.cpp") 
 LIST(APPEND MAVLINK_SOURCES "${AIRSIM_ROOT}/MavLinkCom/src/MavLinkLog.cpp") 
@@ -26,6 +27,7 @@ LIST(APPEND MAVLINK_SOURCES "${AIRSIM_ROOT}/MavLinkCom/src/MavLinkTcpServer.cpp"
 LIST(APPEND MAVLINK_SOURCES "${AIRSIM_ROOT}/MavLinkCom/src/MavLinkVehicle.cpp") 
 LIST(APPEND MAVLINK_SOURCES "${AIRSIM_ROOT}/MavLinkCom/src/MavLinkVideoStream.cpp") 
 LIST(APPEND MAVLINK_SOURCES "${AIRSIM_ROOT}/MavLinkCom/src/Semaphore.cpp") 
+LIST(APPEND MAVLINK_SOURCES "${AIRSIM_ROOT}/MavLinkCom/src/impl/AdHocConnectionImpl.cpp") 
 LIST(APPEND MAVLINK_SOURCES "${AIRSIM_ROOT}/MavLinkCom/src/impl/MavLinkConnectionImpl.cpp") 
 LIST(APPEND MAVLINK_SOURCES "${AIRSIM_ROOT}/MavLinkCom/src/impl/MavLinkFtpClientImpl.cpp") 
 LIST(APPEND MAVLINK_SOURCES "${AIRSIM_ROOT}/MavLinkCom/src/impl/MavLinkNodeImpl.cpp") 


### PR DESCRIPTION
Support for the 3DR Solo quadrotor, which uses a fork of ArduPilot ( https://github.com/3drobotics/ardupilot-solo ) for its autopilot, and ad hoc UDP links (pushing FlightGear FDM messages) for sensor data and rotor control flow in SIL mode