### PR TITLE
Fixed Cmakelists.txt for macos check

### DIFF
--- a/Unity/AirLibWrapper/AirsimWrapper/CMakeLists.txt
+++ b/Unity/AirLibWrapper/AirsimWrapper/CMakeLists.txt
@@ -33,7 +33,7 @@ BuildAirsimWrapper()
 
 
 ###################### Link source files to library ######################################
-if (${MACOSX})
+if (${APPLE})
 	add_library(
 	    ${PROJECT_NAME} MODULE
 	    ${RPC_LIBRARY_SOURCE_FILES}


### PR DESCRIPTION
Seems `MACOS` in the CMakeLists.txt to determine if its run on Mac is no longer valid, so I changed it to `APPLE` which seems to work.