### PR TITLE
Ground Truth aid for Semantic Segmentation of Point Cloud

### DIFF
--- a/AirLib/include/api/RpcLibAdapatorsBase.hpp
+++ b/AirLib/include/api/RpcLibAdapatorsBase.hpp
@@ -471,8 +471,9 @@ public:
         msr::airlib::TTimePoint time_stamp;    // timestamp
         std::vector<float> point_cloud;        // data
         Pose pose;
+		std::vector<std::string> labels;
 
-        MSGPACK_DEFINE_MAP(time_stamp, point_cloud, pose);
+        MSGPACK_DEFINE_MAP(time_stamp, point_cloud, pose, labels);
 
         LidarData()
         {}
@@ -487,6 +488,7 @@ public:
                 point_cloud.push_back(0);
 
             pose = s.pose;
+			labels = s.labels;
         }
 
         msr::airlib::LidarData to() const
@@ -496,6 +498,7 @@ public:
             d.time_stamp = time_stamp;
             d.point_cloud = point_cloud;
             d.pose = pose.to();
+			d.labels = labels;
 
             return d;
         }

--- a/AirLib/include/common/CommonStructs.hpp
+++ b/AirLib/include/common/CommonStructs.hpp
@@ -300,6 +300,8 @@ struct LidarData {
     TTimePoint time_stamp = 0;
     vector<real_T> point_cloud;
     Pose pose;
+    std::vector<std::string> labels;
+
 
     LidarData()
     {}

--- a/AirLib/include/sensors/lidar/LidarBase.hpp
+++ b/AirLib/include/sensors/lidar/LidarBase.hpp
@@ -28,6 +28,7 @@ public: //types
         // - in lidar local NED coordinates
         // - in meters
         vector<real_T> point_cloud;
+		std::vector<std::string> labels;
     };
 
 public:
@@ -38,7 +39,9 @@ public:
 
         reporter.writeValue("Lidar-Timestamp", output_.time_stamp);
         reporter.writeValue("Lidar-NumPoints", static_cast<int>(output_.point_cloud.size() / 3));
-    }
+		reporter.writeValue("Labels-Num", static_cast<int>(output_.labels.size()));
+
+	}
 
     const LidarData& getOutput() const
     {

--- a/AirLib/include/sensors/lidar/LidarSimple.hpp
+++ b/AirLib/include/sensors/lidar/LidarSimple.hpp
@@ -68,15 +68,16 @@ public:
 
 protected:
     virtual void getPointCloud(const Pose& lidar_pose, const Pose& vehicle_pose, 
-        TTimeDelta delta_time, vector<real_T>& point_cloud) = 0;
+        TTimeDelta delta_time, vector<real_T>& point_cloud, std::vector<std::string>& label) = 0;
 
     
 private: //methods
     void updateOutput()
     {
-        TTimeDelta delta_time = clock()->updateSince(last_time_);
+		TTimeDelta delta_time = clock()->updateSince(last_time_);
 
         point_cloud_.clear();
+		label_.clear();
 
         const GroundTruth& ground_truth = getGroundTruth();
 
@@ -92,24 +93,25 @@ private: //methods
         getPointCloud(params_.relative_pose, // relative lidar pose
             ground_truth.kinematics->pose,   // relative vehicle pose
             delta_time, 
-            point_cloud_);
+            point_cloud_,label_);
 
         LidarData output;
         output.point_cloud = point_cloud_;
         output.time_stamp = clock()->nowNanos();
         output.pose = lidar_pose;            
-
-        last_time_ = output.time_stamp;
+		output.labels = label_;
+		last_time_ = output.time_stamp;
 
         setOutput(output);
+
     }
 
 private:
     LidarSimpleParams params_;
     vector<real_T> point_cloud_;
-
     FrequencyLimiter freq_limiter_;
     TTimePoint last_time_;
+	std::vector<std::string> label_; //the labels of the pointcloud
 };
 
 }} //namespace

