### PR TITLE
Updated Unity build.sh for Mac

### DIFF
--- a/Unity/build.sh
+++ b/Unity/build.sh
@@ -11,7 +11,12 @@ fi
 cd linux-build;
 export CC="clang-5.0"
 export CXX="clang++-5.0"
-CMAKE="$(readlink -f ../../cmake_build/bin/cmake)"
+
+if [ "$(uname)" == "Darwin" ]; then
+    CMAKE="$(greadlink -f ../../cmake_build/bin/cmake)"
+else
+    CMAKE="$(readlink -f ../../cmake_build/bin/cmake)"
+fi
 
 "$CMAKE" ../../cmake ../AirLibWrapper/AirsimWrapper;
 make -j`nproc`;


### PR DESCRIPTION
Needed for Mac, fails otherwise. 