### PR TITLE
Add APIs for Barometer, IMU, GPS, Magnetometer, Distance Sensor

### DIFF
--- a/AirLib/include/api/RpcLibAdapatorsBase.hpp
+++ b/AirLib/include/api/RpcLibAdapatorsBase.hpp
@@ -636,7 +636,6 @@ public:
         GnssReport gnss;
         bool is_valid = false;
 
-
         MSGPACK_DEFINE_MAP(time_stamp, gnss, is_valid);
 
         GpsData()

--- a/AirLib/include/api/RpcLibAdapatorsBase.hpp
+++ b/AirLib/include/api/RpcLibAdapatorsBase.hpp
@@ -564,6 +564,35 @@ public:
             return d;
         }
     };
+
+    struct MagnetometerData {
+        msr::airlib::TTimePoint time_stamp;
+        Vector3r magnetic_field_body;
+        std::vector<float> magnetic_field_covariance; // not implemented in MagnetometerBase.hpp
+
+        MSGPACK_DEFINE_MAP(time_stamp, magnetic_field_body, magnetic_field_covariance);
+
+        MagnetometerData()
+        {}
+
+        MagnetometerData(const msr::airlib::MagnetometerBase::Output& s)
+        {
+            time_stamp = s.time_stamp;
+            magnetic_field_body = s.magnetic_field_body;
+            magnetic_field_covariance = s.magnetic_field_covariance;
+        }
+
+        msr::airlib::MagnetometerBase::Output to() const
+        {
+            msr::airlib::MagnetometerBase::Output d;
+
+            d.time_stamp = time_stamp;
+            d.magnetic_field_body = magnetic_field_body.to();
+            d.magnetic_field_covariance = magnetic_field_covariance;
+
+            return d;
+        }
+    };
 };
 
 }} //namespace

--- a/AirLib/include/api/RpcLibAdapatorsBase.hpp
+++ b/AirLib/include/api/RpcLibAdapatorsBase.hpp
@@ -593,6 +593,73 @@ public:
             return d;
         }
     };
+
+    struct GnssReport {
+        GeoPoint geo_point;
+        msr::airlib::real_T eph = 0.0, epv = 0.0; 
+        Vector3r velocity;
+        msr::airlib::GpsBase::GnssFixType fix_type;
+        uint64_t time_utc = 0;
+
+        MSGPACK_DEFINE_MAP(geo_point, eph, epv, velocity, fix_type, time_utc);
+
+        GnssReport()
+        {}
+
+        GnssReport(const msr::airlib::GpsBase::GnssReport& s)
+        {
+            geo_point = s.geo_point;
+            eph = s.eph;
+            epv = s.epv;
+            velocity = s.velocity;
+            fix_type = s.fix_type;
+            time_utc = s.time_utc;
+        }
+
+        msr::airlib::GpsBase::GnssReport to() const
+        {
+            msr::airlib::GpsBase::GnssReport d;
+
+            d.geo_point = geo_point.to();
+            d.eph = eph;
+            d.epv = epv;
+            d.velocity = velocity.to();
+            d.fix_type = fix_type;
+            d.time_utc = time_utc;
+
+            return d;
+        }
+    };
+
+    struct GpsData {
+        msr::airlib::TTimePoint time_stamp;
+        GnssReport gnss;
+        bool is_valid = false;
+
+
+        MSGPACK_DEFINE_MAP(time_stamp, gnss, is_valid);
+
+        GpsData()
+        {}
+
+        GpsData(const msr::airlib::GpsBase::Output& s)
+        {
+            time_stamp = s.time_stamp;
+            gnss = s.gnss;
+            is_valid = s.is_valid;
+        }
+
+        msr::airlib::GpsBase::Output to() const
+        {
+            msr::airlib::GpsBase::Output d;
+
+            d.time_stamp = time_stamp;
+            d.gnss = gnss.to();
+            d.is_valid = is_valid;
+
+            return d;
+        }
+    };
 };
 
 }} //namespace
@@ -601,5 +668,6 @@ MSGPACK_ADD_ENUM(msr::airlib::SafetyEval::SafetyViolationType_);
 MSGPACK_ADD_ENUM(msr::airlib::SafetyEval::ObsAvoidanceStrategy);
 MSGPACK_ADD_ENUM(msr::airlib::ImageCaptureBase::ImageType);
 MSGPACK_ADD_ENUM(msr::airlib::WorldSimApiBase::WeatherParameter);
+MSGPACK_ADD_ENUM(msr::airlib::GpsBase::GnssFixType);
 
 #endif

--- a/AirLib/include/api/RpcLibAdapatorsBase.hpp
+++ b/AirLib/include/api/RpcLibAdapatorsBase.hpp
@@ -532,6 +532,38 @@ public:
             return d;
         }
     };
+
+    struct BarometerData {
+        msr::airlib::TTimePoint time_stamp;
+        float altitude;
+        float pressure;
+        float qnh;
+
+        MSGPACK_DEFINE_MAP(time_stamp, altitude, pressure, qnh);
+
+        BarometerData()
+        {}
+
+        BarometerData(const msr::airlib::BarometerBase::Output& s)
+        {
+            time_stamp = s.time_stamp;
+            altitude = s.altitude;
+            pressure = s.pressure;
+            qnh = s.qnh;
+        }
+
+        msr::airlib::BarometerBase::Output to() const
+        {
+            msr::airlib::BarometerBase::Output d;
+
+            d.time_stamp = time_stamp;
+            d.altitude = altitude;
+            d.pressure = pressure;
+            d.qnh = qnh;
+
+            return d;
+        }
+    };
 };
 
 }} //namespace

--- a/AirLib/include/api/RpcLibAdapatorsBase.hpp
+++ b/AirLib/include/api/RpcLibAdapatorsBase.hpp
@@ -500,6 +500,38 @@ public:
             return d;
         }
     };
+
+    struct ImuData {
+        msr::airlib::TTimePoint time_stamp;
+        Quaternionr orientation;
+        Vector3r angular_velocity;
+        Vector3r linear_acceleration;
+
+        MSGPACK_DEFINE_MAP(time_stamp, orientation, angular_velocity, linear_acceleration);
+
+        ImuData()
+        {}
+
+        ImuData(const msr::airlib::ImuBase::Output& s)
+        {
+            time_stamp = s.time_stamp;
+            orientation = s.orientation;
+            angular_velocity = s.angular_velocity;
+            linear_acceleration = s.linear_acceleration;
+        }
+
+        msr::airlib::ImuBase::Output to() const
+        {
+            msr::airlib::ImuBase::Output d;
+
+            d.time_stamp = time_stamp;
+            d.orientation = orientation.to();
+            d.angular_velocity = angular_velocity.to();
+            d.linear_acceleration = linear_acceleration.to();
+
+            return d;
+        }
+    };
 };
 
 }} //namespace

