### PR TITLE
added offset option so velocity vectors don't get bungled with car sim (#1760)

### DIFF
--- a/Unreal/Plugins/AirSim/Source/NedTransform.cpp
+++ b/Unreal/Plugins/AirSim/Source/NedTransform.cpp
@@ -26,14 +26,15 @@ NedTransform::NedTransform(const AActor* pivot, const FTransform& global_transfo
         local_ned_offset_ = FVector::ZeroVector;
 }
 
-NedTransform::Vector3r NedTransform::toLocalNed(const FVector& position) const
+NedTransform::Vector3r NedTransform::toLocalNed(const FVector& position, bool offset=true) const
 {
-    return NedTransform::toVector3r(position - local_ned_offset_,
+
+    return NedTransform::toVector3r((offset ? position - local_ned_offset_ : position),
         1 / world_to_meters_, true);
 }
-NedTransform::Vector3r NedTransform::toGlobalNed(const FVector& position) const
+NedTransform::Vector3r NedTransform::toGlobalNed(const FVector& position, bool offset=true) const
 {
-    return NedTransform::toVector3r(position - global_transform_.GetLocation(),
+    return NedTransform::toVector3r((offset ? position - global_transform_.GetLocation() : position),
         1 / world_to_meters_, true);
 }
 NedTransform::Quaternionr NedTransform::toNed(const FQuat& q) const
@@ -57,13 +58,13 @@ float NedTransform::fromNed(float length) const
 {
     return length * world_to_meters_;
 }
-FVector NedTransform::fromLocalNed(const NedTransform::Vector3r& position) const
+FVector NedTransform::fromLocalNed(const NedTransform::Vector3r& position, bool offset=true) const
 {
-    return NedTransform::toFVector(position, world_to_meters_, true) + local_ned_offset_;
+    return (offset ? NedTransform::toFVector(position, world_to_meters_, true) + local_ned_offset_ : NedTransform::toFVector(position, world_to_meters_, true));
 }
-FVector NedTransform::fromGlobalNed(const NedTransform::Vector3r& position) const
+FVector NedTransform::fromGlobalNed(const NedTransform::Vector3r& position, bool offset=true) const
 {
-    return NedTransform::toFVector(position, world_to_meters_, true) + global_transform_.GetLocation();
+    return (offset ? NedTransform::toFVector(position, world_to_meters_, true) + global_transform_.GetLocation(), NedTransform::toFVector(position, world_to_meters_, true));
 }
 FQuat NedTransform::fromNed(const Quaternionr& q) const
 {

--- a/Unreal/Plugins/AirSim/Source/NedTransform.h
+++ b/Unreal/Plugins/AirSim/Source/NedTransform.h
@@ -29,9 +29,11 @@ public:
     NedTransform(const FTransform& global_transform, float world_to_meters);
     NedTransform(const AActor* pivot, const NedTransform& global_transform);
 
+
+
     //UU -> local NED
-    Vector3r toLocalNed(const FVector& position) const;
-    Vector3r toGlobalNed(const FVector& position) const;
+    Vector3r toLocalNed(const FVector& position, bool offset) const;
+    Vector3r toGlobalNed(const FVector& position, bool offset) const;
     Quaternionr toNed(const FQuat& q) const;
     float toNed(float length) const;
     Pose toLocalNed(const FTransform& pose) const;
@@ -39,8 +41,8 @@ public:
 
 
     //local NED -> UU
-    FVector fromLocalNed(const Vector3r& position) const;
-    FVector fromGlobalNed(const Vector3r& position) const;
+    FVector fromLocalNed(const Vector3r& position, bool offset) const;
+    FVector fromGlobalNed(const Vector3r& position, bool offset) const;
     FQuat fromNed(const Quaternionr& q) const;
     float fromNed(float length) const;
     FTransform fromLocalNed(const Pose& pose) const;
@@ -54,6 +56,7 @@ private:
     NedTransform(const AActor* pivot, const FTransform& global_transform, float world_to_meters); //create only through static factory methods
     FVector toFVector(const Vector3r& vec, float scale, bool convert_from_ned) const;
     Vector3r toVector3r(const FVector& vec, float scale, bool convert_to_ned) const;
+	
 
 private:
     FTransform global_transform_;

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
@@ -190,10 +190,8 @@ std::vector<PawnSimApi::ImageCaptureBase::ImageResponse> PawnSimApi::getImages(
     const std::vector<ImageCaptureBase::ImageRequest>& requests) const
 {
     std::vector<ImageCaptureBase::ImageResponse> responses;
-
     const ImageCaptureBase* camera = getImageCapture();
     camera->getImages(requests, responses);
-
     return responses;
 }
 
@@ -495,14 +493,12 @@ void PawnSimApi::updateKinematics(float dt)
     //update kinematics from pawn's movement instead of physics engine
 
     auto next_kinematics = kinematics_->getState();
-
     next_kinematics.pose = getPose();
-    next_kinematics.twist.linear = getNedTransform().toLocalNed(getPawn()->GetVelocity());
+	next_kinematics.twist.linear = getNedTransform().toLocalNed(getPawn()->GetVelocity(), false);
     next_kinematics.twist.angular = msr::airlib::VectorMath::toAngularVelocity(
         kinematics_->getPose().orientation, next_kinematics.pose.orientation, dt);
-
-    next_kinematics.accelerations.linear = (next_kinematics.twist.linear - kinematics_->getTwist().linear) / dt;
-    next_kinematics.accelerations.angular = (next_kinematics.twist.angular - kinematics_->getTwist().angular) / dt;
+	next_kinematics.accelerations.linear = (next_kinematics.twist.linear - kinematics_->getTwist().linear) / dt;
+	next_kinematics.accelerations.angular = (next_kinematics.twist.angular - kinematics_->getTwist().angular) / dt;
 
     kinematics_->setState(next_kinematics);
     kinematics_->update();


### PR DESCRIPTION
Car local_ned_offset_ is a non-zero vector, so it messes up the velocity vector when converting from Unreal `FVector` to airsim `Vector3r`. Commit adds an option to discard position offset when calculating velocity.
[see here](https://github.com/Microsoft/AirSim/issues/1760)