### PR TITLE
setSegmentationId Iterator changed dict to list

### DIFF
--- a/Unity/UnityDemo/Assets/AirSimAssets/Scripts/HUD/CameraFiltersScript.cs
+++ b/Unity/UnityDemo/Assets/AirSimAssets/Scripts/HUD/CameraFiltersScript.cs
@@ -1,8 +1,10 @@
 ﻿using UnityEngine;
 using UnityEngine.Rendering;
 using System.Collections.Generic;
+using System.IO;
 
 namespace AirSimUnity {
+
     /*
      * MonoBehaviour class that is attached to cameras in the scene.
      * Used for applying image filters based on settings.json or Image request by the client to record the data.
@@ -20,6 +22,8 @@ namespace AirSimUnity {
         private static Dictionary<string, int> segmentationIds = new Dictionary<string, int>();
 
         private void Start() {
+
+
             myCamera = GetComponent<Camera>();
             var renderers = FindObjectsOfType<Renderer>();
             var mpb = new MaterialPropertyBlock();
@@ -59,15 +63,18 @@ namespace AirSimUnity {
         }
 
         public static bool SetSegmentationId(string objectName, int segmentationId, bool isNameRegex) {
+            List<string> keyList = new List<string>(segmentationIds.Keys);
+
             if (isNameRegex) {
                 bool isValueSet = false;
-                foreach (string s in segmentationIds.Keys) {
+                foreach (string s in keyList) {
                     if (!s.Contains(objectName)) {
                         continue;
                     }
-                    segmentationIds[objectName] = segmentationId;
+                    segmentationIds[s] = segmentationId;
                     isValueSet = true;
                 }
+
                 return isValueSet;
             }
 


### PR DESCRIPTION
Hello ,

**Firstly** when we set object segmentationId with Regex there is problem.  Initially **contains** command in C# searching substring this is not regex.

 We can not add or remove items from a dictionary while iterating over them. However I don't understand why you can't simply change a value for an existing key within the foreach loop.

Setting a value in a dictionary updates its internal "version number" - which invalidates the iterator, and any iterator associated with the keys or values collection.

So I add `List<string> keyList = new List<string>(segmentationIds.Keys);` this line and iterate over the list.

**Secondly** there is a logical problem in here.
With regex objectName Ground[\w]* and  if my meshnames are Ground_1, Ground_2 and Ground_3.
Never assign the correct key  to new segmentationID. Always try to change same key. But if objectname changed to iterator key this problem will be solved.
_**objectname = "Ground" and s = "Ground_1"**_
**Old code:** `segmentationIds[objectname] = segmentationId;`
**New code:** `segmentationIds[s] = segmentationId;`

Sincerely
