### PR TITLE
Fixed bug in startsWith. Changed <= to >=.

### DIFF
--- a/AirLib/include/common/common_utils/Utils.hpp
+++ b/AirLib/include/common/common_utils/Utils.hpp
@@ -127,7 +127,7 @@ public:
     }
 
     static bool startsWith(const string& s, const string& prefix) {
-        return s.size() <= prefix.size() && s.compare(0, prefix.size(), prefix) == 0;
+        return s.size() >= prefix.size() && s.compare(0, prefix.size(), prefix) == 0;
     }
 
     template <template<class, class, class...> class TContainer, typename TKey, typename TVal, typename... Args>


### PR DESCRIPTION
Simple bug fix. I noticed that the startsWith() function failed in many cases where the string started with "default_". Basically it would return false for any case where the string was bigger than the prefix, which is almost all the cases we actually want to catch.