### PR TITLE
Fix for issue#1415 and additionnal RC support

### DIFF
--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
@@ -15,8 +15,6 @@
 PawnSimApi::PawnSimApi(const Params& params)
     : params_(params), ned_transform_(params.pawn, *params.global_transform)
 {
-    image_capture_.reset(new UnrealImageCapture(&params_.cameras));
-
     msr::airlib::Environment::State initial_environment;
     initial_environment.position = getPose().position;
     initial_environment.geo_point = params_.home_geopoint;
@@ -41,6 +39,8 @@ PawnSimApi::PawnSimApi(const Params& params)
     initial_state_.was_last_move_teleport = canTeleportWhileMove();
 
     setupCamerasFromSettings(params_.cameras);
+	image_capture_.reset(new UnrealImageCapture(&cameras_));
+	
     //add listener for pawn's collision event
     params_.pawn_events->getCollisionSignal().connect_member(this, &PawnSimApi::onCollision);
     params_.pawn_events->getPawnTickSignal().connect_member(this, &PawnSimApi::pawnTick);

--- a/Unreal/Plugins/AirSim/Source/SimJoyStick/SimJoyStick.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimJoyStick/SimJoyStick.cpp
@@ -79,6 +79,18 @@ private:
                     throw std::invalid_argument("Unsupported axis_type in getMappedValue");
                 }
             }
+			else if (device_pid_vid == "VID_0401&PID_0401") { //Flysky FS-SM100 RC USB adapter
+				switch (axis_type) {
+				case AxisMap::AxisType::LeftX: rc_axis = AxisMap::AxisType::RightY; break;
+				case AxisMap::AxisType::LeftY: rc_axis = AxisMap::AxisType::LeftX; break;
+				case AxisMap::AxisType::LeftZ: rc_axis = AxisMap::AxisType::RightX; break;
+				case AxisMap::AxisType::RightX: rc_axis = AxisMap::AxisType::LeftY; break;
+				case AxisMap::AxisType::RightY: rc_axis = AxisMap::AxisType::LeftZ; break;
+				case AxisMap::AxisType::RightZ: rc_axis = AxisMap::AxisType::RightZ; break;
+				default:
+					throw std::invalid_argument("Unsupported axis_type in getMappedValue");
+				}
+			}
             else { //Xbox controllers
                 rc_axis = axis_type;
             }
@@ -115,7 +127,7 @@ private:
             if (
                 ((device_pid_vid == "" || device_pid_vid == "VID_0483&PID_5710") &&
                     (axis_type == AxisMap::AxisType::LeftZ || axis_type == AxisMap::AxisType::RightY)) ||
-                ((device_pid_vid != "" && device_pid_vid != "VID_0483&PID_5710") &&
+                ((device_pid_vid != "" && device_pid_vid != "VID_0483&PID_5710" && device_pid_vid != "VID_0401&PID_0401") &&
                     (axis_type == AxisMap::AxisType::LeftY))
                )
                 val = 1 - val;


### PR DESCRIPTION
- Fixes issue#1415 (custom cameras and camera parameters not taken into account during initialization phase which leads to crashes when trying to request images from the API).
- Proposes support (correct axis mapping) for an additional RC :  the Flysky FS-SM100 RC to USB adapter which converts PPM signals typically outputted by a wide range of UAV RCs to USB HID protocol (this should therefore offer a good support for a wide range of UAV RCs)