### PR TITLE
Feature rate control

### DIFF
--- a/AirLib/include/vehicles/multirotor/api/MultirotorApiBase.hpp
+++ b/AirLib/include/vehicles/multirotor/api/MultirotorApiBase.hpp
@@ -26,6 +26,7 @@ protected: //must be implemented
     /************************* low level move APIs *********************************/
     virtual void commandRollPitchZ(float pitch, float roll, float z, float yaw) = 0;
     virtual void commandRollPitchThrottle(float pitch, float roll, float throttle, float yaw_rate) = 0;
+	virtual void commandRateThrottle(float pitch_rate, float roll_rate, float yaw_rate, float throttle) = 0;
     virtual void commandVelocity(float vx, float vy, float vz, const YawMode& yaw_mode) = 0;
     virtual void commandVelocityZ(float vx, float vy, float z, const YawMode& yaw_mode) = 0;
     virtual void commandPosition(float x, float y, float z, const YawMode& yaw_mode) = 0;
@@ -83,6 +84,7 @@ public: //these APIs uses above low level APIs
 
     virtual bool moveByAngleZ(float pitch, float roll, float z, float yaw, float duration);
     virtual bool moveByAngleThrottle(float pitch, float roll, float throttle, float yaw_rate, float duration);
+	virtual bool moveByRateThrottle(float pitch_rate, float roll_rate, float yaw_rate, float throttle, float duration);
     virtual bool moveByVelocity(float vx, float vy, float vz, float duration, DrivetrainType drivetrain, const YawMode& yaw_mode);
     virtual bool moveByVelocityZ(float vx, float vy, float z, float duration, DrivetrainType drivetrain, const YawMode& yaw_mode);
     virtual bool moveOnPath(const vector<Vector3r>& path, float velocity, float timeout_sec, DrivetrainType drivetrain, const YawMode& yaw_mode,
@@ -131,6 +133,7 @@ protected: //utility methods
     virtual void moveToPositionInternal(const Vector3r& dest, const YawMode& yaw_mode);
     virtual void moveByRollPitchZInternal(float pitch, float roll, float z, float yaw);
     virtual void moveByRollPitchThrottleInternal(float pitch, float roll, float throttle, float yaw_rate);
+	virtual void moveByRateThrottleInternal(float pitch_rate, float roll_rate, float yaw_rate, float throttle);
 
     /************* safety checks & emergency maneuvers ************/
     virtual bool emergencyManeuverIfUnsafe(const SafetyEval::EvalResult& result);

--- a/AirLib/include/vehicles/multirotor/api/MultirotorRpcLibClient.hpp
+++ b/AirLib/include/vehicles/multirotor/api/MultirotorRpcLibClient.hpp
@@ -24,6 +24,7 @@ public:
 
     MultirotorRpcLibClient* moveByAngleZAsync(float pitch, float roll, float z, float yaw, float duration, const std::string& vehicle_name = "");
     MultirotorRpcLibClient* moveByAngleThrottleAsync(float pitch, float roll, float throttle, float yaw_rate, float duration, const std::string& vehicle_name = "");
+	MultirotorRpcLibClient* moveByRateThrottleAsync(float pitch_rate, float roll_rate, float yaw_rate, float throttle, float duration, const std::string& vehicle_name = "");
     MultirotorRpcLibClient* moveByVelocityAsync(float vx, float vy, float vz, float duration,
         DrivetrainType drivetrain = DrivetrainType::MaxDegreeOfFreedom, const YawMode& yaw_mode = YawMode(), const std::string& vehicle_name = "");
     MultirotorRpcLibClient* moveByVelocityZAsync(float vx, float vy, float z, float duration,

--- a/AirLib/include/vehicles/multirotor/firmwares/mavlink/MavLinkMultirotorApi.hpp
+++ b/AirLib/include/vehicles/multirotor/firmwares/mavlink/MavLinkMultirotorApi.hpp
@@ -434,6 +434,10 @@ protected: //methods
 	virtual void commandRateThrottle(float pitch_rate, float roll_rate, float yaw_rate, float throttle)
 	{
 		checkValidVehicle();
+        // convert to deg/s
+        roll_rate = roll_rate * 180.0f / M_PIf;
+        pitch_rate = pitch_rate * 180.0f / M_PIf;
+        yaw_rate = yaw_rate * 180.0f / M_PIf;
 		mav_vehicle_->moveByRate(roll_rate, pitch_rate, yaw_rate, throttle);
 	}
     virtual void commandVelocity(float vx, float vy, float vz, const YawMode& yaw_mode) override

--- a/AirLib/include/vehicles/multirotor/firmwares/mavlink/MavLinkMultirotorApi.hpp
+++ b/AirLib/include/vehicles/multirotor/firmwares/mavlink/MavLinkMultirotorApi.hpp
@@ -431,6 +431,10 @@ protected: //methods
         checkValidVehicle();
         mav_vehicle_->moveByAttitude(roll, pitch, yaw_rate, 0, 0, 0, throttle);
     }
+	virtual void commandRateThrottle(float pitch_rate, float roll_rate, float yaw_rate, float throttle)
+	{
+		// TODO: implement
+	}
     virtual void commandVelocity(float vx, float vy, float vz, const YawMode& yaw_mode) override
     {
         checkValidVehicle();

--- a/AirLib/include/vehicles/multirotor/firmwares/mavlink/MavLinkMultirotorApi.hpp
+++ b/AirLib/include/vehicles/multirotor/firmwares/mavlink/MavLinkMultirotorApi.hpp
@@ -434,10 +434,6 @@ protected: //methods
 	virtual void commandRateThrottle(float pitch_rate, float roll_rate, float yaw_rate, float throttle)
 	{
 		checkValidVehicle();
-        // convert to deg/s
-        roll_rate = roll_rate * 180.0f / M_PIf;
-        pitch_rate = pitch_rate * 180.0f / M_PIf;
-        yaw_rate = yaw_rate * 180.0f / M_PIf;
 		mav_vehicle_->moveByRate(roll_rate, pitch_rate, yaw_rate, throttle);
 	}
     virtual void commandVelocity(float vx, float vy, float vz, const YawMode& yaw_mode) override

--- a/AirLib/include/vehicles/multirotor/firmwares/mavlink/MavLinkMultirotorApi.hpp
+++ b/AirLib/include/vehicles/multirotor/firmwares/mavlink/MavLinkMultirotorApi.hpp
@@ -433,7 +433,8 @@ protected: //methods
     }
 	virtual void commandRateThrottle(float pitch_rate, float roll_rate, float yaw_rate, float throttle)
 	{
-		// TODO: implement
+		checkValidVehicle();
+		mav_vehicle_->moveByRate(roll_rate, pitch_rate, yaw_rate, throttle);
 	}
     virtual void commandVelocity(float vx, float vy, float vz, const YawMode& yaw_mode) override
     {

--- a/AirLib/include/vehicles/multirotor/firmwares/simple_flight/SimpleFlightApi.hpp
+++ b/AirLib/include/vehicles/multirotor/firmwares/simple_flight/SimpleFlightApi.hpp
@@ -208,6 +208,20 @@ protected:
         firmware_->offboardApi().setGoalAndMode(&goal, &mode, message);
     }
 
+	virtual void commandRateThrottle(float pitch_rate, float roll_rate, float yaw_rate, float throttle)
+	{
+		Utils::log(Utils::stringf("commandRateThrottle %f, %f, %f, %f", pitch_rate, roll_rate, yaw_rate, throttle));
+
+		typedef simple_flight::GoalModeType GoalModeType;
+		simple_flight::GoalMode mode(GoalModeType::AngleRate, GoalModeType::AngleRate, GoalModeType::AngleRate, GoalModeType::Passthrough);
+		// alternative: simple_flight::GoalMode mode = simple_flight::GoalMode::getAllRateMode();
+
+		simple_flight::Axis4r goal(roll_rate, pitch_rate, yaw_rate, throttle);
+
+		std::string message;
+		firmware_->offboardApi().setGoalAndMode(&goal, &mode, message);
+	}
+
     virtual void commandRollPitchZ(float pitch, float roll, float z, float yaw) override
     {
         //Utils::log(Utils::stringf("commandRollPitchZ %f, %f, %f, %f", pitch, roll, z, yaw));

--- a/AirLib/include/vehicles/multirotor/firmwares/simple_flight/SimpleFlightApi.hpp
+++ b/AirLib/include/vehicles/multirotor/firmwares/simple_flight/SimpleFlightApi.hpp
@@ -202,7 +202,7 @@ protected:
         typedef simple_flight::GoalModeType GoalModeType;
         simple_flight::GoalMode mode(GoalModeType::AngleLevel, GoalModeType::AngleLevel, GoalModeType::AngleRate, GoalModeType::Passthrough);
 
-        simple_flight::Axis4r goal(roll, pitch, yaw_rate, throttle);
+        simple_flight::Axis4r goal(Utils::degreesToRadians(roll), Utils::degreesToRadians(pitch), Utils::degreesToRadians(yaw_rate), throttle);
 
         std::string message;
         firmware_->offboardApi().setGoalAndMode(&goal, &mode, message);
@@ -216,7 +216,7 @@ protected:
 		simple_flight::GoalMode mode(GoalModeType::AngleRate, GoalModeType::AngleRate, GoalModeType::AngleRate, GoalModeType::Passthrough);
 		// alternative: simple_flight::GoalMode mode = simple_flight::GoalMode::getAllRateMode();
 
-		simple_flight::Axis4r goal(roll_rate, pitch_rate, yaw_rate, throttle);
+		simple_flight::Axis4r goal(Utils::degreesToRadians(roll_rate), Utils::degreesToRadians(pitch_rate), Utils::degreesToRadians(yaw_rate), throttle);
 
 		std::string message;
 		firmware_->offboardApi().setGoalAndMode(&goal, &mode, message);
@@ -229,7 +229,7 @@ protected:
         typedef simple_flight::GoalModeType GoalModeType;
         simple_flight::GoalMode mode(GoalModeType::AngleLevel, GoalModeType::AngleLevel, GoalModeType::AngleLevel, GoalModeType::PositionWorld);
 
-        simple_flight::Axis4r goal(roll, pitch, yaw, z);
+        simple_flight::Axis4r goal(Utils::degreesToRadians(roll), Utils::degreesToRadians(pitch), Utils::degreesToRadians(yaw), z);
 
         std::string message;
         firmware_->offboardApi().setGoalAndMode(&goal, &mode, message);

--- a/AirLib/src/vehicles/multirotor/api/MultirotorApiBase.cpp
+++ b/AirLib/src/vehicles/multirotor/api/MultirotorApiBase.cpp
@@ -95,9 +95,22 @@ bool MultirotorApiBase::moveByAngleThrottle(float pitch, float roll, float throt
         return true;
 
     return waitForFunction([&]() {
-        moveByRollPitchThrottleInternal(pitch, roll, throttle, yaw_rate);
+        moveByRollPitchThrottleInternal(pitch, roll, throttle, yaw_rate); // called in a loop
         return false; //keep moving until timeout
     }, duration).isTimeout();
+}
+
+bool MultirotorApiBase::moveByRateThrottle(float pitch_rate, float roll_rate, float yaw_rate, float throttle, float duration)
+{
+	SingleTaskCall lock(this);
+
+	if (duration <= 0)
+		return true;
+
+	return waitForFunction([&]() {
+		moveByRateThrottleInternal(pitch_rate, roll_rate, yaw_rate, throttle);
+		return false; //keep moving until timeout
+	}, duration).isTimeout();
 }
 
 bool MultirotorApiBase::moveByVelocity(float vx, float vy, float vz, float duration, DrivetrainType drivetrain, const YawMode& yaw_mode)
@@ -457,6 +470,11 @@ void MultirotorApiBase::moveByRollPitchThrottleInternal(float pitch, float roll,
 {
     if (safetyCheckVelocity(getVelocity()))
         commandRollPitchThrottle(pitch, roll, throttle, yaw_rate);
+}
+
+void MultirotorApiBase::moveByRateThrottleInternal(float pitch_rate, float roll_rate, float yaw_rate, float throttle) {
+	if (safetyCheckVelocity(getVelocity()))
+		commandRateThrottle(pitch_rate, roll_rate, yaw_rate, throttle);
 }
 
 void MultirotorApiBase::moveByRollPitchZInternal(float pitch, float roll, float z, float yaw)

--- a/AirLib/src/vehicles/multirotor/api/MultirotorRpcLibClient.cpp
+++ b/AirLib/src/vehicles/multirotor/api/MultirotorRpcLibClient.cpp
@@ -86,6 +86,11 @@ MultirotorRpcLibClient* MultirotorRpcLibClient::moveByAngleThrottleAsync(float p
     pimpl_->last_future = static_cast<rpc::client*>(getClient())->async_call("moveByAngleThrottle", pitch, roll, throttle, yaw_rate, duration, vehicle_name);
     return this;
 }
+MultirotorRpcLibClient* MultirotorRpcLibClient::moveByRateThrottleAsync(float pitch_rate, float roll_rate, float yaw_rate, float throttle, float duration, const std::string& vehicle_name)
+{
+	pimpl_->last_future = static_cast<rpc::client*>(getClient())->async_call("moveByRateThrottle", pitch_rate, roll_rate, yaw_rate, throttle, duration, vehicle_name);
+	return this;
+}
 
 MultirotorRpcLibClient* MultirotorRpcLibClient::moveByVelocityAsync(float vx, float vy, float vz, float duration, 
     DrivetrainType drivetrain, const YawMode& yaw_mode, const std::string& vehicle_name)

--- a/AirLib/src/vehicles/multirotor/api/MultirotorRpcLibServer.cpp
+++ b/AirLib/src/vehicles/multirotor/api/MultirotorRpcLibServer.cpp
@@ -62,6 +62,11 @@ MultirotorRpcLibServer::MultirotorRpcLibServer(ApiProvider* api_provider, string
             const std::string& vehicle_name) -> bool { 
                 return getVehicleApi(vehicle_name)->moveByAngleThrottle(pitch, roll, throttle, yaw_rate, duration); 
     });
+	(static_cast<rpc::server*>(getServer()))->
+		bind("moveByRateThrottle", [&](float pitch_rate, float roll_rate, float yaw_rate, float throttle, float duration,
+			const std::string& vehicle_name) -> bool {
+		return getVehicleApi(vehicle_name)->moveByRateThrottle(pitch_rate, roll_rate, yaw_rate, throttle, duration);
+	});
     (static_cast<rpc::server*>(getServer()))->
         bind("moveByVelocity", [&](float vx, float vy, float vz, float duration, DrivetrainType drivetrain, 
             const MultirotorRpcLibAdapators::YawMode& yaw_mode, const std::string& vehicle_name) -> bool { 

--- a/MavLinkCom/include/MavLinkVehicle.hpp
+++ b/MavLinkCom/include/MavLinkVehicle.hpp
@@ -64,7 +64,9 @@ namespace mavlinkcom {
         // Move drone by directly controlling the attitude of the drone (units are degrees).
         // If the rollRate, pitchRate and yawRate are all zero then you will get the default rates provided by the drone.
         void moveByAttitude(float roll, float pitch, float yaw, float rollRate, float pitchRate, float yawRate, float thrust);
-         
+        // Move drone by controlling the rotational rates (units are deg/s)
+        void moveByRate(float rollRate, float pitchRate, float yawRate, float thrust);
+
         uint32_t getTimeStamp();
         int getVehicleStateVersion();
         const VehicleState& getVehicleState();

--- a/MavLinkCom/src/MavLinkVehicle.cpp
+++ b/MavLinkCom/src/MavLinkVehicle.cpp
@@ -98,6 +98,12 @@ void MavLinkVehicle::moveByAttitude(float roll, float pitch, float yaw, float ro
 	ptr->moveByAttitude(roll, pitch, yaw, rollRate, pitchRate, yawRate, thrust);
 }
 
+void MavLinkVehicle::moveByRate(float rollRate, float pitchRate, float yawRate, float thrust)
+{
+    auto ptr = static_cast<MavLinkVehicleImpl*>(pImpl.get());
+    ptr->moveByRate(rollRate, pitchRate, yawRate, thrust);
+}
+
 void MavLinkVehicle::writeMessage(MavLinkMessageBase& message, bool update_stats)
 {
     auto ptr = static_cast<MavLinkVehicleImpl*>(pImpl.get());

--- a/MavLinkCom/src/impl/MavLinkVehicleImpl.cpp
+++ b/MavLinkCom/src/impl/MavLinkVehicleImpl.cpp
@@ -896,7 +896,7 @@ void MavLinkVehicleImpl::moveByRate(float rollRate, float pitchRate, float yawRa
     msg.target_system = getTargetSystemId();
     msg.target_component = getTargetComponentId();
 
-    // altitude is not set, because all fields in msg are 0-initialized
+    // attitude is not set, because all fields in msg are 0-initialized
     //mavlink_euler_to_quaternion(0.0f, 0.0f, 0.0f, msg.q);
 
     // thrust must be between -1 and 1.

--- a/MavLinkCom/src/impl/MavLinkVehicleImpl.hpp
+++ b/MavLinkCom/src/impl/MavLinkVehicleImpl.hpp
@@ -61,9 +61,11 @@ namespace mavlinkcom_impl {
 		// low level control, only use this one if you really know what you are doing!!
 		bool isAttitudeControlSupported();
 
-		// Move drone by directly controlling the attitude of the drone (units are degrees).
-		// If the rollRate, pitchRate and yawRate are all zero then you will get the default rates provided by the drone.
-		void moveByAttitude(float roll, float pitch, float yaw, float rollRate, float pitchRate, float yawRate, float thrust);
+        // Move drone by directly controlling the attitude of the drone (units are degrees).
+        // If the rollRate, pitchRate and yawRate are all zero then you will get the default rates provided by the drone.
+        void moveByAttitude(float roll, float pitch, float yaw, float rollRate, float pitchRate, float yawRate, float thrust);
+        // Move drone by controlling the rotational rates (units are deg/s)
+        void moveByRate(float rollRate, float pitchRate, float yawRate, float thrust);
         void writeMessage(MavLinkMessageBase& message, bool update_stats = true);
 
 		int getVehicleStateVersion();


### PR DESCRIPTION
This branch adds the possibility to control the drone by rates. This feature was previously requested in 
https://github.com/Microsoft/AirSim/issues/434

Furthermore, the API was unified: All mutirotor move-methods expect angles to be given in degrees. This was necessary since SimpleFlight and MAVlink (PX4 SITL) flight controller were expecting angles in different units.