### PR TITLE
Update setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -48,8 +48,10 @@ else #linux
     # Since Ubuntu 17 clang-5.0 is part of the core repository
     # See https://packages.ubuntu.com/search?keywords=clang-5.0
     if [ "$VERSION" -lt "17" ]; then
+        set +e
         wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
         sudo apt-get update
+        set -e
     fi
     sudo apt-get install -y clang-5.0 clang++-5.0
     sudo apt-get install -y unzip


### PR DESCRIPTION
This change does not let the script error out while doing sudo apt-get update. i was trying to build airsim and my sudo apt-get update was returning with a 
"Some packages installed, some packages not found" that was not related to the Airsim build at all, and the setup.sh script stopped. I think other people might hve problem building airsim if their sudo apt-get update has some not found packages. Hence I've put a clause for the script to not error out only when the sudo apt-get update command is called.

The exact error/warning message out of my sudo apt-get update was:

```
E: Failed to fetch http://ppa.launchpad.net/mc3man/trusty-media/ubuntu/dists/xenial/main/binary-amd64/Packages  404  Not Found
W: Some index files failed to download. They have been ignored, or old ones used instead.
```

I think other people might have similar problems too. I was able to successfully build airsim after this file change.