### PR TITLE
Added camera_name to ImageResponse to reflect ImageCaptureBase::ImageResponse

### DIFF
--- a/AirLib/include/api/RpcLibAdapatorsBase.hpp
+++ b/AirLib/include/api/RpcLibAdapatorsBase.hpp
@@ -381,6 +381,7 @@ public:
         std::vector<uint8_t> image_data_uint8;
         std::vector<float> image_data_float;
 
+		std::string camera_name;
         Vector3r camera_position;
         Quaternionr camera_orientation;
         msr::airlib::TTimePoint time_stamp;
@@ -390,7 +391,7 @@ public:
         int width, height;
         msr::airlib::ImageCaptureBase::ImageType image_type;
 
-        MSGPACK_DEFINE_MAP(image_data_uint8, image_data_float, camera_position, 
+        MSGPACK_DEFINE_MAP(image_data_uint8, image_data_float, camera_position, camera_name,
             camera_orientation, time_stamp, message, pixels_as_float, compress, width, height, image_type);
 
         ImageResponse()
@@ -409,6 +410,7 @@ public:
             if (image_data_float.size() == 0)
                 image_data_float.push_back(0);
 
+			camera_name = s.camera_name;
             camera_position = Vector3r(s.camera_position);
             camera_orientation = Quaternionr(s.camera_orientation);
             time_stamp = s.time_stamp;
@@ -430,6 +432,7 @@ public:
             else
                 d.image_data_float = image_data_float;
 
+			d.camera_name = camera_name;
             d.camera_position = camera_position.to();
             d.camera_orientation = camera_orientation.to();
             d.time_stamp = time_stamp;

--- a/AirLib/include/api/RpcLibAdapatorsBase.hpp
+++ b/AirLib/include/api/RpcLibAdapatorsBase.hpp
@@ -381,7 +381,7 @@ public:
         std::vector<uint8_t> image_data_uint8;
         std::vector<float> image_data_float;
 
-		std::string camera_name;
+        std::string camera_name;
         Vector3r camera_position;
         Quaternionr camera_orientation;
         msr::airlib::TTimePoint time_stamp;
@@ -410,7 +410,7 @@ public:
             if (image_data_float.size() == 0)
                 image_data_float.push_back(0);
 
-			camera_name = s.camera_name;
+            camera_name = s.camera_name;
             camera_position = Vector3r(s.camera_position);
             camera_orientation = Quaternionr(s.camera_orientation);
             time_stamp = s.time_stamp;
@@ -432,7 +432,7 @@ public:
             else
                 d.image_data_float = image_data_float;
 
-			d.camera_name = camera_name;
+            d.camera_name = camera_name;
             d.camera_position = camera_position.to();
             d.camera_orientation = camera_orientation.to();
             d.time_stamp = time_stamp;


### PR DESCRIPTION
While running the HelloDrone example, I noticed that I the camera_name field in the response from MultiRotorRpcLibClient::simGetImages always ended up as "". I tracked this down to the RpcLibAdaptorBase, where there is another definition of ImageResponse. This did however not include the camera_name string, so I added it. This fixed the problem.