### PR TITLE
fix problem with multirotor sim on PX4 drones.

### DIFF
--- a/PythonClient/multirotor/land.py
+++ b/PythonClient/multirotor/land.py
@@ -11,7 +11,7 @@ if landed == airsim.LandedState.Landed:
     print("already landed...")
 else:
     print("landing...")
-    client.land()
+    client.landAsync()
 
 client.armDisarm(False)
 client.enableApiControl(False)

--- a/PythonClient/multirotor/land.py
+++ b/PythonClient/multirotor/land.py
@@ -11,7 +11,7 @@ if landed == airsim.LandedState.Landed:
     print("already landed...")
 else:
     print("landing...")
-    client.landAsync()
+    client.landAsync().join()
 
 client.armDisarm(False)
 client.enableApiControl(False)

--- a/PythonClient/multirotor/path.py
+++ b/PythonClient/multirotor/path.py
@@ -8,6 +8,14 @@ client = airsim.MultirotorClient()
 client.confirmConnection()
 client.enableApiControl(True)
 
+client.armDisarm(True)
+
+landed = client.getMultirotorState().landed_state
+if landed == airsim.LandedState.Landed:
+    print("taking off...")
+    client.takeoffAsync().join()
+else:
+    client.hoverAsync().join()
 
 # AirSim uses NED coordinates so negative axis is up.
 # z of -7 is 7 meters above the original launch point.

--- a/PythonClient/multirotor/path.py
+++ b/PythonClient/multirotor/path.py
@@ -8,14 +8,6 @@ client = airsim.MultirotorClient()
 client.confirmConnection()
 client.enableApiControl(True)
 
-client.armDisarm(True)
-
-landed = client.getMultirotorState().landed_state
-if landed == airsim.LandedState.Landed:
-    print("taking off...")
-    client.takeoffAsync().join()
-else:
-    client.hoverAsync().join()
 
 # AirSim uses NED coordinates so negative axis is up.
 # z of -7 is 7 meters above the original launch point.

