### PR TITLE
Fixed some Steering Wheel & Config Bug.

### DIFF
--- a/AirLib/include/common/AirSimSettings.hpp
+++ b/AirLib/include/common/AirSimSettings.hpp
@@ -708,10 +708,7 @@ private:
         vehicle_setting->is_fpv_vehicle = settings_json.getBool("IsFpvVehicle",
             vehicle_setting->is_fpv_vehicle);
 
-        Settings rc_json;
-        if (settings_json.getChild("RC", rc_json)) {
-            loadRCSetting(simmode_name, rc_json, vehicle_setting->rc);
-        }
+        loadRCSetting(simmode_name, settings_json, vehicle_setting->rc);
 
         vehicle_setting->position = createVectorSetting(settings_json, vehicle_setting->position);
         vehicle_setting->rotation = createRotationSetting(settings_json, vehicle_setting->rotation);

--- a/AirLib/include/common/CommonStructs.hpp
+++ b/AirLib/include/common/CommonStructs.hpp
@@ -269,7 +269,7 @@ struct RCData {
 
     unsigned int getSwitch(uint16_t index) const
     {
-        return switches && (1 << index) ? 1 : 0;
+        return switches & (1 << index) ? 1 : 0;
     }
 
     void add(const RCData& other)

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
@@ -219,6 +219,7 @@ msr::airlib::RCData PawnSimApi::getRCData() const
 {
     joystick_.getJoyStickState(getRemoteControlID(), joystick_state_);
 
+	rc_data_.is_initialized = joystick_state_.is_initialized;
     rc_data_.is_valid = joystick_state_.is_valid;
 
     if (rc_data_.is_valid) {

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
@@ -219,7 +219,7 @@ msr::airlib::RCData PawnSimApi::getRCData() const
 {
     joystick_.getJoyStickState(getRemoteControlID(), joystick_state_);
 
-	rc_data_.is_initialized = joystick_state_.is_initialized;
+    rc_data_.is_initialized = joystick_state_.is_initialized;
     rc_data_.is_valid = joystick_state_.is_valid;
 
     if (rc_data_.is_valid) {


### PR DESCRIPTION
1. Fixed Steering Wheel's Buttons Bug. 
When you press any key on the steering wheel, all keys are recognized as true.
Bit operations are using & instead of &&.

2. Fixed Steering Wheel is not Work.
In file CarPawnSimApi.cpp Line 90 we used the function getRCData() and checked the value of rc_data.is_initialized. However, the value of rc_data.is_initialized is not set in the function getRCData(). Causes rc_data.is_initialized to be in false all the time. So the value of rc_data.is_initialized is always false, and the steering wheel cannot be enabled.

3. Fixed RC failed to read in the configuration file.
At Line 546. The code is repeated. So we mast set RC like this.
```
"RC": {
    "RC": {
        "RemoteControlID": 0,
        "AllowAPIWhenDisconnected": false
    }
}
```