### PR TITLE
fixed abstract class error

### DIFF
--- a/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.cpp
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.cpp
@@ -52,6 +52,14 @@ void WorldSimApi::printLogMessage(const std::string& message, const std::string&
 	PrintLogMessage(message.c_str(), message_param.c_str(), vehicle_name_.c_str(), severity);
 }
 
+std::vector<std::string> WorldSimApi::listSceneObjects(const std::string& name_regex) const
+{
+	std::vector<std::string> result;
+	throw std::invalid_argument(common_utils::Utils::stringf(
+		"simListSceneObject is not supported on unity").c_str());
+	return result;
+}
+
 WorldSimApi::Pose WorldSimApi::getObjectPose(const std::string& object_name) const
 {
 	AirSimUnity::AirSimPose airSimPose = GetPose(object_name.c_str());

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.h
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.h
@@ -26,6 +26,8 @@ public:
 	virtual int getSegmentationObjectID(const std::string& mesh_name) const override;
 	virtual void printLogMessage(const std::string& message,
 		const std::string& message_param = "", unsigned char severity = 0) override;
+
+	virtual std::vector<std::string> listSceneObjects(const std::string& name_regex) const override;
 	virtual Pose getObjectPose(const std::string& object_name) const override;
 	virtual bool setObjectPose(const std::string& object_name, const Pose& pose, bool teleport) override;
 


### PR DESCRIPTION
[this error](https://github.com/microsoft/AirSim/issues/1964) has surface from [this commit](https://github.com/microsoft/AirSim/pull/1925/files#diff-5eb19662930009010d368bddc989b729R45).

This PR is a placeholder fix for the missing API simListSceneObjects