--- a/PythonClient/multirotor/path.py
+++ b/PythonClient/multirotor/path.py
@@ -28,6 +28,6 @@ result = client.moveOnPathAsync([airsim.Vector3r(0,-253,z),airsim.Vector3r(125,-
                         12, 120, 
                         airsim.DrivetrainType.ForwardOnly, airsim.YawMode(False,0), 20, 1).join()
 client.moveToPositionAsync(0,0,z,1).join()
-client.land()
+client.landAsync()
 client.armDisarm(False)
 client.enableApiControl(False)

--- a/PythonClient/multirotor/setup_path.py
+++ b/PythonClient/multirotor/setup_path.py
@@ -4,7 +4,7 @@
 # Else we look up grand-parent folder to see if it has airsim folder
 #    and if it does then we add that in sys.path
 
-import os,sys,inspect,logging
+import os,sys,logging
 
 #this class simply tries to see if airsim 
 class SetupPath:
@@ -15,7 +15,7 @@ class SetupPath:
 
     @staticmethod
     def getCurrentPath():
-        cur_filepath = os.path.abspath(inspect.getfile(inspect.currentframe()))
+        cur_filepath = __file__
         return os.path.dirname(cur_filepath)
 
     @staticmethod

--- a/PythonClient/multirotor/survey.py
+++ b/PythonClient/multirotor/survey.py
@@ -15,19 +15,6 @@ class SurveyNavigator:
         self.client.confirmConnection()
         self.client.enableApiControl(True)
 
-    def move_to_position(self, x, y, z, threshold=2):
-        self.client.moveToPositionAsync(0, 0, z, self.velocity).join()
-        # bufbuf: seems moveToPositionAsync isn't working right...
-        while True:
-            k = self.client.simGetGroundTruthKinematics()
-            pos = self.client.getPosition()
-            dx = abs(pos.x_val - x)
-            dy = abs(pos.y_val - y)
-            dz = abs(pos.z_val - z)
-            if dx+dy+dz < threshold:
-                return
-            time.sleep(0.1)  # 100ms should be fine        
-
     def start(self):
         print("arming the drone...")
         self.client.armDisarm(True)
@@ -42,10 +29,10 @@ class SurveyNavigator:
         z = -self.altitude
 
         print("climbing to altitude: " + str(self.altitude))
-        self.move_to_position(0, 0, z)
+        self.client.moveToPositionAsync(0, 0, z, self.velocity).join()
 
         print("flying to first corner of survey box")
-        self.move_to_position(x, -self.boxsize, z)
+        self.client.moveToPositionAsync(x, -self.boxsize, z, self.velocity).join()
         
         # let it settle there a bit.
         self.client.hoverAsync().join()
@@ -79,12 +66,11 @@ class SurveyNavigator:
             pass
 
         print("flying back home")
-        self.move_to_position(0, 0, z)
+        self.client.moveToPositionAsync(0, 0, z, self.velocity).join()
         
         if z < -5:
             print("descending")
-            self.velocity = 2
-            self.move_to_position(0, 0, -5)
+            self.client.moveToPositionAsync(0, 0, -5, 2).join()
 
         print("landing...")
         self.client.landAsync().join()

--- a/PythonClient/multirotor/survey.py
+++ b/PythonClient/multirotor/survey.py
@@ -15,6 +15,19 @@ class SurveyNavigator:
         self.client.confirmConnection()
         self.client.enableApiControl(True)
 
+    def move_to_position(self, x, y, z, threshold=2):
+        self.client.moveToPositionAsync(0, 0, z, self.velocity).join()
+        # bufbuf: seems moveToPositionAsync isn't working right...
+        while True:
+            k = self.client.simGetGroundTruthKinematics()
+            pos = self.client.getPosition()
+            dx = abs(pos.x_val - x)
+            dy = abs(pos.y_val - y)
+            dz = abs(pos.z_val - z)
+            if dx+dy+dz < threshold:
+                return
+            time.sleep(0.1)  # 100ms should be fine        
+
     def start(self):
         print("arming the drone...")
         self.client.armDisarm(True)
@@ -29,10 +42,10 @@ class SurveyNavigator:
         z = -self.altitude
 
         print("climbing to altitude: " + str(self.altitude))
-        self.client.moveToPositionAsync(0, 0, z, self.velocity).join()
+        self.move_to_position(0, 0, z)
 
         print("flying to first corner of survey box")
-        self.client.moveToPositionAsync(x, -self.boxsize, z, self.velocity).join()
+        self.move_to_position(x, -self.boxsize, z)
         
         # let it settle there a bit.
         self.client.hoverAsync().join()
@@ -66,11 +79,12 @@ class SurveyNavigator:
             pass
 
         print("flying back home")
-        self.client.moveToPositionAsync(0, 0, z, self.velocity).join()
+        self.move_to_position(0, 0, z)
         
         if z < -5:
             print("descending")
-            self.client.moveToPositionAsync(0, 0, -5, 2).join()
+            self.velocity = 2
+            self.move_to_position(0, 0, -5)
 
         print("landing...")
         self.client.landAsync().join()

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
@@ -295,12 +295,6 @@ void PawnSimApi::update()
     environment_->update();
     //kinematics_->update();
 
-    // and in the case of subclasses that are overriding getGroundTruthEnvironment, make sure those 
-    // are also updated.
-    msr::airlib::Environment* vehicleEnvironment = const_cast<msr::airlib::Environment*>(getGroundTruthEnvironment());
-    vehicleEnvironment->setPosition(kinematics_.pose.position);
-    vehicleEnvironment->update();
-
     VehicleSimApiBase::update();
 }
 
@@ -515,6 +509,11 @@ const msr::airlib::Kinematics::State* PawnSimApi::getGroundTruthKinematics() con
     return &kinematics_;
 }
 const msr::airlib::Environment* PawnSimApi::getGroundTruthEnvironment() const
+{
+    return environment_.get();
+}
+
+msr::airlib::Environment* PawnSimApi::getEnvironment() const
 {
     return environment_.get();
 }

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
@@ -295,6 +295,12 @@ void PawnSimApi::update()
     environment_->update();
     //kinematics_->update();
 
+    // and in the case of subclasses that are overriding getGroundTruthEnvironment, make sure those 
+    // are also updated.
+    msr::airlib::Environment* vehicleEnvironment = const_cast<msr::airlib::Environment*>(getGroundTruthEnvironment());
+    vehicleEnvironment->setPosition(kinematics_.pose.position);
+    vehicleEnvironment->update();
+
     VehicleSimApiBase::update();
 }
 
@@ -418,6 +424,7 @@ void PawnSimApi::setPoseInternal(const Pose& pose, bool ignore_collision)
     //translate to new PawnSimApi position & orientation from NED to NEU
     FVector position = ned_transform_.fromLocalNed(pose.position);
     state_.current_position = position;