--- a/PythonClient/airsim/types.py
+++ b/PythonClient/airsim/types.py
@@ -356,7 +356,7 @@ class LidarData(MsgpackMixin):
     point_cloud = 0.0
     time_stamp = np.uint64(0)
     pose = Pose()
-	labels = []
+    labels = []
 
 class ImuData(MsgpackMixin):
     time_stamp = np.uint64(0)

--- a/PythonClient/airsim/types.py
+++ b/PythonClient/airsim/types.py
@@ -356,6 +356,7 @@ class LidarData(MsgpackMixin):
     point_cloud = 0.0
     time_stamp = np.uint64(0)
     pose = Pose()
+	labels = []
 
 class ImuData(MsgpackMixin):
     time_stamp = np.uint64(0)

--- a/Unreal/Plugins/AirSim/Source/UnrealSensors/UnrealLidarSensor.cpp
+++ b/Unreal/Plugins/AirSim/Source/UnrealSensors/UnrealLidarSensor.cpp
@@ -6,181 +6,203 @@
 #include "common/Common.hpp"
 #include "NedTransform.h"
 #include "DrawDebugHelpers.h"
+#include <vector>
+#include <iostream>
+#include <cstring>
+
+
+//lidar return actor variables
+FName actor_temp;
+std::string actor_string;
+
+
 
 // ctor
 UnrealLidarSensor::UnrealLidarSensor(const AirSimSettings::LidarSetting& setting,
-    AActor* actor, const NedTransform* ned_transform)
-    : LidarSimple(setting), actor_(actor), ned_transform_(ned_transform)
+	AActor* actor, const NedTransform* ned_transform)
+	: LidarSimple(setting), actor_(actor), ned_transform_(ned_transform)
 {
-    createLasers();
+	createLasers();
 }
 
 // initializes information based on lidar configuration
 void UnrealLidarSensor::createLasers()
 {
-    msr::airlib::LidarSimpleParams params = getParams();
+	msr::airlib::LidarSimpleParams params = getParams();
 
-    const auto number_of_lasers = params.number_of_channels;
+	const auto number_of_lasers = params.number_of_channels;
 
-    if (number_of_lasers <= 0)
-        return;
+	if (number_of_lasers <= 0)
+		return;
 
-    // calculate verticle angle distance between each laser
-    float delta_angle = 0;
-    if (number_of_lasers > 1)
-        delta_angle = (params.vertical_FOV_upper - (params.vertical_FOV_lower)) /
-            static_cast<float>(number_of_lasers - 1);
+	// calculate verticle angle distance between each laser
+	float delta_angle = 0;
+	if (number_of_lasers > 1)
+		delta_angle = (params.vertical_FOV_upper - (params.vertical_FOV_lower)) /
+		static_cast<float>(number_of_lasers - 1);
 
-    // store vertical angles for each laser
-    laser_angles_.clear();
-    for (auto i = 0u; i < number_of_lasers; ++i)
-    {
-        const float vertical_angle = params.vertical_FOV_upper - static_cast<float>(i) * delta_angle;
-        laser_angles_.emplace_back(vertical_angle);
-    }
+	// store vertical angles for each laser
+	laser_angles_.clear();
+	for (auto i = 0u; i < number_of_lasers; ++i)
+	{
+		const float vertical_angle = params.vertical_FOV_upper - static_cast<float>(i) * delta_angle;
+		laser_angles_.emplace_back(vertical_angle);
+	}
 }
 
 // returns a point-cloud for the tick
 void UnrealLidarSensor::getPointCloud(const msr::airlib::Pose& lidar_pose, const msr::airlib::Pose& vehicle_pose,
-    const msr::airlib::TTimeDelta delta_time, msr::airlib::vector<msr::airlib::real_T>& point_cloud)
+	const msr::airlib::TTimeDelta delta_time, msr::airlib::vector<msr::airlib::real_T>& point_cloud, std::vector<std::string>& labels)
 {
-    point_cloud.clear();
+	point_cloud.clear();
+	labels.clear();
+	
+	msr::airlib::LidarSimpleParams params = getParams();
+	const auto number_of_lasers = params.number_of_channels;
 
-    msr::airlib::LidarSimpleParams params = getParams();
-    const auto number_of_lasers = params.number_of_channels;
+	// cap the points to scan via ray-tracing; this is currently needed for car/Unreal tick scenarios
+	// since SensorBase mechanism uses the elapsed clock time instead of the tick delta-time.
+	constexpr float MAX_POINTS_IN_SCAN = 1e+5f;
+	uint32 total_points_to_scan = FMath::RoundHalfFromZero(params.points_per_second * delta_time);
+	if (total_points_to_scan > MAX_POINTS_IN_SCAN)
+	{
+		total_points_to_scan = MAX_POINTS_IN_SCAN;
+		UAirBlueprintLib::LogMessageString("Lidar: ", "Capping number of points to scan", LogDebugLevel::Failure);
+	}
 
-    // cap the points to scan via ray-tracing; this is currently needed for car/Unreal tick scenarios
-    // since SensorBase mechanism uses the elapsed clock time instead of the tick delta-time.
-    constexpr float MAX_POINTS_IN_SCAN = 1e+5f;
-    uint32 total_points_to_scan = FMath::RoundHalfFromZero(params.points_per_second * delta_time);
-    if (total_points_to_scan > MAX_POINTS_IN_SCAN)
-    {
-        total_points_to_scan = MAX_POINTS_IN_SCAN;
-        UAirBlueprintLib::LogMessageString("Lidar: ", "Capping number of points to scan", LogDebugLevel::Failure);
-    }
+	// calculate number of points needed for each laser/channel
+	const uint32 points_to_scan_with_one_laser = FMath::RoundHalfFromZero(total_points_to_scan / float(number_of_lasers));
+	if (points_to_scan_with_one_laser <= 0)
+	{
+		//UAirBlueprintLib::LogMessageString("Lidar: ", "No points requested this frame", LogDebugLevel::Failure);
+		return;
+	}
 
-    // calculate number of points needed for each laser/channel
-    const uint32 points_to_scan_with_one_laser = FMath::RoundHalfFromZero(total_points_to_scan / float(number_of_lasers));
-    if (points_to_scan_with_one_laser <= 0)
-    {
-        //UAirBlueprintLib::LogMessageString("Lidar: ", "No points requested this frame", LogDebugLevel::Failure);
-        return;
-    }
+	// calculate needed angle/distance between each point
+	const float angle_distance_of_tick = params.horizontal_rotation_frequency * 360.0f * delta_time;
+	const float angle_distance_of_laser_measure = angle_distance_of_tick / points_to_scan_with_one_laser;
 
-    // calculate needed angle/distance between each point
-    const float angle_distance_of_tick = params.horizontal_rotation_frequency * 360.0f * delta_time;
-    const float angle_distance_of_laser_measure = angle_distance_of_tick / points_to_scan_with_one_laser;
+	// normalize FOV start/end
+	const float laser_start = std::fmod(360.0f + params.horizontal_FOV_start, 360.0f);
+	const float laser_end = std::fmod(360.0f + params.horizontal_FOV_end, 360.0f);
 
-    // normalize FOV start/end
-    const float laser_start = std::fmod(360.0f + params.horizontal_FOV_start, 360.0f);
-    const float laser_end = std::fmod(360.0f + params.horizontal_FOV_end, 360.0f);
+	// shoot lasers
 
-    // shoot lasers
-    for (auto laser = 0u; laser < number_of_lasers; ++laser)
-    {
-        const float vertical_angle = laser_angles_[laser];
+	
+	for (auto laser = 0u; laser < number_of_lasers; ++laser)
+	{
+		const float vertical_angle = laser_angles_[laser];
 
-        for (auto i = 0u; i < points_to_scan_with_one_laser; ++i)
-        {
-            const float horizontal_angle = std::fmod(current_horizontal_angle_ + angle_distance_of_laser_measure * i, 360.0f);
+		for (auto i = 0u; i < points_to_scan_with_one_laser; ++i)
+		{
+			const float horizontal_angle = std::fmod(current_horizontal_angle_ + angle_distance_of_laser_measure * i, 360.0f);
 
-            // check if the laser is outside the requested horizontal FOV
-            if (!VectorMath::isAngleBetweenAngles(horizontal_angle, laser_start, laser_end))
-                continue;
-       
-            Vector3r point;
-            // shoot laser and get the impact point, if any
-            if (shootLaser(lidar_pose, vehicle_pose, laser, horizontal_angle, vertical_angle, params, point))
-            {
-                point_cloud.emplace_back(point.x());
-                point_cloud.emplace_back(point.y());
-                point_cloud.emplace_back(point.z());
-            }
-        }
-    }
+			// check if the laser is outside the requested horizontal FOV
+			if (!VectorMath::isAngleBetweenAngles(horizontal_angle, laser_start, laser_end))
+				continue;
 
-    current_horizontal_angle_ = std::fmod(current_horizontal_angle_ + angle_distance_of_tick, 360.0f);
+			Vector3r point;
+			// shoot laser and get the impact point, if any
+			if (shootLaser(lidar_pose, vehicle_pose, laser, horizontal_angle, vertical_angle, params, point))
+			{
+				point_cloud.emplace_back(point.x());
+				point_cloud.emplace_back(point.y());
+				point_cloud.emplace_back(point.z());
+				labels.emplace_back(actor_string);
+				
+			}
+		}
+	}
 
-    return;
+	current_horizontal_angle_ = std::fmod(current_horizontal_angle_ + angle_distance_of_tick, 360.0f);
+	return;
 }
 
 // simulate shooting a laser via Unreal ray-tracing.
 bool UnrealLidarSensor::shootLaser(const msr::airlib::Pose& lidar_pose, const msr::airlib::Pose& vehicle_pose,
-    const uint32 laser, const float horizontal_angle, const float vertical_angle, 
-    const msr::airlib::LidarSimpleParams params, Vector3r &point)
+	const uint32 laser, const float horizontal_angle, const float vertical_angle,
+	const msr::airlib::LidarSimpleParams params, Vector3r &point)
 {
-    // start position
-    Vector3r start = lidar_pose.position + vehicle_pose.position;
+	// start position
+	Vector3r start = lidar_pose.position + vehicle_pose.position;
 
-    // We need to compose rotations here rather than rotate a vector by a quaternion
-    // Hence using coordOrientationAdd(..) rather than rotateQuaternion(..)
+	// We need to compose rotations here rather than rotate a vector by a quaternion
+	// Hence using coordOrientationAdd(..) rather than rotateQuaternion(..)
 
-    // get ray quaternion in lidar frame (angles must be in radians)
-    msr::airlib::Quaternionr ray_q_l = msr::airlib::VectorMath::toQuaternion(
-        msr::airlib::Utils::degreesToRadians(vertical_angle),   //pitch - rotation around Y axis
-        0,                                                      //roll  - rotation around X axis
-        msr::airlib::Utils::degreesToRadians(horizontal_angle));//yaw   - rotation around Z axis
+	// get ray quaternion in lidar frame (angles must be in radians)
+	msr::airlib::Quaternionr ray_q_l = msr::airlib::VectorMath::toQuaternion(
+		msr::airlib::Utils::degreesToRadians(vertical_angle),   //pitch - rotation around Y axis
+		0,                                                      //roll  - rotation around X axis
+		msr::airlib::Utils::degreesToRadians(horizontal_angle));//yaw   - rotation around Z axis
 
-    // get ray quaternion in body frame
-    msr::airlib::Quaternionr ray_q_b = VectorMath::coordOrientationAdd(ray_q_l, lidar_pose.orientation);
+	// get ray quaternion in body frame
+	msr::airlib::Quaternionr ray_q_b = VectorMath::coordOrientationAdd(ray_q_l, lidar_pose.orientation);
 
-    // get ray quaternion in world frame
-    msr::airlib::Quaternionr ray_q_w = VectorMath::coordOrientationAdd(ray_q_b, vehicle_pose.orientation);
+	// get ray quaternion in world frame
+	msr::airlib::Quaternionr ray_q_w = VectorMath::coordOrientationAdd(ray_q_b, vehicle_pose.orientation);
 
-    // get ray vector (end position)
-    Vector3r end = VectorMath::rotateVector(VectorMath::front(), ray_q_w, true) * params.range + start;
-   
-    FHitResult hit_result = FHitResult(ForceInit);
-    bool is_hit = UAirBlueprintLib::GetObstacle(actor_, ned_transform_->fromLocalNed(start), ned_transform_->fromLocalNed(end), hit_result, actor_, ECC_Visibility);
+	// get ray vector (end position)
+	Vector3r end = VectorMath::rotateVector(VectorMath::front(), ray_q_w, true) * params.range + start;
 
-    if (is_hit)
-    {
-        if (false && UAirBlueprintLib::IsInGameThread())
-        {
-            // Debug code for very specific cases.
-            // Mostly shouldn't be needed. Use SimModeBase::drawLidarDebugPoints()
-            DrawDebugPoint(
-                actor_->GetWorld(),
-                hit_result.ImpactPoint,
-                5,                       //size
-                FColor::Red,
-                true,                    //persistent (never goes away)
-                0.1                      //point leaves a trail on moving object
-            );
-        }
+	FHitResult hit_result = FHitResult(ForceInit);
+	bool is_hit = UAirBlueprintLib::GetObstacle(actor_, ned_transform_->fromLocalNed(start), ned_transform_->fromLocalNed(end), hit_result, actor_, ECC_Visibility);
 
-        // decide the frame for the point-cloud
-        if (params.data_frame == AirSimSettings::kVehicleInertialFrame) {
-            // current detault behavior; though it is probably not very useful.
-            // not changing the default for now to maintain backwards-compat.
-            point = ned_transform_->toLocalNed(hit_result.ImpactPoint);
-        }
-        else if (params.data_frame == AirSimSettings::kSensorLocalFrame) {
-            // point in vehicle intertial frame
-            Vector3r point_v_i = ned_transform_->toLocalNed(hit_result.ImpactPoint);
+	if (is_hit)
+	{
+		//lidar return actor
+		actor_temp = hit_result.Actor.Get()->GetFName();
+		//Fname to Fstring and Fstring to std::string
+		FString actor_Fstring = actor_temp.ToString();
+		actor_string = std::string(TCHAR_TO_UTF8(*actor_Fstring));
+		
+		//list.push_back(actor_string);
 
-            // tranform to lidar frame
-            point = VectorMath::transformToBodyFrame(point_v_i, lidar_pose + vehicle_pose, true);
+		if (false && UAirBlueprintLib::IsInGameThread())
+		{
+			// Debug code for very specific cases.
+			// Mostly shouldn't be needed. Use SimModeBase::drawLidarDebugPoints()
+			DrawDebugPoint(
+				actor_->GetWorld(),
+				hit_result.ImpactPoint,
+				5,                       //size
+				FColor::Red,
+				true,                    //persistent (never goes away)
+				0.1                      //point leaves a trail on moving object
+			);
+		}
 
-            // The above should be same as first transforming to vehicle-body frame and then to lidar frame
-            //    Vector3r point_v_b = VectorMath::transformToBodyFrame(point_v_i, vehicle_pose, true);
-            //    point = VectorMath::transformToBodyFrame(point_v_b, lidar_pose, true);
+		// decide the frame for the point-cloud
+		if (params.data_frame == AirSimSettings::kVehicleInertialFrame) {
+			// current detault behavior; though it is probably not very useful.
+			// not changing the default for now to maintain backwards-compat.
+			point = ned_transform_->toLocalNed(hit_result.ImpactPoint);
+		}
+		else if (params.data_frame == AirSimSettings::kSensorLocalFrame) {
+			// point in vehicle intertial frame
+			Vector3r point_v_i = ned_transform_->toLocalNed(hit_result.ImpactPoint);
 
-            // On the client side, if it is needed to transform this data back to the world frame,
-            // then do the equivalent of following,
-            //     Vector3r point_w = VectorMath::transformToWorldFrame(point, lidar_pose + vehicle_pose, true);
-            // See SimModeBase::drawLidarDebugPoints()
+			// tranform to lidar frame
+			point = VectorMath::transformToBodyFrame(point_v_i, lidar_pose + vehicle_pose, true);
 
-            // TODO: Optimization -- instead of doing this for every point, it should be possible to do this
-            // for the point-cloud together? Need to look into matrix operations to do this together for all points.
-        }
-        else 
-            throw std::runtime_error("Unknown requested data frame");
+			// The above should be same as first transforming to vehicle-body frame and then to lidar frame
+			//    Vector3r point_v_b = VectorMath::transformToBodyFrame(point_v_i, vehicle_pose, true);
+			//    point = VectorMath::transformToBodyFrame(point_v_b, lidar_pose, true);
 
-        return true;
-    }
-    else 
-    {
-        return false;
-    }
+			// On the client side, if it is needed to transform this data back to the world frame,
+			// then do the equivalent of following,
+			//     Vector3r point_w = VectorMath::transformToWorldFrame(point, lidar_pose + vehicle_pose, true);
+			// See SimModeBase::drawLidarDebugPoints()
+
+			// TODO: Optimization -- instead of doing this for every point, it should be possible to do this
+			// for the point-cloud together? Need to look into matrix operations to do this together for all points.
+		}
+		else
+			throw std::runtime_error("Unknown requested data frame");
+
+		return true;
+	}
+	else
+	{
+		return false;
+	}
 }


