### PR TITLE
Improve simgetimages speed 

### DIFF
--- a/PythonClient/airsim/pfm.py
+++ b/PythonClient/airsim/pfm.py
@@ -49,7 +49,6 @@ def read_pfm(file):
 
     data = np.reshape(data, shape)
     # DEY: I don't know why this was there.
-    #data = np.flipud(data)
     file.close()
     
     return data, scale
@@ -63,8 +62,6 @@ def write_pfm(file, image, scale=1):
 
     if image.dtype.name != 'float32':
         raise Exception('Image dtype must be float32.')
-
-    image = np.flipud(image)
 
     if len(image.shape) == 3 and image.shape[2] == 3: # color image
         color = True

--- a/PythonClient/airsim/utils.py
+++ b/PythonClient/airsim/utils.py
@@ -157,7 +157,6 @@ def read_pfm(file):
 
     data = np.reshape(data, shape)
     # DEY: I don't know why this was there.
-    #data = np.flipud(data)
     file.close()
     
     return data, scale
@@ -172,11 +171,9 @@ def write_pfm(file, image, scale=1):
     if image.dtype.name != 'float32':
         raise Exception('Image dtype must be float32.')
 
-    image = np.flipud(image)
-
     if len(image.shape) == 3 and image.shape[2] == 3: # color image
         color = True
-    elif len(image.shape) == 2 or len(image.shape) == 3 and image.shape[2] == 1: # greyscale
+    elif len(image.shape) == 2 or len(image.shape) == 3 and image.shape[2] == 1: # grayscale
         color = False
     else:
         raise Exception('Image must have H x W x 3, H x W x 1 or H x W dimensions.')
@@ -206,9 +203,9 @@ def write_png(filename, image):
     height = image.shape[0]
 
     # reverse the vertical line order and add null bytes at the start
-    width_byte_4 = width * 4
-    raw_data = b''.join(b'\x00' + buf[span:span + width_byte_4]
-                        for span in range((height - 1) * width_byte_4, -1, - width_byte_4))
+    width_byte_3 = width * 3
+    raw_data = b''.join(b'\x00' + buf[span:span + width_byte_3]
+                        for span in range((height - 1) * width_byte_3, -1, - width_byte_3))
 
     def png_pack(png_tag, data):
         chunk_head = png_tag + data

--- a/PythonClient/car/drive_straight.py
+++ b/PythonClient/car/drive_straight.py
@@ -29,7 +29,6 @@ def get_image():
     image = client.simGetImages([airsim.ImageRequest("0", airsim.ImageType.Scene, False, False)])[0]
     image1d = np.fromstring(image.image_data_uint8, dtype=np.uint8)
     image_rgb = image1d.reshape(image.height, image.width, 3)
-    image_rgb = np.flipud(image_rgb)
     return image_rgb
 
 while (True):
@@ -42,7 +41,6 @@ while (True):
     else:
         car_controls.throttle = 0.0
     
-    #image_buf[0] = get_image()
     #state_buf[0] = np.array([car_controls.steering, car_controls.throttle, car_controls.brake, car_state.speed])
     #model_output = model.predict([image_buf, state_buf])
     #car_controls.steering = float(model_output[0][0])
@@ -51,4 +49,3 @@ while (True):
     print('Sending steering = {0}, throttle = {1}'.format(car_controls.steering, car_controls.throttle))
     
     client.setCarControls(car_controls)
-

--- a/PythonClient/car/drive_straight.py
+++ b/PythonClient/car/drive_straight.py
@@ -28,9 +28,9 @@ state_buf = np.zeros((1,4))
 def get_image():
     image = client.simGetImages([airsim.ImageRequest("0", airsim.ImageType.Scene, False, False)])[0]
     image1d = np.fromstring(image.image_data_uint8, dtype=np.uint8)
-    image_rgba = image1d.reshape(image.height, image.width, 4)
-    image_rgba = np.flipud(image_rgba)
-    return image_rgba[:, :, 0:3]
+    image_rgb = image1d.reshape(image.height, image.width, 3)
+    image_rgb = np.flipud(image_rgb)
+    return image_rgb
 
 while (True):
     car_state = client.getCarState()

--- a/PythonClient/car/hello_car.py
+++ b/PythonClient/car/hello_car.py
@@ -53,7 +53,7 @@ for idx in range(3):
         airsim.ImageRequest("0", airsim.ImageType.DepthVis),  #depth visualization image
         airsim.ImageRequest("1", airsim.ImageType.DepthPerspective, True), #depth in perspective projection
         airsim.ImageRequest("1", airsim.ImageType.Scene), #scene vision image in png format
