### PR TITLE
On windows, this file "MavLinkFindSerialPorts.cpp" is named "WindowsF…

### DIFF
--- a/cmake/MavLinkCom/CMakeLists.txt
+++ b/cmake/MavLinkCom/CMakeLists.txt
@@ -41,7 +41,7 @@ LIST(APPEND MAVLINK_SOURCES "${AIRSIM_ROOT}/MavLinkCom/src/serial_com/wifi.cpp")
 IF(UNIX)
     LIST(APPEND MAVLINK_SOURCES "${AIRSIM_ROOT}/MavLinkCom/src/impl/linux/MavLinkFindSerialPorts.cpp")
 ELSE()
-    LIST(APPEND MAVLINK_SOURCES "${AIRSIM_ROOT}/MavLinkCom/src/impl/windows/MavLinkFindSerialPorts.cpp")
+    LIST(APPEND MAVLINK_SOURCES "${AIRSIM_ROOT}/MavLinkCom/src/impl/windows/WindowsFindSerialPorts.cpp")
 ENDIF()
 
 add_library(MavLinkCom STATIC ${MAVLINK_SOURCES})


### PR DESCRIPTION
Fixing error  "Cannot find source file: MavLinkFindSerialPorts.cpp", when building CMAKE fileOn windows The file name "MavLinkFindSerialPorts.cpp" was changed to "WindowsFindSerialPorts.cpp"