### PR TITLE
add unity to ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,10 @@ matrix:
       sudo: required
       services:
         - docker
-    # - os: windows
+    - os: windows
+      services:
+        - docker
+        
 
     # OS X CMake
     #- os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
       services:
         - docker
     - os: windows
+      dotnet: 2.1.5
       services:
         - docker
         

--- a/Unity/build.cmd
+++ b/Unity/build.cmd
@@ -9,3 +9,4 @@ exit /b 0
 :buildfailed
 echo(
 echo #### Build failed - see messages above. 1>&2
+exit /b 1


### PR DESCRIPTION
Adding unity building as a step in travis, so we can avoid issues like #1589 .

Until we get Linux support added to Airsim, this will help with bug detection.  