-        airsim.ImageRequest("1", airsim.ImageType.Scene, False, False)])  #scene vision image in uncompressed RGBA array
+        airsim.ImageRequest("1", airsim.ImageType.Scene, False, False)])  #scene vision image in uncompressed RGB array
     print('Retrieved images: %d', len(responses))
 
     for response in responses:
@@ -69,10 +69,9 @@ for idx in range(3):
         else: #uncompressed array
             print("Type %d, size %d" % (response.image_type, len(response.image_data_uint8)))
             img1d = np.fromstring(response.image_data_uint8, dtype=np.uint8) #get numpy array
-            img_rgba = img1d.reshape(response.height, response.width, 4) #reshape array to 4 channel image array H X W X 4
-            img_rgba = np.flipud(img_rgba) #original image is flipped vertically
-            img_rgba[:,:,1:2] = 100 #just for fun add little bit of green in all pixels
-            airsim.write_png(os.path.normpath(filename + '.greener.png'), img_rgba) #write to png 
+            img_rgb = img1d.reshape(response.height, response.width, 3) #reshape array to 3 channel image array H X W X 3
+            img_rgb = np.flipud(img_rgb) #original image is flipped vertically
+            airsim.write_png(os.path.normpath(filename + '.png'), img_rgb) #write to png 
 
 
 #restore to original state

--- a/PythonClient/car/hello_car.py
+++ b/PythonClient/car/hello_car.py
@@ -1,9 +1,9 @@
-import setup_path 
 import airsim
-
-import time
-import os
+import cv2
 import numpy as np
+import os
+import setup_path 
+import time
 
 # connect to the AirSim simulator 
 client = airsim.CarClient()
@@ -68,11 +68,9 @@ for idx in range(3):
             airsim.write_file(os.path.normpath(filename + '.png'), response.image_data_uint8)
         else: #uncompressed array
             print("Type %d, size %d" % (response.image_type, len(response.image_data_uint8)))
-            img1d = np.fromstring(response.image_data_uint8, dtype=np.uint8) #get numpy array
-            img_rgb = img1d.reshape(response.height, response.width, 3) #reshape array to 3 channel image array H X W X 3
-            img_rgb = np.flipud(img_rgb) #original image is flipped vertically
-            airsim.write_png(os.path.normpath(filename + '.png'), img_rgb) #write to png 
-
+            img1d = np.fromstring(response.image_data_uint8, dtype=np.uint8) # get numpy array
+            img_rgb = img1d.reshape(response.height, response.width, 3) # reshape array to 3 channel image array H X W X 3
+            cv2.imwrite(os.path.normpath(filename + '.png'), img_rgb) # write to png 
 
 #restore to original state
 client.reset()

--- a/PythonClient/car/legacy_hello_car.py
+++ b/PythonClient/car/legacy_hello_car.py
@@ -40,7 +40,7 @@ responses = client.simGetImages([
     ImageRequest(0, airsim.AirSimImageType.DepthVis),  #depth visualiztion image
     ImageRequest(1, airsim.AirSimImageType.DepthPerspective, True), #depth in perspective projection
     ImageRequest(1, airsim.AirSimImageType.Scene), #scene vision image in png format
-    ImageRequest(1, airsim.AirSimImageType.Scene, False, False)])  #scene vision image in uncompressed RGBA array
+    ImageRequest(1, airsim.AirSimImageType.Scene, False, False)])  #scene vision image in uncompressed RGB array
 print('Retrieved images: %d' % len(responses))
 
 tmp_dir = os.path.join(tempfile.gettempdir(), "airsim_drone")
@@ -64,10 +64,9 @@ for idx, response in enumerate(responses):
     else: #uncompressed array
         print("Type %d, size %d" % (response.image_type, len(response.image_data_uint8)))
         img1d = np.fromstring(response.image_data_uint8, dtype=np.uint8) #get numpy array
-        img_rgba = img1d.reshape(response.height, response.width, 4) #reshape array to 4 channel image array H X W X 4
-        img_rgba = np.flipud(img_rgba) #original image is fliped vertically
-        img_rgba[:,:,1:2] = 100 #just for fun add little bit of green in all pixels
-        AirSimClientBase.write_png(os.path.normpath(filename + '.greener.png'), img_rgba) #write to png
+        img_rgb = img1d.reshape(response.height, response.width, 3) #reshape array to 3 channel image array H X W X 3
+        img_rgb = np.flipud(img_rgb) #original image is fliped vertically
+        AirSimClientBase.write_png(os.path.normpath(filename + '.png'), img_rgb) #write to png
 
 AirSimClientBase.wait_key('Press any key to reset to original state')
 

