### PR TITLE
added stalebot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,23 @@
+
+#Number of days of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 30
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - bug
+  - doc update
+  - high-priority
+  - pinned
+  - Great Item
+  - fix proposed
+  - osx
+  - ue4.21
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
Stalebot is an automoderator that will mark inactive issues as stale and close them accordingly. Currently it is set to mark issues as stale after 60 days, and close them 30 days after they are marked.