+    kinematics_.pose = pose;
 
     //quaternion formula comes from http://stackoverflow.com/a/40334755/207661
     FQuat orientation = ned_transform_.fromNed(pose.orientation);

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
@@ -291,7 +291,7 @@ void PawnSimApi::reset()
 void PawnSimApi::update()
 {
     //update position from kinematics so we have latest position after physics update
-    environment_->setPosition(kinematics_.pose.position);
+    environment_->setPosition(getGroundTruthKinematics()->pose.position);
     environment_->update();
     //kinematics_->update();
 
@@ -418,7 +418,6 @@ void PawnSimApi::setPoseInternal(const Pose& pose, bool ignore_collision)
     //translate to new PawnSimApi position & orientation from NED to NEU
     FVector position = ned_transform_.fromLocalNed(pose.position);
     state_.current_position = position;
-    kinematics_.pose = pose;
 
     //quaternion formula comes from http://stackoverflow.com/a/40334755/207661
     FQuat orientation = ned_transform_.fromNed(pose.orientation);
@@ -473,7 +472,7 @@ bool PawnSimApi::canTeleportWhileMove()  const
 
 const msr::airlib::Kinematics::State* PawnSimApi::getPawnKinematics() const
 {
-    return &kinematics_;
+    return getGroundTruthKinematics();
 }
 
 void PawnSimApi::updateKinematics(float dt)

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.h
@@ -96,6 +96,7 @@ protected: //additional interface for derived class
     const msr::airlib::Kinematics::State* getPawnKinematics() const;
     void setPoseInternal(const Pose& pose, bool ignore_collision);
     virtual msr::airlib::VehicleApiBase* getVehicleApiBase() const;
+    virtual msr::airlib::Environment* getEnvironment() const;
 
 public: //Unreal specific methods
     PawnSimApi(const Params& params);

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Multirotor/MultirotorPawnSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Multirotor/MultirotorPawnSimApi.cpp
@@ -23,7 +23,7 @@ MultirotorPawnSimApi::MultirotorPawnSimApi(const Params& params)
     vehicle_api_ = vehicle_params_->createMultirotorApi();
     //setup physics vehicle
     phys_vehicle_ = std::unique_ptr<MultiRotor>(new MultiRotor(vehicle_params_.get(), vehicle_api_.get(),
-        getPose(), params.home_geopoint));
+        getPose(), getEnvironment()));
     rotor_count_ = phys_vehicle_->wrenchVertexCount();
     rotor_info_.assign(rotor_count_, RotorInfo());
 

--- a/docs/px4_sitl.md
+++ b/docs/px4_sitl.md
@@ -15,7 +15,9 @@ you can build and run it there.
     ```
 3. Use following command to start PX4 firmware in SITL mode:
     ```
-    ./build/posix_sitl_default/px4 ./posix-configs/SITL/init/ekf2/iris
+    export PX4_SIM_MODEL="iris"
+    export PX4_ESTIMATOR="ekf2"
+    ./build/px4_sitl_default/bin/px4 ./ROMFS/px4fmu_common -s etc/init.d-posix/rcS -t ./test_data
     ```
 4. You should see a message like this you `INFO  [simulator] Waiting for initial data on UDP port 14560` which means the SITL PX4 app is waiting for someone to connect.
 5. Now edit [AirSim settings](settings.md) file to make sure you have followings:
@@ -49,7 +51,7 @@ You might also want to set this one so that the drone automatically hovers after
 param set COM_OBL_ACT 1
 ````
 
-Now close Unreal app, restart `./build_posix_sitl_default/src/firmware/posix/px4` and re-start the unreal app.  
+Now close Unreal app, restart the `px4` app and re-start the unreal app.  In fact, every time you stop the unreal app you have top restart the `px4` app.
 
 ## Check the Home Position
 


### PR DESCRIPTION
I think I found a bug.   The Environment object being used by Barometer is not the same Environment being updated by MultirotorPawnSimApi.cpp.  For some reason we have two separate Environments…
```cpp
PawnSimApi::PawnSimApi(const Params& params)
    : params_(params), ned_transform_(params.pawn, *params.global_transform)
{
    msr::airlib::Environment::State initial_environment;
    initial_environment.position = getPose().position;
    initial_environment.geo_point = params_.home_geopoint;
    environment_.reset(new msr::airlib::Environment(initial_environment));
```
and
```cpp
    MultiRotor(MultiRotorParams* params, VehicleApiBase* vehicle_api, 
        const Pose& initial_pose, const GeoPoint& home_geopoint)
        : params_(params), vehicle_api_(vehicle_api)
    {
        auto initial_kinematics = Kinematics::State::zero();
        initial_kinematics.pose = initial_pose;
        Environment::State initial_environment;
        initial_environment.position = initial_kinematics.pose.position;
        initial_environment.geo_point = home_geopoint;
        environment_.reset(new Environment(initial_environment));

        initialize(initial_kinematics, environment_.get());
    }
```
Changing MultiRotor constructor so that we can pass in the Environment* instead solves the problem.

This fixes takeoff on PX4 v1.8.1.