--- a/PythonClient/car/legacy_hello_car.py
+++ b/PythonClient/car/legacy_hello_car.py
@@ -65,7 +65,6 @@ for idx, response in enumerate(responses):
         print("Type %d, size %d" % (response.image_type, len(response.image_data_uint8)))
         img1d = np.fromstring(response.image_data_uint8, dtype=np.uint8) #get numpy array
         img_rgb = img1d.reshape(response.height, response.width, 3) #reshape array to 3 channel image array H X W X 3
-        img_rgb = np.flipud(img_rgb) #original image is fliped vertically
         AirSimClientBase.write_png(os.path.normpath(filename + '.png'), img_rgb) #write to png
 
 AirSimClientBase.wait_key('Press any key to reset to original state')

--- a/PythonClient/car/multi_agent_car.py
+++ b/PythonClient/car/multi_agent_car.py
@@ -91,11 +91,11 @@ for idx in range(3):
     # get camera images from the car
     responses1 = client.simGetImages([
         airsim.ImageRequest("0", airsim.ImageType.DepthVis),  #depth visualization image
-        airsim.ImageRequest("1", airsim.ImageType.Scene, False, False)], "Car1")  #scene vision image in uncompressed RGBA array
+        airsim.ImageRequest("1", airsim.ImageType.Scene, False, False)], "Car1")  #scene vision image in uncompressed RGB array
     print('Car1: Retrieved images: %d' % (len(responses1)))
     responses2 = client.simGetImages([
         airsim.ImageRequest("0", airsim.ImageType.Segmentation),  #depth visualization image
-        airsim.ImageRequest("1", airsim.ImageType.Scene, False, False)], "Car2")  #scene vision image in uncompressed RGBA array
+        airsim.ImageRequest("1", airsim.ImageType.Scene, False, False)], "Car2")  #scene vision image in uncompressed RGB array
     print('Car2: Retrieved images: %d' % (len(responses2)))
 
     for response in responses1 + responses2:
@@ -110,10 +110,9 @@ for idx in range(3):
         else: #uncompressed array
             print("Type %d, size %d" % (response.image_type, len(response.image_data_uint8)))
             img1d = np.fromstring(response.image_data_uint8, dtype=np.uint8) #get numpy array
-            img_rgba = img1d.reshape(response.height, response.width, 4) #reshape array to 4 channel image array H X W X 4
-            img_rgba = np.flipud(img_rgba) #original image is flipped vertically
-            img_rgba[:,:,1:2] = 100 #just for fun add little bit of green in all pixels
-            airsim.write_png(os.path.normpath(filename + '.greener.png'), img_rgba) #write to png 
+            img_rgb = img1d.reshape(response.height, response.width, 3) #reshape array to 3 channel image array H X W X 3
+            img_rgb = np.flipud(img_rgb) #original image is flipped vertically
+            airsim.write_png(os.path.normpath(filename + '.png'), img_rgb) #write to png 
 
 
 #restore to original state

--- a/PythonClient/car/multi_agent_car.py
+++ b/PythonClient/car/multi_agent_car.py
@@ -1,9 +1,9 @@
-import setup_path 
 import airsim
-
-import time
-import os
+import cv2
 import numpy as np
