### PR TITLE
bug fixes #1656

### DIFF
--- a/Unity/build.sh
+++ b/Unity/build.sh
@@ -7,11 +7,13 @@ if [ ! -d "linux-build" ]; then
     mkdir linux-build;
 fi
 
+
 cd linux-build;
 export CC="clang-5.0"
 export CXX="clang++-5.0"
+CMAKE="$(readlink -f ../../cmake_build/bin/cmake)"
 
-cmake ../AirLibWrapper/AirsimWrapper;
+"$CMAKE" ../../cmake ../AirLibWrapper/AirsimWrapper;
 make -j`nproc`;
 if [ ! -d "../UnityDemo/Assets/Plugins" ]; then
 	mkdir ../ UnityDemo/Assets/Plugins;


### PR DESCRIPTION
Stops AirSim from looking inside of the unity executable folder for settings.json file and removes the need to have cmake installed globally on your machine.