### PR TITLE
Incorporating changes from the CarApiBase class

### DIFF
--- a/AirLib/include/vehicles/car/api/CarApiBase.hpp
+++ b/AirLib/include/vehicles/car/api/CarApiBase.hpp
@@ -67,6 +67,10 @@ public:
     };
 
 public:
+
+    // TODO: Temporary constructor for the Unity implementation which does not use the new Sensor Configuration Settings implementation.
+	CarApiBase() {}
+
     CarApiBase(const AirSimSettings::VehicleSetting* vehicle_setting, 
         std::shared_ptr<SensorFactory> sensor_factory, 
         const Kinematics::State& state, const Environment& environment)

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/UnitySensors/UnitySensorFactory.cpp
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/UnitySensors/UnitySensorFactory.cpp
@@ -6,21 +6,24 @@ UnitySensorFactory::UnitySensorFactory(std::string vehicle_name, const NedTransf
 	setActor(vehicle_name, ned_transform);
 }
 
-std::unique_ptr<msr::airlib::SensorBase> UnitySensorFactory::createSensor(msr::airlib::SensorBase::SensorType sensor_type) const
-{
-	using SensorBase = msr::airlib::SensorBase;
-
-	switch (sensor_type)
-	{
-	case SensorBase::SensorType::Distance:
-		return std::unique_ptr<UnityDistanceSensor>(new UnityDistanceSensor(vehicle_name_, ned_transform_));
-	default:
-		return msr::airlib::SensorFactory::createSensor(sensor_type);
-	}
-}
-
 void UnitySensorFactory::setActor(std::string vehicle_name, const NedTransform* ned_transform)
 {
 	vehicle_name_ = vehicle_name;
 	ned_transform_ = ned_transform;
+}
+
+std::unique_ptr<msr::airlib::SensorBase> UnitySensorFactory::createSensorFromSettings(const AirSimSettings::SensorSetting * sensor_setting) const
+{
+	
+	using SensorBase = msr::airlib::SensorBase;
+
+	switch (sensor_setting->sensor_type)
+	{
+	case SensorBase::SensorType::Distance:
+		return std::unique_ptr<UnityDistanceSensor>(new UnityDistanceSensor(vehicle_name_, ned_transform_));
+	default:
+		return msr::airlib::SensorFactory::createSensorFromSettings(sensor_setting);
+	}
+
+	return std::unique_ptr<msr::airlib::SensorBase>();
 }

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/UnitySensors/UnitySensorFactory.h
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/UnitySensors/UnitySensorFactory.h
@@ -10,7 +10,7 @@ class UnitySensorFactory : public SensorFactory
 public:
 	UnitySensorFactory(std::string vehicle_name, const NedTransform* ned_transform);
 	void setActor(std::string vehicle_name, const NedTransform* ned_transform);
-	virtual std::unique_ptr<msr::airlib::SensorBase> createSensor(msr::airlib::SensorBase::SensorType sensor_type) const override;
+	virtual std::unique_ptr<msr::airlib::SensorBase> createSensorFromSettings(const AirSimSettings::SensorSetting* sensor_setting) const override;
 
 private:
 	std::string vehicle_name_;

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/Vehicles/Car/CarPawnApi.cpp
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/Vehicles/Car/CarPawnApi.cpp
@@ -1,8 +1,15 @@
 #include "CarPawnApi.h"
 #include "../../PInvokeWrapper.h"
 
-CarPawnApi::CarPawnApi(CarPawn* pawn, const msr::airlib::Kinematics::State* pawn_kinematics, const msr::airlib::GeoPoint& home_geopoint, std::string car_name)
-	: pawn_(pawn), pawn_kinematics_(pawn_kinematics), home_geopoint_(home_geopoint), car_name_(car_name)
+
+CarPawnApi::CarPawnApi(CarPawn* pawn, 
+	const msr::airlib::Kinematics::State* pawn_kinematics, 
+	const msr::airlib::GeoPoint& home_geopoint, 
+	std::string car_name)
+	: pawn_(pawn), 
+	pawn_kinematics_(pawn_kinematics), 
+	home_geopoint_(home_geopoint), 
+	car_name_(car_name)
 {
 }
 


### PR DESCRIPTION
This fixes the latest build issue in the Unity projects. Changes to the CarApiBase class needed to be incorporated into the AirlibWrapper.