### PR TITLE
Fix LogViewer so it can handle mavlink2 messages.

### DIFF
--- a/LogViewer/LogViewer/LogViewer.csproj
+++ b/LogViewer/LogViewer/LogViewer.csproj
@@ -33,7 +33,7 @@
     <SuiteName>PX4 Log Viewer</SuiteName>
     <CreateWebPageOnPublish>true</CreateWebPageOnPublish>
     <WebPage>publish.htm</WebPage>
-    <ApplicationRevision>46</ApplicationRevision>
+    <ApplicationRevision>48</ApplicationRevision>
     <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <PublishWizardCompleted>true</PublishWizardCompleted>


### PR DESCRIPTION
LogViewer was not working because it couldn't handle mavlink2 protocol.  This fixes it so it can see mavlink2 messages from PX4 drones.