### PR TITLE
mac code fixes, needed for compile on mac

### DIFF
--- a/Unity/AirLibWrapper/AirsimWrapper/CMakeLists.txt
+++ b/Unity/AirLibWrapper/AirsimWrapper/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.5.0)
 
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set(MACOSX TRUE)
+endif()
 
 find_path(AIRSIM_ROOT NAMES AirSim.sln PATHS ".." "../.." "../../.." "../../../.." "../../../../.." "../../../../../..")
 message(AirSim Root directory: ${AIRSIM_ROOT})
@@ -29,14 +32,27 @@ BuildAirlib()
 BuildAirsimWrapper()
 
 
-###################### Link source files to library ######################################33
-add_library(
-    ${PROJECT_NAME} SHARED
-    ${RPC_LIBRARY_SOURCE_FILES}
-    ${MAVLINK_LIBRARY_SOURCE_FILES}
-    ${AIRLIB_LIBRARY_SOURCE_FILES}
-    ${AIRSIMWRAPPER_LIBRARY_SOURCE_FILES}
+###################### Link source files to library ######################################
+if (${MACOSX})
+	add_library(
+	    ${PROJECT_NAME} MODULE
+	    ${RPC_LIBRARY_SOURCE_FILES}
+	    ${MAVLINK_LIBRARY_SOURCE_FILES}
+	    ${AIRLIB_LIBRARY_SOURCE_FILES}
+	    ${AIRSIMWRAPPER_LIBRARY_SOURCE_FILES}
+	)
+
+	set_target_properties(${PROJECT_NAME} PROPERTIES BUNDLE TRUE)
+else ()
+	add_library(
+	    ${PROJECT_NAME} SHARED
+	    ${RPC_LIBRARY_SOURCE_FILES}
+	    ${MAVLINK_LIBRARY_SOURCE_FILES}
+	    ${AIRLIB_LIBRARY_SOURCE_FILES}
+	    ${AIRSIMWRAPPER_LIBRARY_SOURCE_FILES}
     )
+endif ()
+
 target_link_libraries(${PROJECT_NAME} ${CMAKE_THREAD_LIBS_INIT}  -lstdc++ -lpthread -lboost_filesystem)
 
 

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/AirSimStructs.hpp
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/AirSimStructs.hpp
@@ -103,7 +103,7 @@ namespace AirSimUnity
 	{
 		#ifdef _WIN32
 			_int64 timestamp = 0;
-		#elif __linux__
+		#elif defined(__linux__) || defined(__APPLE__)
 			int64_t timestamp = 0;
 		#endif
 		float pitch = 0, roll = 0, throttle = 0, yaw = 0;
@@ -123,7 +123,7 @@ namespace AirSimUnity
 		float penetration_depth = 0.0f;
 		#ifdef _WIN32
 			_int64 time_stamp = 0;
-		#elif __linux__
+		#elif defined(__linux__) || defined(__APPLE__)
 			int64_t time_stamp = 0;
 		#endif
 		int collision_count = 0;
@@ -173,7 +173,7 @@ namespace AirSimUnity
 		float speed = 0.0f;
 		#ifdef _WIN32
 			__int64 time_stamp = 0;
-		#elif __linux__
+		#elif defined(__linux__) || defined(__APPLE__)
 			int64_t timestamp = 0;
 		#endif
 		

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/Logger.cpp
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/Logger.cpp
@@ -6,7 +6,7 @@
   #define WIN32_LEAN_AND_MEAN // combaseapi.h build break fix  
 	#include <Windows.h>
 	std::ofstream Logger::fileStream;
-#elif __linux__
+#elif defined(__linux__) || defined(__APPLE__)
 	bfs::ofstream Logger::fileStream;
 #endif
 
@@ -38,8 +38,8 @@ Logger* Logger::GetLogger()
 					logger->logFileName = "Logs/WrapperDllLog_" + std::string(buff) + ".txt";
 					fileStream.open(logger->logFileName, std::ios::out);
 				}
-			#elif __linux__
-				if (bfs::create_directory("Logs") || bfs::exists("Logs")) 
+            #elif defined(__linux__) || defined(__APPLE__)
+				if (bfs::create_directory("Logs") || bfs::exists("Logs"))
 				{ 
 					logger = new Logger(); //** pointer to logger set here
 
@@ -66,7 +66,7 @@ Logger* Logger::GetLogger()
 		{
 			#ifdef _WIN32
 				throw std::exception(e.what());
-			#elif __linux__
+			#elif defined(__linux__) || defined(__APPLE__)
 				throw std::exception(e);
 			#endif
 		}
@@ -86,7 +86,7 @@ std::string Logger::GetCurrentDateTime()
 	#ifdef _WIN32
 		char buff[50];
 		ctime_s(buff, 50, &now);
-	#elif __linux__
+	#elif defined(__linux__) || defined(__APPLE__)
 		auto buff = asctime(localtime(&now));
 	#endif
 	

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/Logger.h
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/Logger.h
@@ -2,7 +2,7 @@
 #define LOGGER_FILE
 
 #include <fstream>
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 	#include <boost/filesystem.hpp>
 	#include <boost/filesystem/fstream.hpp>
 	namespace bfs = boost::filesystem;

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/PInvokeWrapper.h
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/PInvokeWrapper.h
@@ -7,7 +7,7 @@
 
 #ifdef _WIN32
 	#define EXPORT __declspec(dllexport)
-#elif __linux__
+#elif defined(__linux__) || defined(__APPLE__)
 	#define EXPORT __attribute__((visibility("default")))
 #endif
 /*

--- a/Unity/build.sh
+++ b/Unity/build.sh
@@ -23,7 +23,12 @@ make -j`nproc`;
 if [ ! -d "../UnityDemo/Assets/Plugins" ]; then
 	mkdir ../ UnityDemo/Assets/Plugins;
 fi
-cp libAirsimWrapper.so ../UnityDemo/Assets/Plugins;
+
+if [ "$(uname)" == "Darwin" ]; then
+	cp AirsimWrapper.bundle ../UnityDemo/Assets/Plugins;
+else
+	cp libAirsimWrapper.so ../UnityDemo/Assets/Plugins;
+fi
 
 cd ..
 if [ -f AirLibWrapper/AirsimWrapper/rpclib.pc.in ]; then


### PR DESCRIPTION
Some smaller code changes, if these are not present, it won't compile because these won't be defined on Mac. 

However I'm uncertain that the change in `PInvokeWrapper.h` is correct, because even though it compiles, haven't yet gotten Unity to recognize the`libAirLibWrapper.a` file.

If you have any additional ideas on what it might be feel free to comment and I'll update.
Everything else seems fine.

Edit: Got it to work now, added some changes. Needed to change some files in the build.sh and cmakelists for the airsimwrapper custom for Mac, building a .bundle file instead of .so.

In general I also updated to the latest LLVM (not the old 5.0, since that one wouldn't build as described in some other issues) let me know if those changes are of interest. 
