### PR TITLE
Unity `SetSegmentationID` API BugFix - Iterating on the Dictionary

### DIFF
--- a/Unity/UnityDemo/Assets/AirSimAssets/Scripts/HUD/CameraFiltersScript.cs
+++ b/Unity/UnityDemo/Assets/AirSimAssets/Scripts/HUD/CameraFiltersScript.cs
@@ -59,9 +59,10 @@ namespace AirSimUnity {
         }
 
         public static bool SetSegmentationId(string objectName, int segmentationId, bool isNameRegex) {
-            if (isNameRegex) {
+            List<string> keyList = new List<string>(segmentationIds.Keys); 
+            if (isNameRegex) {isNameRegex
                 bool isValueSet = false;
-                foreach (string s in segmentationIds.Keys) {
+                foreach (string s in keylist) {
                     if (!s.Contains(objectName)) {
                         continue;
                     }


### PR DESCRIPTION
Hi,
When I use `SetSegmentationID` API  from python client with using `client.simSetSegmentationID` with `Regex=True`, Python  is freezing. I tracked the code and I found it: **AirSim/Unity/UnityDemo/Assets/AirSimAssets/Scripts/HUD/CameraFiltersScript.cs**
The `SetSegmentationId` function is wrong. It try to iterate over the dictionary and also try to set a value in same dictionary. This is wrong for C#. Please look at the: 
[Editing Dictionary Values in a foreach loop](https://stackoverflow.com/questions/1070766/editing-dictionary-values-in-a-foreach-loop)

* OS: Linux and Windows
*AirSim version: 1.2  Python version: 3.6.5 
#1737 