--- a/AirLib/include/api/RpcLibAdapatorsBase.hpp
+++ b/AirLib/include/api/RpcLibAdapatorsBase.hpp
@@ -535,9 +535,9 @@ public:
 
     struct BarometerData {
         msr::airlib::TTimePoint time_stamp;
-        float altitude;
-        float pressure;
-        float qnh;
+        msr::airlib::real_T altitude;
+        msr::airlib::real_T pressure;
+        msr::airlib::real_T qnh;
 
         MSGPACK_DEFINE_MAP(time_stamp, altitude, pressure, qnh);
 
@@ -656,6 +656,41 @@ public:
             d.time_stamp = time_stamp;
             d.gnss = gnss.to();
             d.is_valid = is_valid;
+
+            return d;
+        }
+    };
+
+    struct DistanceSensorData {
+        msr::airlib::TTimePoint time_stamp;
+        msr::airlib::real_T distance;    //meters
+        msr::airlib::real_T min_distance;//m
+        msr::airlib::real_T max_distance;//m
+        Pose relative_pose;
+
+        MSGPACK_DEFINE_MAP(time_stamp, distance, min_distance, max_distance, relative_pose);
+
+        DistanceSensorData()
+        {}
+
+        DistanceSensorData(const msr::airlib::DistanceBase::Output& s)
+        {
+            time_stamp = s.time_stamp;
+            distance = s.distance;
+            min_distance = s.min_distance;
+            max_distance = s.max_distance;
+            relative_pose = s.relative_pose;
+        }
+
+        msr::airlib::DistanceBase::Output to() const
+        {
+            msr::airlib::DistanceBase::Output d;
+
+            d.time_stamp = time_stamp;
+            d.distance = distance;
+            d.min_distance = min_distance;
+            d.max_distance = max_distance;
+            d.relative_pose = relative_pose.to();
 
             return d;
         }

--- a/AirLib/include/api/RpcLibClientBase.hpp
+++ b/AirLib/include/api/RpcLibClientBase.hpp
@@ -8,6 +8,7 @@
 #include "common/CommonStructs.hpp"
 #include "common/ImageCaptureBase.hpp"
 #include "sensors/imu/ImuBase.hpp"
+#include "sensors/barometer/BarometerBase.hpp"
 #include "physics/Kinematics.hpp"
 #include "physics/Environment.hpp"
 #include "api/WorldSimApiBase.hpp"
@@ -64,6 +65,7 @@ public:
 
     msr::airlib::LidarData getLidarData(const std::string& lidar_name = "", const std::string& vehicle_name = "") const;
 
+    msr::airlib::BarometerBase::Output getBarometerData(const std::string& barometer_name = "", const std::string& vehicle_name = "") const;
     msr::airlib::ImuBase::Output getImuData(const std::string& imu_name = "", const std::string& vehicle_name = "") const;
 
     Pose simGetVehiclePose(const std::string& vehicle_name = "") const;

--- a/AirLib/include/api/RpcLibClientBase.hpp
+++ b/AirLib/include/api/RpcLibClientBase.hpp
@@ -11,6 +11,7 @@
 #include "sensors/barometer/BarometerBase.hpp"
 #include "sensors/magnetometer/MagnetometerBase.hpp"
 #include "sensors/gps/GpsBase.hpp"
+#include "sensors/distance/DistanceBase.hpp"
 #include "physics/Kinematics.hpp"
 #include "physics/Environment.hpp"
 #include "api/WorldSimApiBase.hpp"
@@ -71,6 +72,7 @@ public:
     msr::airlib::BarometerBase::Output getBarometerData(const std::string& barometer_name = "", const std::string& vehicle_name = "") const;
     msr::airlib::MagnetometerBase::Output getMagnetometerData(const std::string& magnetometer_name = "", const std::string& vehicle_name = "") const;
     msr::airlib::GpsBase::Output getGpsData(const std::string& gps_name = "", const std::string& vehicle_name = "") const;
+    msr::airlib::DistanceBase::Output getDistanceSensorData(const std::string& distance_sensor_name = "", const std::string& vehicle_name = "") const;
 
     Pose simGetVehiclePose(const std::string& vehicle_name = "") const;
     void simSetVehiclePose(const Pose& pose, bool ignore_collision, const std::string& vehicle_name = "");

--- a/AirLib/include/api/RpcLibClientBase.hpp
+++ b/AirLib/include/api/RpcLibClientBase.hpp
@@ -10,6 +10,7 @@
 #include "sensors/imu/ImuBase.hpp"
 #include "sensors/barometer/BarometerBase.hpp"
 #include "sensors/magnetometer/MagnetometerBase.hpp"
+#include "sensors/gps/GpsBase.hpp"
 #include "physics/Kinematics.hpp"
 #include "physics/Environment.hpp"
 #include "api/WorldSimApiBase.hpp"
@@ -64,11 +65,12 @@ public:
 
     msr::airlib::GeoPoint getHomeGeoPoint(const std::string& vehicle_name = "") const;
 
+    // sensor APIs
     msr::airlib::LidarData getLidarData(const std::string& lidar_name = "", const std::string& vehicle_name = "") const;
-
     msr::airlib::ImuBase::Output getImuData(const std::string& imu_name = "", const std::string& vehicle_name = "") const;
     msr::airlib::BarometerBase::Output getBarometerData(const std::string& barometer_name = "", const std::string& vehicle_name = "") const;
     msr::airlib::MagnetometerBase::Output getMagnetometerData(const std::string& magnetometer_name = "", const std::string& vehicle_name = "") const;
+    msr::airlib::GpsBase::Output getGpsData(const std::string& gps_name = "", const std::string& vehicle_name = "") const;
 
     Pose simGetVehiclePose(const std::string& vehicle_name = "") const;
     void simSetVehiclePose(const Pose& pose, bool ignore_collision, const std::string& vehicle_name = "");

--- a/AirLib/include/api/RpcLibClientBase.hpp
+++ b/AirLib/include/api/RpcLibClientBase.hpp
@@ -9,6 +9,7 @@
 #include "common/ImageCaptureBase.hpp"
 #include "sensors/imu/ImuBase.hpp"
 #include "sensors/barometer/BarometerBase.hpp"
+#include "sensors/magnetometer/MagnetometerBase.hpp"
 #include "physics/Kinematics.hpp"
 #include "physics/Environment.hpp"
 #include "api/WorldSimApiBase.hpp"
@@ -65,8 +66,9 @@ public:
 
     msr::airlib::LidarData getLidarData(const std::string& lidar_name = "", const std::string& vehicle_name = "") const;
 
-    msr::airlib::BarometerBase::Output getBarometerData(const std::string& barometer_name = "", const std::string& vehicle_name = "") const;
     msr::airlib::ImuBase::Output getImuData(const std::string& imu_name = "", const std::string& vehicle_name = "") const;
+    msr::airlib::BarometerBase::Output getBarometerData(const std::string& barometer_name = "", const std::string& vehicle_name = "") const;
+    msr::airlib::MagnetometerBase::Output getMagnetometerData(const std::string& magnetometer_name = "", const std::string& vehicle_name = "") const;
 
     Pose simGetVehiclePose(const std::string& vehicle_name = "") const;
     void simSetVehiclePose(const Pose& pose, bool ignore_collision, const std::string& vehicle_name = "");

--- a/AirLib/include/api/RpcLibClientBase.hpp
+++ b/AirLib/include/api/RpcLibClientBase.hpp
@@ -7,6 +7,7 @@
 #include "common/Common.hpp"
 #include "common/CommonStructs.hpp"
 #include "common/ImageCaptureBase.hpp"
+#include "sensors/imu/ImuBase.hpp"
 #include "physics/Kinematics.hpp"
 #include "physics/Environment.hpp"
 #include "api/WorldSimApiBase.hpp"
@@ -62,6 +63,8 @@ public:
     msr::airlib::GeoPoint getHomeGeoPoint(const std::string& vehicle_name = "") const;
 
     msr::airlib::LidarData getLidarData(const std::string& lidar_name = "", const std::string& vehicle_name = "") const;
+
+    msr::airlib::ImuBase::Output getImuData(const std::string& imu_name = "", const std::string& vehicle_name = "") const;
 
     Pose simGetVehiclePose(const std::string& vehicle_name = "") const;
     void simSetVehiclePose(const Pose& pose, bool ignore_collision, const std::string& vehicle_name = "");

--- a/AirLib/include/api/VehicleApiBase.hpp
+++ b/AirLib/include/api/VehicleApiBase.hpp
@@ -14,6 +14,7 @@
 #include "sensors/SensorCollection.hpp"
 #include "sensors/lidar/LidarBase.hpp"
 #include "sensors/imu/ImuBase.hpp"
+#include "sensors/barometer/BarometerBase.hpp"
 #include <exception>
 #include <string>
 
@@ -147,6 +148,27 @@ public:
             throw VehicleControllerException(Utils::stringf("No IMU with name %s exist on vehicle", imu_name.c_str()));
 
         return imu->getOutput();
+    }
+
+    // Barometer API
+    virtual BarometerBase::Output getBarometerData(const std::string& barometer_name) const
+    {
+        const BarometerBase* barometer = nullptr;
+
+        uint count_imus = getSensors().size(SensorBase::SensorType::Barometer);
+        for (uint i = 0; i < count_imus; i++)
+        {
+            const BarometerBase* current_barometer = static_cast<const BarometerBase*>(getSensors().getByType(SensorBase::SensorType::Barometer, i));
+            if (current_barometer != nullptr && (current_barometer->getName() == barometer_name || barometer_name == ""))
+            {
+                barometer = current_barometer;
+                break;
+            }
+        }
+        if (barometer == nullptr)
+            throw VehicleControllerException(Utils::stringf("No barometer with name %s exist on vehicle", barometer_name.c_str()));
+
+        return barometer->getOutput();
     }
 
     virtual ~VehicleApiBase() = default;

