### PR TITLE
Add Unity Linux specific data recorder changes

### DIFF
--- a/Unity/README.md
+++ b/Unity/README.md
@@ -75,7 +75,7 @@ Keyboard control is not currently available for drone flight.
 * Changing camera views:    
 Keys `0`, `1`, `2`, `3` are used to toggle windows of different camera views.
 * Recording simulation data:    
-Press *Record* button(Red button) located at the right bottom corner of the screen, to toggle recording of the simulation data. The recorded data can be found at `Documents\AirSim\(Date of recording)`
+Press *Record* button(Red button) located at the right bottom corner of the screen, to toggle recording of the simulation data. The recorded data can be found at `Documents\AirSim\(Date of recording)` on Windows and `~/Documents/AirSim/(Date of recording)` on Linux.
 ## Building Custom Environments For AirSim
 To use environments other than `UnityDemo`, follow the instructions written [here](../docs/custom_unity_environments.md)
 ## Cross-Compiling to Linux

--- a/Unity/UnityDemo/Assets/AirSimAssets/Scripts/Utilities/DataRecorder.cs
+++ b/Unity/UnityDemo/Assets/AirSimAssets/Scripts/Utilities/DataRecorder.cs
@@ -37,11 +37,19 @@ namespace AirSimUnity {
         public DataRecorder() {
             isDrone = true;
             count = 0;
-            docsLocation = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments) + "/AirSim/";
+            docsLocation = IsLinux ? "/Documents/AirSim/" : "/AirSim/";
+            docsLocation = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments) + docsLocation;
         }
 
         public void IsDrone(bool isDrone) {
             this.isDrone = isDrone;
+        }
+
+        public static bool IsLinux {
+            get {
+                int p = (int)Environment.OSVersion.Platform;
+                return (p == 4) || (p == 6) || (p == 128);
+            }
         }
 
         //Start the thread to dequeue the capture data and save them in a folder.
@@ -57,12 +65,14 @@ namespace AirSimUnity {
                 Directory.CreateDirectory(folderLocation);
             }
 
-            imagesLocation = folderLocation + "\\images";
+            imagesLocation = IsLinux ? "/images" : "\\images";
+            imagesLocation = folderLocation + imagesLocation;
             if (!Directory.Exists(imagesLocation)) {
                 Directory.CreateDirectory(imagesLocation);
             }
 
-            fileName = folderLocation + "\\airsim_rec.txt";
+            fileName = IsLinux ? "/airsim_rec.txt" : "\\airsim_rec.txt";
+            fileName = folderLocation + fileName;
             dataWriter = new StreamWriter(File.Open(fileName, FileMode.OpenOrCreate, FileAccess.Write));
             string heading;
             if (isDrone) {
@@ -115,7 +125,11 @@ namespace AirSimUnity {
                         data.carData.gear, imageName));
                 }
 
-                imageName = string.Format("{0}\\{1}", imagesLocation, imageName);
+                if (IsLinux) {
+                    imageName = string.Format("{0}/{1}", imagesLocation, imageName);
+                } else {
+                    imageName = string.Format("{0}\\{1}", imagesLocation, imageName);
+                }
 
                 File.WriteAllBytes(imageName, data.image);
             }


### PR DESCRIPTION
Adds check for running platform and adjusts the storage for data recording results.
It stores images and ground truth in the default settings.json location ~/Documents/AirSim/* with the proper forward slashes on Linux. 
Documentation was updated as well.