+import os
+import setup_path 
+import time
 
 # Use below in settings.json with blocks environment
 """
@@ -109,11 +109,9 @@ for idx in range(3):
             airsim.write_file(os.path.normpath(filename + '.png'), response.image_data_uint8)
         else: #uncompressed array
             print("Type %d, size %d" % (response.image_type, len(response.image_data_uint8)))
-            img1d = np.fromstring(response.image_data_uint8, dtype=np.uint8) #get numpy array
-            img_rgb = img1d.reshape(response.height, response.width, 3) #reshape array to 3 channel image array H X W X 3
-            img_rgb = np.flipud(img_rgb) #original image is flipped vertically
-            airsim.write_png(os.path.normpath(filename + '.png'), img_rgb) #write to png 
-
+            img1d = np.fromstring(response.image_data_uint8, dtype=np.uint8) # get numpy array
+            img_rgb = img1d.reshape(response.height, response.width, 3) # reshape array to 3 channel image array H X W X 3
+            cv2.imwrite(os.path.normpath(filename + '.png'), img_rgb) # write to png
 
 #restore to original state
 client.reset()

--- a/PythonClient/computer_vision/segmentation.py
+++ b/PythonClient/computer_vision/segmentation.py
@@ -1,10 +1,10 @@
 # In settings.json first activate computer vision mode: 
 # https://github.com/Microsoft/AirSim/blob/master/docs/image_apis.md#computer-vision-mode
 
-import setup_path 
 import airsim
-
+import cv2
 import numpy as np
+import setup_path 
 
 client = airsim.VehicleClient()
 client.confirmConnection()
@@ -55,8 +55,7 @@ for idx, response in enumerate(responses):
         print("Type %d, size %d" % (response.image_type, len(response.image_data_uint8)))
         img1d = np.fromstring(response.image_data_uint8, dtype=np.uint8) #get numpy array
         img_rgb = img1d.reshape(response.height, response.width, 3) #reshape array to 3 channel image array H X W X 3
-        img_rgb = np.flipud(img_rgb) #original image is flipped vertically
-        #airsim.write_png(os.path.normpath(filename + '.numpy.png'), img_rgb) #write to png 
+        # cv2.imwrite(os.path.normpath(filename + '.png'), img_rgb) # write to png
 
         #find unique colors
         print(np.unique(img_rgb[:,:,0], return_counts=True)) #red

--- a/PythonClient/computer_vision/segmentation.py
+++ b/PythonClient/computer_vision/segmentation.py
@@ -54,20 +54,11 @@ for idx, response in enumerate(responses):
     else: #uncompressed array - numpy demo
         print("Type %d, size %d" % (response.image_type, len(response.image_data_uint8)))
         img1d = np.fromstring(response.image_data_uint8, dtype=np.uint8) #get numpy array
-        img_rgba = img1d.reshape(response.height, response.width, 4) #reshape array to 4 channel image array H X W X 4
-        img_rgba = np.flipud(img_rgba) #original image is flipped vertically
-        #airsim.write_png(os.path.normpath(filename + '.numpy.png'), img_rgba) #write to png 
+        img_rgb = img1d.reshape(response.height, response.width, 3) #reshape array to 3 channel image array H X W X 3
+        img_rgb = np.flipud(img_rgb) #original image is flipped vertically
+        #airsim.write_png(os.path.normpath(filename + '.numpy.png'), img_rgb) #write to png 
 
         #find unique colors
-        print(np.unique(img_rgba[:,:,0], return_counts=True)) #red
-        print(np.unique(img_rgba[:,:,1], return_counts=True)) #green
-        print(np.unique(img_rgba[:,:,2], return_counts=True)) #blue  
-        print(np.unique(img_rgba[:,:,3], return_counts=True)) #blue
-
-
-
-
-
-
-
-
+        print(np.unique(img_rgb[:,:,0], return_counts=True)) #red
+        print(np.unique(img_rgb[:,:,1], return_counts=True)) #green
+        print(np.unique(img_rgb[:,:,2], return_counts=True)) #blue  

--- a/PythonClient/imitation_learning/drive_model.py
+++ b/PythonClient/imitation_learning/drive_model.py
@@ -39,8 +39,8 @@ def get_image():
     """
     image_response = client.simGetImages([airsim.ImageRequest("0", airsim.ImageType.Scene, False, False)])[0]
     image1d = np.fromstring(image_response.image_data_uint8, dtype=np.uint8)
-    image_rgba = image1d.reshape(image_response.height, image_response.width, 4)
-    return image_rgba[78:144,27:227,0:3].astype(float)
+    image_rgb = image1d.reshape(image_response.height, image_response.width, 3)
+    return image_rgb[78:144,27:227,0:2].astype(float)
 
 while True:    
     # Update throttle value according to steering angle

--- a/PythonClient/multirotor/hello_drone.py
+++ b/PythonClient/multirotor/hello_drone.py
@@ -5,6 +5,7 @@ import numpy as np
 import os
 import tempfile
 import pprint
+import cv2
 
 # connect to the AirSim simulator
 client = airsim.MultirotorClient()
@@ -59,11 +60,9 @@ for idx, response in enumerate(responses):
         airsim.write_file(os.path.normpath(filename + '.png'), response.image_data_uint8)
     else: #uncompressed array
         print("Type %d, size %d" % (response.image_type, len(response.image_data_uint8)))
-        img1d = np.fromstring(response.image_data_uint8, dtype=np.uint8) #get numpy array
-        img_rgba = img1d.reshape(response.height, response.width, 4) #reshape array to 4 channel image array H X W X 4
-        img_rgba = np.flipud(img_rgba) #original image is flipped vertically
-        img_rgba[:,:,1:2] = 100 #just for fun add little bit of green in all pixels
-        airsim.write_png(os.path.normpath(filename + '.greener.png'), img_rgba) #write to png
+        img1d = np.fromstring(response.image_data_uint8, dtype=np.uint8) # get numpy array
+        img_rgb = img1d.reshape(response.height, response.width, 3) # reshape array to 4 channel image array H X W X 3
+        cv2.imwrite(os.path.normpath(filename + '.png'), img_rgb) # write to png
 
 airsim.wait_key('Press any key to reset to original state')
 