--- a/AirLib/include/api/VehicleApiBase.hpp
+++ b/AirLib/include/api/VehicleApiBase.hpp
@@ -13,6 +13,7 @@
 #include "common/ImageCaptureBase.hpp"
 #include "sensors/SensorCollection.hpp"
 #include "sensors/lidar/LidarBase.hpp"
+#include "sensors/imu/ImuBase.hpp"
 #include <exception>
 #include <string>
 
@@ -123,6 +124,29 @@ public:
             throw VehicleControllerException(Utils::stringf("No lidar with name %s exist on vehicle", lidar_name.c_str()));
 
         return lidar->getOutput();
+    }
+
+    // IMU API
+    virtual ImuBase::Output getImuData(const std::string& imu_name) const
+    {
+        const ImuBase* imu = nullptr;
+
+        // Find imu with the given name (for empty input name, return the first one found)
+        // Not efficient but should suffice given small number of imus
+        uint count_imus = getSensors().size(SensorBase::SensorType::Imu);
+        for (uint i = 0; i < count_imus; i++)
+        {
+            const ImuBase* current_imu = static_cast<const ImuBase*>(getSensors().getByType(SensorBase::SensorType::Imu, i));
+            if (current_imu != nullptr && (current_imu->getName() == imu_name || imu_name == ""))
+            {
+                imu = current_imu;
+                break;
+            }
+        }
+        if (imu == nullptr)
+            throw VehicleControllerException(Utils::stringf("No IMU with name %s exist on vehicle", imu_name.c_str()));
+
+        return imu->getOutput();
     }
 
     virtual ~VehicleApiBase() = default;

--- a/AirLib/include/api/VehicleApiBase.hpp
+++ b/AirLib/include/api/VehicleApiBase.hpp
@@ -16,6 +16,7 @@
 #include "sensors/imu/ImuBase.hpp"
 #include "sensors/barometer/BarometerBase.hpp"
 #include "sensors/magnetometer/MagnetometerBase.hpp"
+#include "sensors/distance/DistanceBase.hpp"
 #include "sensors/gps/GpsBase.hpp"
 #include <exception>
 #include <string>
