### PR TITLE
Fix missing regex support in SetSegmentationId for Unity

### DIFF
--- a/Unity/UnityDemo/Assets/AirSimAssets/Scripts/HUD/CameraFiltersScript.cs
+++ b/Unity/UnityDemo/Assets/AirSimAssets/Scripts/HUD/CameraFiltersScript.cs
@@ -66,7 +66,7 @@ namespace AirSimUnity {
                     if (!s.Contains(objectName)) {
                         continue;
                     }
-                    segmentationIds[objectName] = segmentationId;
+                    segmentationIds[s] = segmentationId;
                     isValueSet = true;
                 }
                 return isValueSet;

--- a/Unity/UnityDemo/Assets/AirSimAssets/Scripts/HUD/CameraFiltersScript.cs
+++ b/Unity/UnityDemo/Assets/AirSimAssets/Scripts/HUD/CameraFiltersScript.cs
@@ -1,6 +1,7 @@
 ﻿using UnityEngine;
 using UnityEngine.Rendering;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 
 namespace AirSimUnity {
     /*
@@ -63,7 +64,7 @@ namespace AirSimUnity {
             if (isNameRegex) {
                 bool isValueSet = false;
                 foreach (string s in keyList) {
-                    if (!s.Contains(objectName)) {
+                    if (!Regex.IsMatch(s, objectName)) {
                         continue;
                     }
                     segmentationIds[s] = segmentationId;


### PR DESCRIPTION
This PR follows #1748 regarding the SetSegmentationId method is not working properly if `isNameRegex` is set `True` in Unity. First commit fixes the key error in dict assign and the second commit implements missing regex support.