### PR TITLE
fixed  'c:\\temp\\py0.png' FileNotFoundError

### DIFF
--- a/PythonClient/car/hello_car.py
+++ b/PythonClient/car/hello_car.py
@@ -58,7 +58,8 @@ for idx in range(3):
 
     for response in responses:
         filename = 'c:/temp/py' + str(idx)
-
+        if not os.path.exists('c:/temp/'):
+            os.makedirs('c:/temp/')
         if response.pixels_as_float:
             print("Type %d, size %d" % (response.image_type, len(response.image_data_float)))
             airsim.write_pfm(os.path.normpath(filename + '.pfm'), airsim.get_pfm_array(response))


### PR DESCRIPTION
if temp folder didn't exist cause error, so checking that and if not exist create [temp] folder in c directory

> Traceback (most recent call last):
  File "hello_car.py", line 68, in <module>
    airsim.write_file(os.path.normpath(filename + '.png'), response.image_data_uint8)
  File "D:\WorkingPartition\University\MS\Self_Driving_Car\Simulators\AirSim (Microsoft)\AirSim-master\PythonClient\airsim\utils.py", line 44, in write_file
    with open(filename, 'wb') as afile:
FileNotFoundError: [Errno 2] No such file or directory: 'c:\\temp\\py0.png'