### PR TITLE
4.22: Fix deprecation warnings.

### DIFF
--- a/Unreal/Plugins/AirSim/Source/RenderRequest.cpp
+++ b/Unreal/Plugins/AirSim/Source/RenderRequest.cpp
@@ -74,13 +74,12 @@ void RenderRequest::getScreenshot(std::shared_ptr<RenderParams> params[], std::v
                 // The completion is called immeidately after GameThread sends the
                 // rendering commands to RenderThread. Hence, our ExecuteTask will
                 // execute *immediately* after RenderThread renders the scene!
-                ENQUEUE_UNIQUE_RENDER_COMMAND_ONEPARAMETER(
-                    SceneDrawCompletion,
-                    RenderRequest *, This, this,
-                    {
-                        This->ExecuteTask();
-                    }
-                );
+                RenderRequest* This = this;
+                ENQUEUE_RENDER_COMMAND(SceneDrawCompletion)(
+                [This](FRHICommandListImmediate& RHICmdList)
+                {
+                    This->ExecuteTask();
+                });
 
                 game_viewport_->bDisableWorldRendering = saved_DisableWorldRendering_;
 


### PR DESCRIPTION
Pull request to fix deprecation warnings for UE4.22.

Ref:
[How to use ENQUEUE_RENDER_COMMAND instead of ENQUEUE_UNIQUE_RENDER_COMMAND_ONEPARAMETER - UE Forums](https://forums.unrealengine.com/development-discussion/engine-source-github/1608365-how-to-use-enqueue_render_command-instead-of-enqueue_unique_render_command_oneparameter)

Signed-off-by: Elvis Dowson <elvis.dowson@gmail.com>