### PR TITLE
Build.cmd - Add build mode argument

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,11 +1,11 @@
-@echo off
+@echo on
 REM //---------- set up variable ----------
 setlocal
 set ROOT_DIR=%~dp0
 
 REM // Check command line arguments
 set "noFullPolyCar="
-set "buildMode=--Debug"
+set "buildMode="
 
 REM //check VS version
 if "%VisualStudioVersion%"=="" (
@@ -23,9 +23,11 @@ if "%VisualStudioVersion%"=="14.0" (
 
 if "%1"=="" goto noargs
 if "%1"=="--no-full-poly-car" set "noFullPolyCar=y"
+if "%1"=="--Debug" set "buildMode=--Debug"
 if "%1"=="--Release" set "buildMode=--Release"
 
 if "%2"=="" goto noargs
+if "%2"=="--Debug" set "buildMode=--Debug"
 if "%2"=="--Release" set "buildMode=--Release"
 
 :noargs
@@ -78,12 +80,17 @@ cd external\rpclib\rpclib-2.2.1\build
 REM cmake -G"Visual Studio 14 2015 Win64" ..
 cmake -G"Visual Studio 15 2017 Win64" ..
 
-if "%buildMode%" == "--Debug" (cmake --build . --config Debug)
-if "%buildMode%" == "--Release" (cmake --build . --config Release)
+if "%buildMode%" == "--Debug" (
+cmake --build . --config Debug
+) else if "%buildMode%" == "--Release" (
+cmake --build . --config Release
+) else (
+cmake --build .
+cmake --build . --config Release
+)
 
 if ERRORLEVEL 1 goto :buildfailed
 chdir /d %ROOT_DIR% 
-
 
 REM //---------- copy rpclib binaries and include folder inside AirLib folder ----------
 set RPCLIB_TARGET_LIB=AirLib\deps\rpclib\lib\x64
@@ -92,8 +99,14 @@ set RPCLIB_TARGET_INCLUDE=AirLib\deps\rpclib\include
 if NOT exist %RPCLIB_TARGET_INCLUDE% mkdir %RPCLIB_TARGET_INCLUDE%
 robocopy /MIR external\rpclib\rpclib-2.2.1\include %RPCLIB_TARGET_INCLUDE%
 
-if "%buildMode%" == "--Debug" (robocopy /MIR external\rpclib\rpclib-2.2.1\build\Debug %RPCLIB_TARGET_LIB%\Debug)
-if "%buildMode%" == "--Release" (robocopy /MIR external\rpclib\rpclib-2.2.1\build\Release %RPCLIB_TARGET_LIB%\Release)
+if "%buildMode%" == "--Debug" (
+robocopy /MIR external\rpclib\rpclib-2.2.1\build\Debug %RPCLIB_TARGET_LIB%\Debug
+) else if "%buildMode%" == "--Release" (
+robocopy /MIR external\rpclib\rpclib-2.2.1\build\Release %RPCLIB_TARGET_LIB%\Release
+) else (
+robocopy /MIR external\rpclib\rpclib-2.2.1\build\Debug %RPCLIB_TARGET_LIB%\Debug
+robocopy /MIR external\rpclib\rpclib-2.2.1\build\Release %RPCLIB_TARGET_LIB%\Release
+)
 
 REM //---------- get High PolyCount SUV Car Model ------------
 IF NOT EXIST Unreal\Plugins\AirSim\Content\VehicleAdv mkdir Unreal\Plugins\AirSim\Content\VehicleAdv
@@ -142,10 +155,18 @@ IF NOT EXIST AirLib\deps\eigen3 goto :buildfailed
 
 
 REM //---------- now we have all dependencies to compile AirSim.sln which will also compile MavLinkCom ----------
-if "%buildMode%" == "--Debug" (msbuild /p:Platform=x64 /p:Configuration=Debug AirSim.sln)
-if "%buildMode%" == "--Release" (msbuild /p:Platform=x64 /p:Configuration=Release AirSim.sln)
-
+if "%buildMode%" == "--Debug" (
+msbuild /p:Platform=x64 /p:Configuration=Debug AirSim.sln
 if ERRORLEVEL 1 goto :buildfailed
+) else if "%buildMode%" == "--Release" (
+msbuild /p:Platform=x64 /p:Configuration=Release AirSim.sln
+if ERRORLEVEL 1 goto :buildfailed
+) else (
+msbuild /p:Platform=x64 /p:Configuration=Debug AirSim.sln
+if ERRORLEVEL 1 goto :buildfailed
+msbuild /p:Platform=x64 /p:Configuration=Release AirSim.sln 
+if ERRORLEVEL 1 goto :buildfailed
+)
 
 REM //---------- copy binaries and include for MavLinkCom in deps ----------
 set MAVLINK_TARGET_LIB=AirLib\deps\MavLinkCom\lib

--- a/build.cmd
+++ b/build.cmd
@@ -1,4 +1,4 @@
-@echo on
+@echo off
 REM //---------- set up variable ----------
 setlocal
 set ROOT_DIR=%~dp0

--- a/build.cmd
+++ b/build.cmd
@@ -5,6 +5,7 @@ set ROOT_DIR=%~dp0
 
 REM // Check command line arguments
 set "noFullPolyCar="
+set "buildMode=--Debug"
 
 REM //check VS version
 if "%VisualStudioVersion%"=="" (
@@ -22,6 +23,10 @@ if "%VisualStudioVersion%"=="14.0" (
 
 if "%1"=="" goto noargs
 if "%1"=="--no-full-poly-car" set "noFullPolyCar=y"
+if "%1"=="--Release" set "buildMode=--Release"
+
+if "%2"=="" goto noargs
+if "%2"=="--Release" set "buildMode=--Release"
 
 :noargs
 
@@ -72,8 +77,10 @@ IF NOT EXIST external\rpclib\rpclib-2.2.1\build mkdir external\rpclib\rpclib-2.2
 cd external\rpclib\rpclib-2.2.1\build
 REM cmake -G"Visual Studio 14 2015 Win64" ..
 cmake -G"Visual Studio 15 2017 Win64" ..
-cmake --build .
-cmake --build . --config Release
+
+if "%buildMode%" == "--Debug" (cmake --build . --config Debug)
+if "%buildMode%" == "--Release" (cmake --build . --config Release)
+
 if ERRORLEVEL 1 goto :buildfailed
 chdir /d %ROOT_DIR% 
 
@@ -84,8 +91,9 @@ if NOT exist %RPCLIB_TARGET_LIB% mkdir %RPCLIB_TARGET_LIB%
 set RPCLIB_TARGET_INCLUDE=AirLib\deps\rpclib\include
 if NOT exist %RPCLIB_TARGET_INCLUDE% mkdir %RPCLIB_TARGET_INCLUDE%
 robocopy /MIR external\rpclib\rpclib-2.2.1\include %RPCLIB_TARGET_INCLUDE%
-robocopy /MIR external\rpclib\rpclib-2.2.1\build\Debug %RPCLIB_TARGET_LIB%\Debug
-robocopy /MIR external\rpclib\rpclib-2.2.1\build\Release %RPCLIB_TARGET_LIB%\Release
+
+if "%buildMode%" == "--Debug" (robocopy /MIR external\rpclib\rpclib-2.2.1\build\Debug %RPCLIB_TARGET_LIB%\Debug)
+if "%buildMode%" == "--Release" (robocopy /MIR external\rpclib\rpclib-2.2.1\build\Release %RPCLIB_TARGET_LIB%\Release)
 
 REM //---------- get High PolyCount SUV Car Model ------------
 IF NOT EXIST Unreal\Plugins\AirSim\Content\VehicleAdv mkdir Unreal\Plugins\AirSim\Content\VehicleAdv
@@ -134,9 +142,9 @@ IF NOT EXIST AirLib\deps\eigen3 goto :buildfailed
 
 
 REM //---------- now we have all dependencies to compile AirSim.sln which will also compile MavLinkCom ----------
-msbuild /p:Platform=x64 /p:Configuration=Debug AirSim.sln
-if ERRORLEVEL 1 goto :buildfailed
-msbuild /p:Platform=x64 /p:Configuration=Release AirSim.sln 
+if "%buildMode%" == "--Debug" (msbuild /p:Platform=x64 /p:Configuration=Debug AirSim.sln)
+if "%buildMode%" == "--Release" (msbuild /p:Platform=x64 /p:Configuration=Release AirSim.sln)
+
 if ERRORLEVEL 1 goto :buildfailed
 
 REM //---------- copy binaries and include for MavLinkCom in deps ----------


### PR DESCRIPTION
By default, the script makes _Debug_ and _Release_ build.
I added an argument to _build.cmd_ where you can specify a _Debug_ or _Release_ build.
The original behavior has not been changed. If _Debug_ or _Release_ is not added, the _Debug_ and _Release_ will be built.

Commands tested:
```
# [Debug and Release build]
build.cmd --no-full-poly-car  

# [Debug build only]
build.cmd --no-full-poly-car --Debug 

# [Release build only]
build.cmd --no-full-poly-car --Release

# [Debug build only]
build.cmd --Debug 

# [Release build only]
build.cmd --Release 

# [Debug and Release build]
build.cmd
```