--- a/PythonClient/multirotor/kinect_publisher.py
+++ b/PythonClient/multirotor/kinect_publisher.py
@@ -40,8 +40,8 @@ class KinectPublisher:
 
     def getRGBImage(self,response_rgb):
         img1d = np.fromstring(response_rgb.image_data_uint8, dtype=np.uint8)
-        img_rgba = img1d.reshape(response_rgb.height, response_rgb.width, 4)
-        img_rgb = img_rgba[..., :3][..., ::-1]
+        img_rgb = img1d.reshape(response_rgb.height, response_rgb.width, 3)
+        img_rgb = img_rgb[..., :3][..., ::-1]
         return img_rgb
 
     def enhanceRGB(self,img_rgb):

--- a/PythonClient/multirotor/multi_agent_drone.py
+++ b/PythonClient/multirotor/multi_agent_drone.py
@@ -59,11 +59,11 @@ airsim.wait_key('Press any key to take images')
 # get camera images from the car
 responses1 = client.simGetImages([
     airsim.ImageRequest("0", airsim.ImageType.DepthVis),  #depth visualization image
-    airsim.ImageRequest("1", airsim.ImageType.Scene, False, False)], vehicle_name="Drone1")  #scene vision image in uncompressed RGBA array
+    airsim.ImageRequest("1", airsim.ImageType.Scene, False, False)], vehicle_name="Drone1")  #scene vision image in uncompressed RGB array
 print('Drone1: Retrieved images: %d' % len(responses1))
 responses2 = client.simGetImages([
     airsim.ImageRequest("0", airsim.ImageType.DepthVis),  #depth visualization image
-    airsim.ImageRequest("1", airsim.ImageType.Scene, False, False)], vehicle_name="Drone2")  #scene vision image in uncompressed RGBA array
+    airsim.ImageRequest("1", airsim.ImageType.Scene, False, False)], vehicle_name="Drone2")  #scene vision image in uncompressed RGB array
 print('Drone2: Retrieved images: %d' % len(responses2))
 
 tmp_dir = os.path.join(tempfile.gettempdir(), "airsim_drone")
@@ -87,10 +87,9 @@ for idx, response in enumerate(responses1 + responses2):
     else: #uncompressed array
         print("Type %d, size %d" % (response.image_type, len(response.image_data_uint8)))
         img1d = np.fromstring(response.image_data_uint8, dtype=np.uint8) #get numpy array
-        img_rgba = img1d.reshape(response.height, response.width, 4) #reshape array to 4 channel image array H X W X 4
-        img_rgba = np.flipud(img_rgba) #original image is flipped vertically
-        img_rgba[:,:,1:2] = 100 #just for fun add little bit of green in all pixels
-        airsim.write_png(os.path.normpath(filename + '.greener.png'), img_rgba) #write to png
+        img_rgb = img1d.reshape(response.height, response.width, 3) #reshape array to 3 channel image array H X W X 3
+        img_rgb = np.flipud(img_rgb) #original image is flipped vertically
+        airsim.write_png(os.path.normpath(filename + '.png'), img_rgb) #write to png
 
 airsim.wait_key('Press any key to reset to original state')
 

--- a/PythonClient/multirotor/multi_agent_drone.py
+++ b/PythonClient/multirotor/multi_agent_drone.py
@@ -1,10 +1,10 @@
-import setup_path 
 import airsim
-
+import cv2
 import numpy as np
 import os
-import tempfile
 import pprint