@@ -157,8 +158,8 @@ public:
     {
         const BarometerBase* barometer = nullptr;
 
-        uint count_imus = getSensors().size(SensorBase::SensorType::Barometer);
-        for (uint i = 0; i < count_imus; i++)
+        uint count_barometers = getSensors().size(SensorBase::SensorType::Barometer);
+        for (uint i = 0; i < count_barometers; i++)
         {
             const BarometerBase* current_barometer = static_cast<const BarometerBase*>(getSensors().getByType(SensorBase::SensorType::Barometer, i));
             if (current_barometer != nullptr && (current_barometer->getName() == barometer_name || barometer_name == ""))
@@ -178,8 +179,8 @@ public:
     {
         const MagnetometerBase* magnetometer = nullptr;
 
-        uint count_imus = getSensors().size(SensorBase::SensorType::Magnetometer);
-        for (uint i = 0; i < count_imus; i++)
+        uint count_magnetometers = getSensors().size(SensorBase::SensorType::Magnetometer);
+        for (uint i = 0; i < count_magnetometers; i++)
         {
             const MagnetometerBase* current_magnetometer = static_cast<const MagnetometerBase*>(getSensors().getByType(SensorBase::SensorType::Magnetometer, i));
             if (current_magnetometer != nullptr && (current_magnetometer->getName() == magnetometer_name || magnetometer_name == ""))
@@ -194,13 +195,13 @@ public:
         return magnetometer->getOutput();
     }
 
-    // Magnetometer API
+    // Gps API
     virtual GpsBase::Output getGpsData(const std::string& gps_name) const
     {
         const GpsBase* gps = nullptr;
 
-        uint count_imus = getSensors().size(SensorBase::SensorType::Gps);
-        for (uint i = 0; i < count_imus; i++)
+        uint count_gps = getSensors().size(SensorBase::SensorType::Gps);
+        for (uint i = 0; i < count_gps; i++)
         {
             const GpsBase* current_gps = static_cast<const GpsBase*>(getSensors().getByType(SensorBase::SensorType::Gps, i));
             if (current_gps != nullptr && (current_gps->getName() == gps_name || gps_name == ""))
@@ -213,6 +214,27 @@ public:
             throw VehicleControllerException(Utils::stringf("No gps with name %s exist on vehicle", gps_name.c_str()));
 
         return gps->getOutput();
+    }
+
+    // Distance Sensor API
+    virtual DistanceBase::Output getDistanceSensorData(const std::string& distance_sensor_name) const
+    {
+        const DistanceBase* distance_sensor = nullptr;
+
+        uint count_distance_sensors = getSensors().size(SensorBase::SensorType::Distance);
+        for (uint i = 0; i < count_distance_sensors; i++)
+        {
+            const DistanceBase* current_distance_sensor = static_cast<const DistanceBase*>(getSensors().getByType(SensorBase::SensorType::Distance, i));
+            if (current_distance_sensor != nullptr && (current_distance_sensor->getName() == distance_sensor_name || distance_sensor_name == ""))
+            {
+                distance_sensor = current_distance_sensor;
+                break;
+            }
+        }
+        if (distance_sensor == nullptr)
+            throw VehicleControllerException(Utils::stringf("No distance sensor with name %s exist on vehicle", distance_sensor_name.c_str()));
+
+        return distance_sensor->getOutput();
     }
 
     virtual ~VehicleApiBase() = default;

--- a/AirLib/include/api/VehicleApiBase.hpp
+++ b/AirLib/include/api/VehicleApiBase.hpp
@@ -16,6 +16,7 @@
 #include "sensors/imu/ImuBase.hpp"
 #include "sensors/barometer/BarometerBase.hpp"
 #include "sensors/magnetometer/MagnetometerBase.hpp"
+#include "sensors/gps/GpsBase.hpp"
 #include <exception>
 #include <string>
 
@@ -191,6 +192,27 @@ public:
             throw VehicleControllerException(Utils::stringf("No magnetometer with name %s exist on vehicle", magnetometer_name.c_str()));
 
         return magnetometer->getOutput();
+    }
+
+    // Magnetometer API
+    virtual GpsBase::Output getGpsData(const std::string& gps_name) const
+    {
+        const GpsBase* gps = nullptr;
+
+        uint count_imus = getSensors().size(SensorBase::SensorType::Gps);
+        for (uint i = 0; i < count_imus; i++)
+        {
+            const GpsBase* current_gps = static_cast<const GpsBase*>(getSensors().getByType(SensorBase::SensorType::Gps, i));
+            if (current_gps != nullptr && (current_gps->getName() == gps_name || gps_name == ""))
+            {
+                gps = current_gps;
+                break;
+            }
+        }
+        if (gps == nullptr)
+            throw VehicleControllerException(Utils::stringf("No gps with name %s exist on vehicle", gps_name.c_str()));
+
+        return gps->getOutput();
     }
 
     virtual ~VehicleApiBase() = default;

--- a/AirLib/include/api/VehicleApiBase.hpp
+++ b/AirLib/include/api/VehicleApiBase.hpp
@@ -15,6 +15,7 @@
 #include "sensors/lidar/LidarBase.hpp"
 #include "sensors/imu/ImuBase.hpp"
 #include "sensors/barometer/BarometerBase.hpp"
+#include "sensors/magnetometer/MagnetometerBase.hpp"
 #include <exception>
 #include <string>
 
@@ -169,6 +170,27 @@ public:
             throw VehicleControllerException(Utils::stringf("No barometer with name %s exist on vehicle", barometer_name.c_str()));
 
         return barometer->getOutput();
+    }
+
+    // Magnetometer API
+    virtual MagnetometerBase::Output getMagnetometerData(const std::string& magnetometer_name) const
+    {
+        const MagnetometerBase* magnetometer = nullptr;
+
+        uint count_imus = getSensors().size(SensorBase::SensorType::Magnetometer);
+        for (uint i = 0; i < count_imus; i++)
+        {
+            const MagnetometerBase* current_magnetometer = static_cast<const MagnetometerBase*>(getSensors().getByType(SensorBase::SensorType::Magnetometer, i));
+            if (current_magnetometer != nullptr && (current_magnetometer->getName() == magnetometer_name || magnetometer_name == ""))
+            {
+                magnetometer = current_magnetometer;
+                break;
+            }
+        }
+        if (magnetometer == nullptr)
+            throw VehicleControllerException(Utils::stringf("No magnetometer with name %s exist on vehicle", magnetometer_name.c_str()));
+
+        return magnetometer->getOutput();
     }
 
     virtual ~VehicleApiBase() = default;

--- a/AirLib/include/sensors/barometer/BarometerBase.hpp
+++ b/AirLib/include/sensors/barometer/BarometerBase.hpp
@@ -18,6 +18,7 @@ public:
 
 public: //types
     struct Output { //same fields as ROS message
+        TTimePoint time_stamp;
         real_T altitude;    //meters
         real_T pressure;    //Pascal
         real_T qnh;

--- a/AirLib/include/sensors/barometer/BarometerSimple.hpp
+++ b/AirLib/include/sensors/barometer/BarometerSimple.hpp
@@ -93,6 +93,8 @@ private: //methods
         output.altitude = (1 - pow(pressure / EarthUtils::SeaLevelPressure, 0.190284f)) * 145366.45f * 0.3048f;
         output.qnh = params_.qnh;
 
+        output.time_stamp = clock()->nowNanos();
+
         return output;
     }
     

--- a/AirLib/include/sensors/distance/DistanceBase.hpp
+++ b/AirLib/include/sensors/distance/DistanceBase.hpp
@@ -18,6 +18,7 @@ public:
 
 public: //types
     struct Output { //same fields as ROS message
+        TTimePoint time_stamp;
         real_T distance;    //meters
         real_T min_distance;//m
         real_T max_distance;//m

--- a/AirLib/include/sensors/distance/DistanceSimple.hpp
+++ b/AirLib/include/sensors/distance/DistanceSimple.hpp
@@ -88,6 +88,7 @@ private: //methods
         output.min_distance = params_.min_distance;
         output.max_distance = params_.max_distance;
         output.relative_pose = params_.relative_pose;
+        output.time_stamp = clock()->nowNanos();
 
         return output;
     }

--- a/AirLib/include/sensors/gps/GpsBase.hpp
+++ b/AirLib/include/sensors/gps/GpsBase.hpp
@@ -74,6 +74,7 @@ public: //types
         GNSS_FIX_2D_FIX = 2,
         GNSS_FIX_3D_FIX = 3
     };
+
     struct GnssReport {
         GeoPoint geo_point;
         real_T eph, epv;    //GPS HDOP/VDOP horizontal/vertical dilution of position (unitless), 0-100%
@@ -90,6 +91,7 @@ public: //types
     };
 
     struct Output {	//same as ROS message
+        TTimePoint time_stamp;
         GnssReport gnss;
         bool is_valid = false;
     };

--- a/AirLib/include/sensors/gps/GpsSimple.hpp
+++ b/AirLib/include/sensors/gps/GpsSimple.hpp
@@ -86,6 +86,8 @@ private:
             : output.gnss.eph <= params_.eph_min_2d ? GnssFixType::GNSS_FIX_2D_FIX
             : GnssFixType::GNSS_FIX_NO_FIX;
 
+        output.time_stamp = clock()->nowNanos();
+
         delay_line_.push_back(output);
     }
 

--- a/AirLib/include/sensors/imu/ImuBase.hpp
+++ b/AirLib/include/sensors/imu/ImuBase.hpp
@@ -19,6 +19,7 @@ public:
 public: //types
     struct Output {	//structure is same as ROS IMU message
         EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        TTimePoint time_stamp; 
         Quaternionr orientation;
         Vector3r angular_velocity;
         Vector3r linear_acceleration;

--- a/AirLib/include/sensors/imu/ImuSimple.hpp
+++ b/AirLib/include/sensors/imu/ImuSimple.hpp
@@ -65,6 +65,8 @@ private: //methods
         addNoise(output.linear_acceleration, output.angular_velocity);
         // TODO: Add noise in orientation?
 
+        output.time_stamp = clock()->nowNanos();
+
         setOutput(output);
     }
 

--- a/AirLib/include/sensors/magnetometer/MagnetometerBase.hpp
+++ b/AirLib/include/sensors/magnetometer/MagnetometerBase.hpp
@@ -18,6 +18,7 @@ public:
 
 public: //types
     struct Output { //same fields as ROS message
+        TTimePoint time_stamp;
         Vector3r magnetic_field_body; //in Gauss
         vector<real_T> magnetic_field_covariance; //9 elements 3x3 matrix    
     };