### PR DESCRIPTION
This PR provides the aid for semantic segmentation of the pointcloud obtained from the LIDAR. The getLidarData() API will provide a fourth attribute called labels which refers to the label of every point in the pointcloud.

The labels are the names of actors in the environment. So after the obtaining the pointcloud with the labels, one can postprocess the labels to the desired classes of their choice. i.e. The Blocks environment has an orange ball and every point falling on this orange ball will be named "OrangeBall". So the labels can be changed as per someone's requirement.

-----Python API-----
Add the following lines to **parse_lidarData** function to create a pandas dataframe of the point cloud with labels and then save it to a .csv file. You also need to install and import pandas in your script. 
     
````
import pandas as pd

def parse_lidarData(self, data):
        # reshape array of floats to array of [X,Y,Z]  
        lidarTimeStamp = data.time_stamp  
        points = numpy.array(data.point_cloud, dtype=numpy.dtype('f8'))  
        points = numpy.reshape(points, (int(points.shape[0] / 3), 3))
        labels = data.labels
        x = pd.DataFrame(data = numpy.float_(points), columns = ["x", "y", "z"])
        se = pd.Series(labels)
        x['labels'] = se
        x.to_csv("C:/test/{}.csv".format(lidarTimeStamp), index= None)
````
People familiar with the blocks environment know the **cone** and the **orangeball**. In the image below you can see the corresponding points of the pointcloud along with their labels. (Software used for visualizing: CloudCompare )

![image](https://user-images.githubusercontent.com/39503553/57708715-1a380280-766a-11e9-80ed-39a5e3aa6096.png)

![image](https://user-images.githubusercontent.com/39503553/57708639-0096bb00-766a-11e9-8589-21f6cabdfe86.png)