+import setup_path 
+import tempfile
 
 # Use below in settings.json with Blocks environment
 """
@@ -88,8 +88,7 @@ for idx, response in enumerate(responses1 + responses2):
         print("Type %d, size %d" % (response.image_type, len(response.image_data_uint8)))
         img1d = np.fromstring(response.image_data_uint8, dtype=np.uint8) #get numpy array
         img_rgb = img1d.reshape(response.height, response.width, 3) #reshape array to 3 channel image array H X W X 3
-        img_rgb = np.flipud(img_rgb) #original image is flipped vertically
-        airsim.write_png(os.path.normpath(filename + '.png'), img_rgb) #write to png
+        cv2.imwrite(os.path.normpath(filename + '.png'), img_rgb) # write to png
 
 airsim.wait_key('Press any key to reset to original state')
 

--- a/PythonClient/ros/car_image_raw.py
+++ b/PythonClient/ros/car_image_raw.py
@@ -22,21 +22,21 @@ def airpub():
     while not rospy.is_shutdown():
          # get camera images from the car
         responses = client.simGetImages([
-            airsim.ImageRequest("1", airsim.ImageType.Scene, False, False)])  #scene vision image in uncompressed RGBA array
+            airsim.ImageRequest("1", airsim.ImageType.Scene, False, False)])  #scene vision image in uncompressed RGB array
 
         for response in responses:
-            img_rgba_string = response.image_data_uint8
+            img_rgb_string = response.image_data_uint8
 
         # Populate image message
         msg=Image() 
         msg.header.stamp = rospy.Time.now()
         msg.header.frame_id = "frameId"
-        msg.encoding = "rgba8"
+        msg.encoding = "rgb8"
         msg.height = 360  # resolution should match values in settings.json 
         msg.width = 640
-        msg.data = img_rgba_string
+        msg.data = img_rgb_string
         msg.is_bigendian = 0
-        msg.step = msg.width * 4
+        msg.step = msg.width * 3
 
         # log time and size of published image
         rospy.loginfo(len(response.image_data_uint8))

--- a/PythonClient/ros/drone_image_raw.py
+++ b/PythonClient/ros/drone_image_raw.py
@@ -23,21 +23,21 @@ def airpub():
     while not rospy.is_shutdown():
          # get camera images from the car
         responses = client.simGetImages([
-            airsim.ImageRequest("1", airsim.ImageType.Scene, False, False)])  #scene vision image in uncompressed RGBA array
+            airsim.ImageRequest("1", airsim.ImageType.Scene, False, False)])  #scene vision image in uncompressed RGB array
 
         for response in responses:
-            img_rgba_string = response.image_data_uint8
+            img_rgb_string = response.image_data_uint8
 
         # Populate image message
         msg=Image() 
         msg.header.stamp = rospy.Time.now()
         msg.header.frame_id = "frameId"
-        msg.encoding = "rgba8"
+        msg.encoding = "rgb8"
         msg.height = 360  # resolution should match values in settings.json 
         msg.width = 640
-        msg.data = img_rgba_string
+        msg.data = img_rgb_string
         msg.is_bigendian = 0
-        msg.step = msg.width * 4
+        msg.step = msg.width * 3
 
         # log time and size of published image
         rospy.loginfo(len(response.image_data_uint8))

--- a/Unreal/Plugins/AirSim/Source/PIPCamera.h
+++ b/Unreal/Plugins/AirSim/Source/PIPCamera.h
@@ -4,7 +4,7 @@
 #include "Components/SceneCaptureComponent2D.h"
 #include "Camera/CameraActor.h"
 #include "Materials/Material.h"
-
+#include "Runtime/Core/Public/PixelFormat.h"
 #include "common/ImageCaptureBase.hpp"
 #include "common/common_utils/Utils.hpp"
 #include "common/AirSimSettings.hpp"
@@ -65,6 +65,7 @@ private: //members
     FRotator gimbald_rotator_;
     float gimbal_stabilization_;
     const NedTransform* ned_transform_;
+    TMap<int, EPixelFormat> image_type_to_pixel_format_map_;
 
 private: //methods
     typedef common_utils::Utils Utils;
@@ -73,8 +74,8 @@ private: //methods
 
     static unsigned int imageTypeCount();
     void enableCaptureComponent(const ImageType type, bool is_enabled);
-    static void updateCaptureComponentSetting(USceneCaptureComponent2D* capture, UTextureRenderTarget2D* render_target, const CaptureSetting& setting, 
-        const NedTransform& ned_transform);
+    static void updateCaptureComponentSetting(USceneCaptureComponent2D* capture, UTextureRenderTarget2D* render_target, 
+        bool auto_format, const EPixelFormat& pixel_format, const CaptureSetting& setting, const NedTransform& ned_transform);
     void setNoiseMaterial(int image_type, UObject* outer, FPostProcessSettings& obj, const NoiseSetting& settings);
     static void updateCameraPostProcessingSetting(FPostProcessSettings& obj, const CaptureSetting& setting);
     static void updateCameraSetting(UCameraComponent* camera, const CaptureSetting& setting, const NedTransform& ned_transform);

--- a/Unreal/Plugins/AirSim/Source/RenderRequest.cpp
+++ b/Unreal/Plugins/AirSim/Source/RenderRequest.cpp
@@ -112,9 +112,9 @@ void RenderRequest::getScreenshot(std::shared_ptr<RenderParams> params[], std::v
                 else {
                     uint8* ptr = results[i]->image_data_uint8.GetData();
                     for (const auto& item : results[i]->bmp) {
-                        *ptr++ = item.R;
-                        *ptr++ = item.G;
                         *ptr++ = item.B;
+                        *ptr++ = item.G;
+                        *ptr++ = item.R;
                     }
                 }
             }

--- a/Unreal/Plugins/AirSim/Source/RenderRequest.cpp
+++ b/Unreal/Plugins/AirSim/Source/RenderRequest.cpp
@@ -106,7 +106,7 @@ void RenderRequest::getScreenshot(std::shared_ptr<RenderParams> params[], std::v
     for (unsigned int i = 0; i < req_size; ++i) {
         if (!params[i]->pixels_as_float) {
             if (results[i]->width != 0 && results[i]->height != 0) {
-                results[i]->image_data_uint8.SetNumUninitialized(results[i]->width * results[i]->height * 4, false);
+                results[i]->image_data_uint8.SetNumUninitialized(results[i]->width * results[i]->height * 3, false);
                 if (params[i]->compress)
                     UAirBlueprintLib::CompressImageArray(results[i]->width, results[i]->height, results[i]->bmp, results[i]->image_data_uint8);
                 else {
@@ -115,7 +115,6 @@ void RenderRequest::getScreenshot(std::shared_ptr<RenderParams> params[], std::v
                         *ptr++ = item.R;
                         *ptr++ = item.G;
                         *ptr++ = item.B;
-                        *ptr++ = item.A;
                     }
                 }
             }

--- a/docs/image_apis.md
+++ b/docs/image_apis.md
@@ -51,7 +51,7 @@ client = airsim.MultirotorClient()
 responses = client.simGetImages([
     # png format
     airsim.ImageRequest(0, airsim.ImageType.Scene), 
-    # uncompressed RGBA array bytes
+    # uncompressed RGB array bytes
     airsim.ImageRequest(1, airsim.ImageType.Scene, False, False),
     # floating point uncompressed image
     airsim.ImageRequest(1, airsim.ImageType.DepthPlanner, True)])
@@ -61,7 +61,7 @@ responses = client.simGetImages([
 
 #### Using AirSim Images with NumPy
 
-If you plan to use numpy for image manipulation, you should get uncompressed RGBA image and then convert to numpy like this:
+If you plan to use numpy for image manipulation, you should get uncompressed RGB image and then convert to numpy like this:
 
 ```python
 responses = client.simGetImages([ImageRequest("0", airsim.ImageType.Scene, False, False)])
@@ -71,16 +71,13 @@ response = responses[0]
 img1d = np.fromstring(response.image_data_uint8, dtype=np.uint8) 
 
 # reshape array to 4 channel image array H X W X 4
-img_rgba = img1d.reshape(response.height, response.width, 4)  
+img_rgb = img1d.reshape(response.height, response.width, 3)
 
 # original image is fliped vertically
-img_rgba = np.flipud(img_rgba)
-
-# just for fun add little bit of green in all pixels
-img_rgba[:,:,1:2] = 100
+img_rgb = np.flipud(img_rgb)
 
 # write to png 
-airsim.write_png(os.path.normpath(filename + '.greener.png'), img_rgba) 
+airsim.write_png(os.path.normpath(filename + '.png'), img_rgb) 
 ```
 
 #### Quick Tips
@@ -112,7 +109,7 @@ int getStereoAndDepthImages()
     vector<ImageRequest> request = { 
         //png format
         ImageRequest("0", ImageType::Scene),
-        //uncompressed RGBA array bytes
+        //uncompressed RGB array bytes
         ImageRequest("1", ImageType::Scene, false, false),       
         //floating point uncompressed image  
         ImageRequest("1", ImageType::DepthPlanner, true) 
@@ -246,13 +243,13 @@ It is recommended that you request uncompressed image using this API to ensure y
 ```python
 responses = client.simGetImages([ImageRequest(0, AirSimImageType.Segmentation, False, False)])
 img1d = np.fromstring(response.image_data_uint8, dtype=np.uint8) #get numpy array
-img_rgba = img1d.reshape(response.height, response.width, 4) #reshape array to 4 channel image array H X W X 4
-img_rgba = np.flipud(img_rgba) #original image is fliped vertically
+img_rgb = img1d.reshape(response.height, response.width, 3) #reshape array to 3 channel image array H X W X 3
+img_rgb = np.flipud(img_rgb) #original image is fliped vertically
 
 #find unique colors
-print(np.unique(img_rgba[:,:,0], return_counts=True)) #red
-print(np.unique(img_rgba[:,:,1], return_counts=True)) #green
-print(np.unique(img_rgba[:,:,2], return_counts=True)) #blue  
+print(np.unique(img_rgb[:,:,0], return_counts=True)) #red
+print(np.unique(img_rgb[:,:,1], return_counts=True)) #green
+print(np.unique(img_rgb[:,:,2], return_counts=True)) #blue  
 ```
 
 A complete ready-to-run example can be found in [segmentation.py](https://github.com/Microsoft/AirSim/tree/master/PythonClient//computer_vision/segmentation.py).


### PR DESCRIPTION
~(Don't merge until we find the right format for depth)~

This PR improves speed of simgetimages by :
 - changing pixel format to RGBA8 in PIPCamera.cpp following suggestion https://github.com/Microsoft/AirSim/issues/1818, and
- only copying RGB in RenderRequest.cpp in these lines https://github.com/Microsoft/AirSim/blob/master/Unreal/Plugins/AirSim/Source/RenderRequest.cpp#L109-L118
I've made changes from RGBA->RGB in the client side code I could find. 
An added benefit of RGBA -> RGB is that the image responses from the simgetimages() API match the unreal subwindow previews nicely. This has been a complaint by our users in the past, in that the simgetimage() responses tend to be much darker than the preview in the subwindow


Let's talk about RGB first:
- Behind the scenes, Unreal initializes the render target to RGBA16f as can be seen in the engine code [here](https://github.com/EpicGames/UnrealEngine/blob/7d9919ac7bfd80b7483012eab342cb427d60e8c9/Engine/Source/Runtime/Engine/Private/TextureRenderTarget2D.cpp#L27) 

- The suggestion in #1818 works well in that we can initialize it to `EPixelFormat::PF_B8G8R8A8`.   
There's also an `EPixelFormat::PF_R8G8B8A8_UINT`, but trying that makes the engine crash with assert failure in that the requested render target format is not supported.   
Interestingly, `PF_R8G8B8A8` leads to the same assert failure. 
There's no `PF_B8G8R8A8_UINT`, unfortunately.    
Side note: these names are misleading in that BGR is actually RGB - https://answers.unrealengine.com/questions/69615/are-epixelformats-pf-b8g8r8a8-and-pf-r8g8b8a8-flip.html   
Why engine crashes though, is something I am not sure about.    
- Q. We should try to get int8 images / textures? We can hopefully change the scene capture to get rgba int (not float) and then use `PF_R8G8B8A8_UINT`? Although I am not sure if this will help coz the GPU would have the images as floats only. 

Moving on to depth:
- Now, there should be a similar optimization possible for render targets for depth images. As far as I understand, it should be `EPixelFormat::PF_R16F` as alluded by this line https://github.com/Microsoft/AirSim/blob/master/Unreal/Plugins/AirSim/Source/RenderRequest.cpp#L127. However doing so, again leads to engine crashing with assert failure in that the requested render target format is not supported . 
Not completely sure why is that++  
My hunch is this happens coz the capture source is being initialized to [`ESceneCaptureSource::SCS_FinalColorLDR`](https://api.unrealengine.com/INT/API/Runtime/Engine/Engine/ESceneCaptureSource/index.html) for all image types at this line https://github.com/Microsoft/AirSim/blob/master/Unreal/Plugins/AirSim/Source/PIPCamera.cpp#L66. 

- `ESceneCaptureSource::SCS_FinalColorLDR` doesn't seem efficient for depth images. I tried changing it to `ESceneCaptureSource::SCS_SceneDepth`, similarly there's a `ESceneCaptureSource::SCS_Normal` which should be used for the normal image?
Unfortunately, engine crashes yet again with those two options. 

- Anyhow, for now, I have added a placeholder TMap for image_types to pixel_format types. The map is only used for all non depth image types (aka `image_type==0 || image_type==5 || image_type==6 || image_type==7`). 
for depth images, I still call `initautoformat` for now. 

P.S. *Technically*, we should use [`ETextureRenderTargetFormat`](https://api.unrealengine.com/INT/API/Runtime/Engine/Engine/ETextureRenderTargetFormat/index.html), which is the set of EPixelFormats exposed to rendertarget. 
However, the mapping is fairly intuitive from the variable names as can be seen in the engine code [in these lines](https://github.com/EpicGames/UnrealEngine/blob/7d9919ac7bfd80b7483012eab342cb427d60e8c9/Engine/Source/Runtime/Engine/Classes/Engine/TextureRenderTarget2D.h#L44-#L60), so, i am sticking with pixelformat