### PR TITLE
SetSegmentationID assining wrong key

### DIFF
--- a/Unity/UnityDemo/Assets/AirSimAssets/Scripts/HUD/CameraFiltersScript.cs
+++ b/Unity/UnityDemo/Assets/AirSimAssets/Scripts/HUD/CameraFiltersScript.cs
@@ -1,8 +1,10 @@
 ﻿using UnityEngine;
 using UnityEngine.Rendering;
 using System.Collections.Generic;
+using System.IO;
 
 namespace AirSimUnity {
+
     /*
      * MonoBehaviour class that is attached to cameras in the scene.
      * Used for applying image filters based on settings.json or Image request by the client to record the data.
@@ -20,6 +22,8 @@ namespace AirSimUnity {
         private static Dictionary<string, int> segmentationIds = new Dictionary<string, int>();
 
         private void Start() {
+
+
             myCamera = GetComponent<Camera>();
             var renderers = FindObjectsOfType<Renderer>();
             var mpb = new MaterialPropertyBlock();
@@ -59,15 +63,18 @@ namespace AirSimUnity {
         }
 
         public static bool SetSegmentationId(string objectName, int segmentationId, bool isNameRegex) {
+            List<string> keyList = new List<string>(segmentationIds.Keys);
+
             if (isNameRegex) {
                 bool isValueSet = false;
-                foreach (string s in segmentationIds.Keys) {
+                foreach (string s in keyList) {
                     if (!s.Contains(objectName)) {
                         continue;
                     }
-                    segmentationIds[objectName] = segmentationId;
+                    segmentationIds[s] = segmentationId;
                     isValueSet = true;
                 }
+
                 return isValueSet;
             }
 

--- a/Unity/UnityDemo/Assets/AirSimAssets/Scripts/HUD/CameraFiltersScript.cs
+++ b/Unity/UnityDemo/Assets/AirSimAssets/Scripts/HUD/CameraFiltersScript.cs
@@ -1,10 +1,8 @@
 ﻿using UnityEngine;
 using UnityEngine.Rendering;
 using System.Collections.Generic;
-using System.IO;
 
 namespace AirSimUnity {
-
     /*
      * MonoBehaviour class that is attached to cameras in the scene.
      * Used for applying image filters based on settings.json or Image request by the client to record the data.
@@ -22,8 +20,6 @@ namespace AirSimUnity {
         private static Dictionary<string, int> segmentationIds = new Dictionary<string, int>();
 
         private void Start() {
-
-
             myCamera = GetComponent<Camera>();
             var renderers = FindObjectsOfType<Renderer>();
             var mpb = new MaterialPropertyBlock();
@@ -63,18 +59,16 @@ namespace AirSimUnity {
         }
 
         public static bool SetSegmentationId(string objectName, int segmentationId, bool isNameRegex) {
-            List<string> keyList = new List<string>(segmentationIds.Keys);
-
-            if (isNameRegex) {
+            List<string> keyList = new List<string>(segmentationIds.Keys); 
+            if (isNameRegex) {isNameRegex
                 bool isValueSet = false;
-                foreach (string s in keyList) {
+                foreach (string s in keylist) {
                     if (!s.Contains(objectName)) {
                         continue;
                     }
                     segmentationIds[s] = segmentationId;
                     isValueSet = true;
                 }
-
                 return isValueSet;
             }
 


### PR DESCRIPTION
Hello,

If I want to change segmentationId with regex there is logical problem.
First contains is not regex.

Second for example myRegex = Ground*
Contains command match some index but assingn wrong key.

If code change like below assign correct indices.

**Oldcode:** segmentationIds[objectName] = segmentationId;
**Newcode:** segmentationIds[s] = segmentationId;