### PR TITLE
Fix auto-exposure settings

### DIFF
--- a/Unreal/Plugins/AirSim/Source/PIPCamera.cpp
+++ b/Unreal/Plugins/AirSim/Source/PIPCamera.cpp
@@ -313,25 +313,55 @@ msr::airlib::Pose APIPCamera::getPose() const
 void APIPCamera::updateCameraPostProcessingSetting(FPostProcessSettings& obj, const CaptureSetting& setting)
 {
     if (!std::isnan(setting.motion_blur_amount))
+    {
+        obj.bOverride_MotionBlurAmount = 1;
         obj.MotionBlurAmount = setting.motion_blur_amount;
+    }
     if (setting.auto_exposure_method >= 0)
-        obj.AutoExposureMethod = Utils::toEnum<EAutoExposureMethod>(setting.auto_exposure_method);       
+    {
+        obj.bOverride_AutoExposureMethod = 1;
+        obj.AutoExposureMethod = Utils::toEnum<EAutoExposureMethod>(setting.auto_exposure_method);
+    }
     if (!std::isnan(setting.auto_exposure_speed))
+    {
+        obj.bOverride_AutoExposureSpeedDown = 1;
         obj.AutoExposureSpeedDown = obj.AutoExposureSpeedUp = setting.auto_exposure_speed;
+    }
     if (!std::isnan(setting.auto_exposure_max_brightness))
+    {
+        obj.bOverride_AutoExposureMaxBrightness = 1;
         obj.AutoExposureMaxBrightness = setting.auto_exposure_max_brightness;
+    }
     if (!std::isnan(setting.auto_exposure_min_brightness))
+    {
+        obj.bOverride_AutoExposureMinBrightness = 1;
         obj.AutoExposureMinBrightness = setting.auto_exposure_min_brightness;
+    }
     if (!std::isnan(setting.auto_exposure_bias))
+    {
+        obj.bOverride_AutoExposureBias = 1;
         obj.AutoExposureBias = setting.auto_exposure_bias;
+    }
     if (!std::isnan(setting.auto_exposure_low_percent))
-        obj.AutoExposureLowPercent = setting.auto_exposure_low_percent;        
+    {
+        obj.bOverride_AutoExposureLowPercent = 1;
+        obj.AutoExposureLowPercent = setting.auto_exposure_low_percent;
+    }
     if (!std::isnan(setting.auto_exposure_high_percent))
-        obj.AutoExposureHighPercent = setting.auto_exposure_high_percent;    
+    {
+        obj.bOverride_AutoExposureHighPercent = 1;
+        obj.AutoExposureHighPercent = setting.auto_exposure_high_percent;
+    }
     if (!std::isnan(setting.auto_exposure_histogram_log_min))
-        obj.HistogramLogMin = setting.auto_exposure_histogram_log_min;    
+    {
+        obj.bOverride_HistogramLogMin = 1;
+        obj.HistogramLogMin = setting.auto_exposure_histogram_log_min;
+    }
     if (!std::isnan(setting.auto_exposure_histogram_log_max))
-        obj.HistogramLogMax = setting.auto_exposure_histogram_log_max;  
+    {
+        obj.bOverride_HistogramLogMax = 1;
+        obj.HistogramLogMax = setting.auto_exposure_histogram_log_max;
+    }
 }
 
 void APIPCamera::setNoiseMaterial(int image_type, UObject* outer, FPostProcessSettings& obj, const NoiseSetting& settings)


### PR DESCRIPTION
This PR basically implements @michael-fonder's suggestion in this comment https://github.com/Microsoft/AirSim/issues/1033#issuecomment-385999993 to enable auto-exposure settings in the PIPCamera blueprint, but in code.
 
The auto-exposure settings do not have any effect on the actual images (as reported in #1033, https://github.com/Microsoft/AirSim/issues/352#issuecomment-316530128, https://github.com/Microsoft/AirSim/issues/1144, https://github.com/Microsoft/AirSim/issues/1415#issuecomment-438111256) coz the params are not being updated in unreal camera component's post process settings object, *unless* all these `bOverride_X` for every `X` parameter are set to 1. 
These can be found in the [FPostProcessSettings](http://api.unrealengine.com/INT/API/Runtime/Engine/Engine/FPostProcessSettings/index.html) docs (search for "bOverride_" in that page)

I am not sure if there's a better way to do this, instead of setting `bOverride_X = 1` for every param