--- a/AirLib/include/sensors/magnetometer/MagnetometerSimple.hpp
+++ b/AirLib/include/sensors/magnetometer/MagnetometerSimple.hpp
@@ -95,6 +95,9 @@ private: //methods
             + noise_vec_.next()
             + bias_vec_;
 
+        // todo output.magnetic_field_covariance ? 
+        output.time_stamp = clock()->nowNanos();
+
         return output;
     }
 

--- a/AirLib/src/api/RpcLibClientBase.cpp
+++ b/AirLib/src/api/RpcLibClientBase.cpp
@@ -184,6 +184,11 @@ msr::airlib::GpsBase::Output RpcLibClientBase::getGpsData(const std::string& gps
     return pimpl_->client.call("getGpsData", gps_name, vehicle_name).as<RpcLibAdapatorsBase::GpsData>().to();
 }
 
+msr::airlib::DistanceBase::Output RpcLibClientBase::getDistanceSensorData(const std::string& distance_sensor_name, const std::string& vehicle_name) const
+{
+    return pimpl_->client.call("getDistanceSensorData", distance_sensor_name, vehicle_name).as<RpcLibAdapatorsBase::DistanceSensorData>().to();
+}
+
 bool RpcLibClientBase::simSetSegmentationObjectID(const std::string& mesh_name, int object_id, bool is_name_regex)
 {
     return pimpl_->client.call("simSetSegmentationObjectID", mesh_name, object_id, is_name_regex).as<bool>();

--- a/AirLib/src/api/RpcLibClientBase.cpp
+++ b/AirLib/src/api/RpcLibClientBase.cpp
@@ -169,6 +169,11 @@ msr::airlib::ImuBase::Output RpcLibClientBase::getImuData(const std::string& imu
     return pimpl_->client.call("getImuData", imu_name, vehicle_name).as<RpcLibAdapatorsBase::ImuData>().to();
 }
 
+msr::airlib::BarometerBase::Output RpcLibClientBase::getBarometerData(const std::string& barometer_name, const std::string& vehicle_name) const
+{
+    return pimpl_->client.call("getBarometerData", barometer_name, vehicle_name).as<RpcLibAdapatorsBase::BarometerData>().to();
+}
+
 bool RpcLibClientBase::simSetSegmentationObjectID(const std::string& mesh_name, int object_id, bool is_name_regex)
 {
     return pimpl_->client.call("simSetSegmentationObjectID", mesh_name, object_id, is_name_regex).as<bool>();

--- a/AirLib/src/api/RpcLibClientBase.cpp
+++ b/AirLib/src/api/RpcLibClientBase.cpp
@@ -179,6 +179,11 @@ msr::airlib::MagnetometerBase::Output RpcLibClientBase::getMagnetometerData(cons
     return pimpl_->client.call("getMagnetometerData", magnetometer_name, vehicle_name).as<RpcLibAdapatorsBase::MagnetometerData>().to();
 }
 
+msr::airlib::GpsBase::Output RpcLibClientBase::getGpsData(const std::string& gps_name, const std::string& vehicle_name) const
+{
+    return pimpl_->client.call("getGpsData", gps_name, vehicle_name).as<RpcLibAdapatorsBase::GpsData>().to();
+}
+
 bool RpcLibClientBase::simSetSegmentationObjectID(const std::string& mesh_name, int object_id, bool is_name_regex)
 {
     return pimpl_->client.call("simSetSegmentationObjectID", mesh_name, object_id, is_name_regex).as<bool>();

--- a/AirLib/src/api/RpcLibClientBase.cpp
+++ b/AirLib/src/api/RpcLibClientBase.cpp
@@ -164,6 +164,11 @@ msr::airlib::LidarData RpcLibClientBase::getLidarData(const std::string& lidar_n
     return pimpl_->client.call("getLidarData", lidar_name, vehicle_name).as<RpcLibAdapatorsBase::LidarData>().to();
 }
 
+msr::airlib::ImuBase::Output RpcLibClientBase::getImuData(const std::string& imu_name, const std::string& vehicle_name) const
+{
+    return pimpl_->client.call("getImuData", imu_name, vehicle_name).as<RpcLibAdapatorsBase::ImuData>().to();
+}
+
 bool RpcLibClientBase::simSetSegmentationObjectID(const std::string& mesh_name, int object_id, bool is_name_regex)
 {
     return pimpl_->client.call("simSetSegmentationObjectID", mesh_name, object_id, is_name_regex).as<bool>();

--- a/AirLib/src/api/RpcLibClientBase.cpp
+++ b/AirLib/src/api/RpcLibClientBase.cpp
@@ -174,6 +174,11 @@ msr::airlib::BarometerBase::Output RpcLibClientBase::getBarometerData(const std:
     return pimpl_->client.call("getBarometerData", barometer_name, vehicle_name).as<RpcLibAdapatorsBase::BarometerData>().to();
 }
 
+msr::airlib::MagnetometerBase::Output RpcLibClientBase::getMagnetometerData(const std::string& magnetometer_name, const std::string& vehicle_name) const
+{
+    return pimpl_->client.call("getMagnetometerData", magnetometer_name, vehicle_name).as<RpcLibAdapatorsBase::MagnetometerData>().to();
+}
+
 bool RpcLibClientBase::simSetSegmentationObjectID(const std::string& mesh_name, int object_id, bool is_name_regex)
 {
     return pimpl_->client.call("simSetSegmentationObjectID", mesh_name, object_id, is_name_regex).as<bool>();

--- a/AirLib/src/api/RpcLibServerBase.cpp
+++ b/AirLib/src/api/RpcLibServerBase.cpp
@@ -155,6 +155,11 @@ RpcLibServerBase::RpcLibServerBase(ApiProvider* api_provider, const std::string&
         return RpcLibAdapatorsBase::LidarData(lidar_data);
     });
 
+    pimpl_->server.bind("getImuData", [&](const std::string& imu_name, const std::string& vehicle_name) -> RpcLibAdapatorsBase::ImuData {
+        const auto& imu_data = getVehicleApi(vehicle_name)->getImuData(imu_name);
+        return RpcLibAdapatorsBase::ImuData(imu_data);
+    });
+
     pimpl_->server.bind("simGetCameraInfo", [&](const std::string& camera_name, const std::string& vehicle_name) -> RpcLibAdapatorsBase::CameraInfo {
         const auto& camera_info = getVehicleSimApi(vehicle_name)->getCameraInfo(camera_name);
         return RpcLibAdapatorsBase::CameraInfo(camera_info);

--- a/AirLib/src/api/RpcLibServerBase.cpp
+++ b/AirLib/src/api/RpcLibServerBase.cpp
@@ -175,6 +175,11 @@ RpcLibServerBase::RpcLibServerBase(ApiProvider* api_provider, const std::string&
         return RpcLibAdapatorsBase::GpsData(gps_data);
     });
 
+    pimpl_->server.bind("getDistanceSensorData", [&](const std::string& distance_sensor_name, const std::string& vehicle_name) -> RpcLibAdapatorsBase::DistanceSensorData {
+        const auto& distance_sensor_data = getVehicleApi(vehicle_name)->getDistanceSensorData(distance_sensor_name);
+        return RpcLibAdapatorsBase::DistanceSensorData(distance_sensor_data);
+    });
+
     pimpl_->server.bind("simGetCameraInfo", [&](const std::string& camera_name, const std::string& vehicle_name) -> RpcLibAdapatorsBase::CameraInfo {
         const auto& camera_info = getVehicleSimApi(vehicle_name)->getCameraInfo(camera_name);
         return RpcLibAdapatorsBase::CameraInfo(camera_info);

--- a/AirLib/src/api/RpcLibServerBase.cpp
+++ b/AirLib/src/api/RpcLibServerBase.cpp
@@ -170,6 +170,11 @@ RpcLibServerBase::RpcLibServerBase(ApiProvider* api_provider, const std::string&
         return RpcLibAdapatorsBase::MagnetometerData(magnetometer_data);
     });
 
+    pimpl_->server.bind("getGpsData", [&](const std::string& gps_name, const std::string& vehicle_name) -> RpcLibAdapatorsBase::GpsData {
+        const auto& gps_data = getVehicleApi(vehicle_name)->getGpsData(gps_name);
+        return RpcLibAdapatorsBase::GpsData(gps_data);
+    });
+
     pimpl_->server.bind("simGetCameraInfo", [&](const std::string& camera_name, const std::string& vehicle_name) -> RpcLibAdapatorsBase::CameraInfo {
         const auto& camera_info = getVehicleSimApi(vehicle_name)->getCameraInfo(camera_name);
         return RpcLibAdapatorsBase::CameraInfo(camera_info);

--- a/AirLib/src/api/RpcLibServerBase.cpp
+++ b/AirLib/src/api/RpcLibServerBase.cpp
@@ -160,6 +160,16 @@ RpcLibServerBase::RpcLibServerBase(ApiProvider* api_provider, const std::string&
         return RpcLibAdapatorsBase::ImuData(imu_data);
     });
 
+    pimpl_->server.bind("getBarometerData", [&](const std::string& barometer_name, const std::string& vehicle_name) -> RpcLibAdapatorsBase::BarometerData {
+        const auto& barometer_data = getVehicleApi(vehicle_name)->getBarometerData(barometer_name);
+        return RpcLibAdapatorsBase::BarometerData(barometer_data);
+    });
+
+    pimpl_->server.bind("getMagnetometerData", [&](const std::string& magnetometer_name, const std::string& vehicle_name) -> RpcLibAdapatorsBase::MagnetometerData {
+        const auto& magnetometer_data = getVehicleApi(vehicle_name)->getMagnetometerData(magnetometer_name);
+        return RpcLibAdapatorsBase::MagnetometerData(magnetometer_data);
+    });
+
     pimpl_->server.bind("simGetCameraInfo", [&](const std::string& camera_name, const std::string& vehicle_name) -> RpcLibAdapatorsBase::CameraInfo {
         const auto& camera_info = getVehicleSimApi(vehicle_name)->getCameraInfo(camera_name);
         return RpcLibAdapatorsBase::CameraInfo(camera_info);

--- a/HelloDrone/main.cpp
+++ b/HelloDrone/main.cpp
@@ -14,8 +14,6 @@ STRICT_MODE_ON
 #include <iostream>
 #include <chrono>
 
-
-
 int main() 
 {
     using namespace msr::airlib;
@@ -61,6 +59,36 @@ int main()
         std::cout << "Press Enter to arm the drone" << std::endl; std::cin.get();
         client.enableApiControl(true);
         client.armDisarm(true);
+
+        auto barometer_data = client.getBarometerData();
+        std::cout << "Barometer data \n" 
+            << "barometer_data.time_stamp \t" << barometer_data.time_stamp << std::endl
+            << "barometer_data.altitude \t" << barometer_data.altitude << std::endl
+            << "barometer_data.pressure \t" << barometer_data.pressure << std::endl
+            << "barometer_data.qnh \t" << barometer_data.qnh << std::endl;
+
+        auto imu_data = client.getImuData();
+        std::cout << "IMU data \n" 
+            << "imu_data.time_stamp \t" << imu_data.time_stamp << std::endl 
+            << "imu_data.orientation \t" << imu_data.orientation << std::endl 
+            << "imu_data.angular_velocity \t" << imu_data.angular_velocity << std::endl 
+            << "imu_data.linear_acceleration \t" << imu_data.linear_acceleration << std::endl;
+
+        auto gps_data = client.getGpsData();
+        std::cout << "GPS data \n" 
+            << "gps_data.time_stamp \t" << gps_data.time_stamp << std::endl 
+            << "gps_data.gnss.time_utc \t" << gps_data.gnss.time_utc << std::endl
+            << "gps_data.gnss.geo_point \t" << gps_data.gnss.geo_point << std::endl
+            << "gps_data.gnss.eph \t" << gps_data.gnss.eph << std::endl
+            << "gps_data.gnss.epv \t" << gps_data.gnss.epv << std::endl
+            << "gps_data.gnss.velocity \t" << gps_data.gnss.velocity << std::endl
+            << "gps_data.gnss.fix_type \t" << gps_data.gnss.fix_type << std::endl;
+
+        auto magnetometer_data = client.getMagnetometerData();
+        std::cout << "Magnetometer data \n" 
+            << "magnetometer_data.time_stamp \t" << magnetometer_data.time_stamp << std::endl 
+            << "magnetometer_data.magnetic_field_body \t" << magnetometer_data.magnetic_field_body << std::endl; 
+            // << "magnetometer_data.magnetic_field_covariance" << magnetometer_data.magnetic_field_covariance // not implemented in sensor
 
         std::cout << "Press Enter to takeoff" << std::endl; std::cin.get();
         float takeoffTimeout = 5; 

--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -140,6 +140,9 @@ class VehicleClient:
         return EnvironmentState.from_msgpack(env_state)
     simGetGroundTruthEnvironment.__annotations__ = {'return': EnvironmentState}
 
+    def getImuData(self, imu_name = '', vehicle_name = ''):
+        return ImuData.from_msgpack(self.client.call('getImuData', imu_name, vehicle_name))
+
     # lidar APIs
     def getLidarData(self, lidar_name = '', vehicle_name = ''):
         return LidarData.from_msgpack(self.client.call('getLidarData', lidar_name, vehicle_name))

--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -140,13 +140,19 @@ class VehicleClient:
         return EnvironmentState.from_msgpack(env_state)
     simGetGroundTruthEnvironment.__annotations__ = {'return': EnvironmentState}
 
+    # sensor APIs
     def getImuData(self, imu_name = '', vehicle_name = ''):
         return ImuData.from_msgpack(self.client.call('getImuData', imu_name, vehicle_name))
 
     def getBarometerData(self, barometer_name = '', vehicle_name = ''):
-        return ImuData.from_msgpack(self.client.call('getBarometerData', barometer_name, vehicle_name))
+        return BarometerData.from_msgpack(self.client.call('getBarometerData', barometer_name, vehicle_name))
 
-    # lidar APIs
+    def getMagnetometerData(self, magnetometer_name = '', vehicle_name = ''):
+        return MagnetometerData.from_msgpack(self.client.call('getMagnetometerData', magnetometer_name, vehicle_name))
+
+    def getGpsData(self, gps_name = '', vehicle_name = ''):
+        return GpsData.from_msgpack(self.client.call('getGpsData', gps_name, vehicle_name))
+
     def getLidarData(self, lidar_name = '', vehicle_name = ''):
         return LidarData.from_msgpack(self.client.call('getLidarData', lidar_name, vehicle_name))
 

--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -153,6 +153,9 @@ class VehicleClient:
     def getGpsData(self, gps_name = '', vehicle_name = ''):
         return GpsData.from_msgpack(self.client.call('getGpsData', gps_name, vehicle_name))
 
+    def getDistanceSensorData(self, lidar_name = '', vehicle_name = ''):
+        return DistanceSensorData.from_msgpack(self.client.call('getDistanceSensorData', distance_sensor_name, vehicle_name))
+
     def getLidarData(self, lidar_name = '', vehicle_name = ''):
         return LidarData.from_msgpack(self.client.call('getLidarData', lidar_name, vehicle_name))
 

--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -143,6 +143,9 @@ class VehicleClient:
     def getImuData(self, imu_name = '', vehicle_name = ''):
         return ImuData.from_msgpack(self.client.call('getImuData', imu_name, vehicle_name))
 
+    def getBarometerData(self, barometer_name = '', vehicle_name = ''):
+        return ImuData.from_msgpack(self.client.call('getBarometerData', barometer_name, vehicle_name))
+
     # lidar APIs
     def getLidarData(self, lidar_name = '', vehicle_name = ''):
         return LidarData.from_msgpack(self.client.call('getLidarData', lidar_name, vehicle_name))

--- a/PythonClient/airsim/types.py
+++ b/PythonClient/airsim/types.py
@@ -373,3 +373,22 @@ class Magnetometer(MsgpackMixin):
     time_stamp = np.uint64(0)
     magnetic_field_body = Vector3r()
     magnetic_field_covariance = 0.0
+
+class GnssFixType(MsgpackMixin):
+    GNSS_FIX_NO_FIX = 0
+    GNSS_FIX_TIME_ONLY = 1
+    GNSS_FIX_2D_FIX = 2
+    GNSS_FIX_3D_FIX = 3
+
+class GnssReport(MsgpackMixin): 
+    geo_point = GeoPoint();
+    eph = 0.0
+    epv = 0.0;
+    velocity = Vector3r();
+    fix_type = GnssFixType();
+    time_utc = np.uint64(0);
+
+class GpsData(MsgpackMixin):
+    time_stamp = np.uint64(0)
+    gnss = GnssReport()
+    is_valid = False

--- a/PythonClient/airsim/types.py
+++ b/PythonClient/airsim/types.py
@@ -368,3 +368,8 @@ class BarometerData(MsgpackMixin):
     altitude = Quaternionr()
     pressure = Vector3r()
     qnh = Vector3r()
+
+class Magnetometer(MsgpackMixin):
+    time_stamp = np.uint64(0)
+    magnetic_field_body = Vector3r()
+    magnetic_field_covariance = 0.0

--- a/PythonClient/airsim/types.py
+++ b/PythonClient/airsim/types.py
@@ -356,3 +356,9 @@ class LidarData(MsgpackMixin):
     point_cloud = 0.0
     time_stamp = np.uint64(0)
     pose = Pose()
+
+class ImuData(MsgpackMixin):
+    time_stamp = np.uint64(0)
+    orientation = Quaternionr()
+    angular_velocity = Vector3r()
+    linear_acceleration = Vector3r()

--- a/PythonClient/airsim/types.py
+++ b/PythonClient/airsim/types.py
@@ -362,3 +362,9 @@ class ImuData(MsgpackMixin):
     orientation = Quaternionr()
     angular_velocity = Vector3r()
     linear_acceleration = Vector3r()
+
+class BarometerData(MsgpackMixin):
+    time_stamp = np.uint64(0)
+    altitude = Quaternionr()
+    pressure = Vector3r()
+    qnh = Vector3r()

--- a/PythonClient/airsim/types.py
+++ b/PythonClient/airsim/types.py
@@ -369,7 +369,7 @@ class BarometerData(MsgpackMixin):
     pressure = Vector3r()
     qnh = Vector3r()
 
-class Magnetometer(MsgpackMixin):
+class MagnetometerData(MsgpackMixin):
     time_stamp = np.uint64(0)
     magnetic_field_body = Vector3r()
     magnetic_field_covariance = 0.0

--- a/PythonClient/multirotor/hello_drone.py
+++ b/PythonClient/multirotor/hello_drone.py
@@ -17,6 +17,22 @@ state = client.getMultirotorState()
 s = pprint.pformat(state)
 print("state: %s" % s)
 
+imu_data = client.getImuData()
+s = pprint.pformat(imu_data)
+print("imu_data: %s" % s)
+
+barometer_data = client.getBarometerData()
+s = pprint.pformat(barometer_data)
+print("barometer_data: %s" % s)
+
+magnetometer_data = client.getMagnetometerData()
+s = pprint.pformat(magnetometer_data)
+print("magnetometer_data: %s" % s)
+
+gps_data = client.getGpsData()
+s = pprint.pformat(gps_data)
+print("gps_data: %s" % s)
+
 airsim.wait_key('Press any key to takeoff')
 client.takeoffAsync().join()
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Cars in AirSim
 
 ## What's New
 
+* [Added sensor APIs for Barometer, IMU, GPS, Magnetometer, Distance Sensor](https://microsoft.github.io/AirSim/docs/sensors.md) 
 * Added support for [docker in ubuntu](https://microsoft.github.io/AirSim/docs/docker_ubuntu) 
 * Added Weather Effects and [APIs](https://microsoft.github.io/AirSim/docs/apis#weather-apis)
 * Added [Time of Day API](https://microsoft.github.io/AirSim/docs/apis#time-of-day-api)

--- a/docs/docker_ubuntu.md
+++ b/docs/docker_ubuntu.md
@@ -1,4 +1,5 @@
 # AirSim on Docker in Linux
+We've two options for docker. You can either build an image for running [airsim linux binaries](#binaries), or for compiling Unreal Engine + AirSim [from source](#source)
 
 ## Binaries
 #### Requirements:
@@ -46,7 +47,7 @@ You can download it by running
         ```
         $ ./run_airsim_image_binary.sh Blocks/Blocks.sh -- headless
         ```
-- [Specifying a `settings.json`](https://github.com/madratman/AirSim/blob/PR/docker_ubuntu/docs/docker_ubuntu.md#airsim_binary-docker-image)
+- [Specifying a `settings.json`](https://github.com/Microsoft/AirSim/blob/master/docs/docker_ubuntu.md#airsim_binary-docker-image)
 
 ## Source
 #### Requirements:
@@ -96,7 +97,7 @@ You can download it by running
 * Inside the container, you can see `UnrealEngine` and `AirSim` under `/home/ue4`. 
 * Start unreal engine inside the container:   
    `ue4@HOSTMACHINE:~$ /home/ue4/UnrealEngine/Engine/Binaries/Linux/UE4Editor`
-* [Specifying an airsim settings.json](https://github.com/madratman/AirSim/blob/PR/docker_ubuntu/docs/docker_ubuntu.md#airsim_source-docker-image)
+* [Specifying an airsim settings.json](https://github.com/Microsoft/AirSim/blob/master/docs/docker_ubuntu.md#airsim_source-docker-image)
 * Continue with [AirSim's Linux docs](https://microsoft.github.io/AirSim/docs/build_linux/#build-unreal-environment). 
 
 #### [Misc] Packaging Unreal Environments in `airsim_source` containers

--- a/docs/sensors.md
+++ b/docs/sensors.md
@@ -1,65 +1,74 @@
 # Sensors in AirSim
 
-AirSim currently supports the following sensors:
+AirSim currently supports the following sensors.    
+Each sensor is associated with a integer enum specifying its sensor type.
+
 * Camera
-* Imu
-* Magnetometer
-* Gps
-* Barometer
-* Distance
-* Lidar
+* Barometer = 1
+* Imu = 2
+* Gps = 3
+* Magnetometer = 4
+* Distance Sensor = 5 
+* Lidar = 6
 
-The cameras are currently configured a bit differently than other sensors. The camera configuration and apis are covered in other documents, e.g., [general settings](settings.md) and [image API](image_apis.md).
-
-This document focuses on the configuration of other sensors.
+**Note** :  Cameras are configured differently than the other sensors and do not have an enum associated with them.    Look at [general settings](settings.md) and [image API](image_apis.md) for camera config and API. 
 
 ## Default sensors
 
-If not sensors are specified in the settings json, the the following sensors are enabled by default based on the simmode.
+If no sensors are specified in the `settings json`, the the following sensors are enabled by default based on the sim mode.
 
 ### Multirotor
 * Imu
 * Magnetometer
 * Gps
 * Barometer
+
 ### Car
 * Gps
+
 ### ComputerVision
 * None
 
-Please see 'createDefaultSensorSettings' method in [AirSimSettings.hpp](https://github.com/Microsoft/AirSim/tree/master/AirLib//include/common/) 
+Behind the scenes, 'createDefaultSensorSettings' method in [AirSimSettings.hpp](https://github.com/Microsoft/AirSim/blob/master/AirLib/include/common/AirSimSettings.hpp) which sets up the above sensors with their default parameters, depending on the sim mode specified in the `settings.json` file. 
 
-## Configuration of Default Sensor list
+## Configuring the default sensor list
 
-A default sensor list can be configured in settings json.
-e.g.,
-```
-    "DefaultSensors": {
-        "Barometer": {
-             "SensorType": 1,
-             "Enabled" : true
-        },
-        "Gps": {
-             "SensorType": 1,
-             "Enabled" : true
-        },
-        "Lidar1": { 
-             "SensorType": 6,
-             "Enabled" : true,
-             "NumberOfChannels": 16,
-             "PointsPerSecond": 10000
-        },
-        "Lidar2": { 
-             "SensorType": 6,
-             "Enabled" : false,
-             "NumberOfChannels": 4,
-             "PointsPerSecond": 10000
-        }
+The default sensor list can be configured in settings json:
+
+```JSON
+"DefaultSensors": {
+    "Barometer": {
+         "SensorType": 1,
+         "Enabled" : true
     },
+    "Imu": {
+         "SensorType": 2,
+         "Enabled" : true
+    },
+    "Gps": {
+         "SensorType": 3,
+         "Enabled" : true
+    },
+    "Magnetometer": {
+         "SensorType": 4,
+         "Enabled" : true
+    },
+    "Distance": {
+         "SensorType": 5,
+         "Enabled" : true
+    },
+    "Lidar2": { 
+         "SensorType": 6,
+         "Enabled" : true,
+         "NumberOfChannels": 4,
+         "PointsPerSecond": 10000
+    }
+},
 ```
 
-## Configuration of vehicle specific sensor settings
+## Configuring vehicle-specific sensor list
 
+If a vehicle provides its sensor list, it **must** provide the whole list. Selective add/remove/update of the default sensor list is **NOT** supported.   
 A vehicle specific sensor list can be specified in the vehicle settings part of the json.
 e.g.,
 
@@ -67,7 +76,7 @@ e.g.,
     "Vehicles": {
 
         "Drone1": {
-            "VehicleType": "simpleflight",
+            "VehicleType": "SimpleFlight",
             "AutoCreate": true,
             ...
             "Sensors": {
@@ -92,29 +101,69 @@ e.g.,
    }
 ```
 
-If a vehicle provides its sensor list, it must provide the whole list. Selective add/remove/update of the default sensor list is NOT supported.
-
-## Configuration of sensor settings
-
-### Shared settings
-There are two shared settings:
-* SensorType
-        An integer representing the sensor-type [SensorBase.hpp](https://github.com/Microsoft/AirSim/tree/master/AirLib//include/sensors/)
-```
-        enum class SensorType : uint {
-            Barometer = 1,
-            Imu = 2,
-            Gps = 3,
-            Magnetometer = 4,
-            Distance = 5,
-            Lidar = 6
-        };
-```
-* Enabled
-    Boolean
-
 ### Sensor specific settings
-Each sensor-type has its own set of settings as well. Please see [lidar](lidar.md) for example of Lidar specific settings.
+Each sensor-type has its own set of settings as well.   
+Please see [lidar](lidar.md) for example of Lidar specific settings.
 
-## Sensor APIs
-Each sensor-type has its own set of APIs currently. Please see [lidar](lidar.md) for example of Lidar specific APIs.
+## Sensor APIs 
+Jump straight to [`hello_drone.py`](https://github.com/Microsoft/AirSim/blob/master/PythonClient/multirotor/hello_drone.py) or [`hello_drone.cpp`](https://github.com/Microsoft/AirSim/blob/master/HelloDrone/main.cpp) for example usage, or see follow below for the full API. 
+
+- Barometer
+
+    C++
+    ```cpp
+    msr::airlib::BarometerBase::Output getBarometerData(const std::string& barometer_name, const std::string& vehicle_name);
+    ```
+
+    Python
+    ```python
+    barometer_data = getBarometerData(barometer_name = "", vehicle_name = "")
+    ```
+
+- IMU
+
+C++
+    ```cpp
+    msr::airlib::ImuBase::Output getImuData(const std::string& imu_name = "", const std::string& vehicle_name = "");
+    ```
+
+    Python
+    ```python
+    imu_data = getImuData(imu_name = "", vehicle_name = "")
+    ```
+
+- GPS
+
+    C++
+    ```cpp
+    msr::airlib::GpsBase::Output getGpsData(const std::string& gps_name = "", const std::string& vehicle_name = "");
+    ```
+    Python
+    ```python
+    gps_data = getGpsData(gps_name = "", vehicle_name = "")
+    ```
+
+- Magnetometer
+
+    C++
+    ```cpp
+    msr::airlib::MagnetometerBase::Output getMagnetometerData(const std::string& magnetometer_name = "", const std::string& vehicle_name = "");
+    ```
+    Python
+    ```python
+    magnetometer_data = getMagnetometerData(magnetometer_name = "", vehicle_name = "")
+    ```
+
+- Distance sensor
+
+    C++
+    ```cpp
+    msr::airlib::DistanceBase::Output getDistanceSensorData(const std::string& distance_sensor_name = "", const std::string& vehicle_name = "");
+    ```
+    Python
+    ```python
+    distance_sensor_name = getDistanceSensorData(distance_sensor_name = "", vehicle_name = "")
+    ```
+
+- Lidar   
+    See [lidar](lidar.md) for Lidar API.


### PR DESCRIPTION
We don't have APIs for Baro, IMU, GPS, and Magnetometer, which has been pointed out in multiple issues. 
We do have a GPS state in `msr::airlib::MultirotorState`'s `GeoPoint gps_location` member [here](https://github.com/Microsoft/AirSim/blob/123bbd6d6416bbe98e775101ba8ebcb5ccbf8501/AirLib/include/vehicles/multirotor/api/MultirotorRpcLibAdapators.hpp#L46), however it isn't in the car state. ( i think that is not using the sensor output but an ned<->gps conversion?).
I think sensors should have their own APIs with their corresponding time stamps, and this PR aims to do that for:

- [x] Barometer
- [x] IMU
- [x] GPS
- [x] Magnetometer
- [x] Distance sensor 
- [x] Documentation
