### PR TITLE
Merge PR 1934 and add some more fixes along the same lines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -307,6 +307,7 @@ cmake_build/
 /boost
 /[Ee]igen
 /build_debug
+/build_gcc_debug
 /cmake/CPackSourceConfig.cmake
 /cmake/CPackConfig.cmake
 /cmake/arch.c

--- a/AirLib/include/common/AirSimSettings.hpp
+++ b/AirLib/include/common/AirSimSettings.hpp
@@ -88,11 +88,6 @@ public: //types
         {
         }
 
-        bool hasNan()
-        {
-            return std::isnan(yaw) || std::isnan(pitch) || std::isnan(roll);
-        }
-
         static Rotation nanRotation()
         {
             static const Rotation val(Utils::nan<float>(), Utils::nan<float>(), Utils::nan<float>());

--- a/AirLib/include/vehicles/multirotor/firmwares/mavlink/MavLinkMultirotorApi.hpp
+++ b/AirLib/include/vehicles/multirotor/firmwares/mavlink/MavLinkMultirotorApi.hpp
@@ -467,13 +467,7 @@ protected: //methods
         endOffboardMode();
     }
 
-public: //types
-    typedef msr::airlib::GeoPoint GeoPoint;
-    typedef msr::airlib::VectorMath VectorMath;
-    typedef msr::airlib::Vector3r Vector3r;
-    typedef msr::airlib::Quaternionr Quaternionr;
-    typedef common_utils::Utils Utils;
-    typedef msr::airlib::real_T real_T;
+public: 
 
     class MavLinkLogViewerLog : public mavlinkcom::MavLinkLog
     {

--- a/AirLibUnitTests/QuaternionTest.hpp
+++ b/AirLibUnitTests/QuaternionTest.hpp
@@ -52,15 +52,15 @@ private:
         if (rotAxis.squaredNorm() == 0)
             rotAxis = VectorMath::up();
         float dot = VectorMath::front().dot(toVector);
-        float ang = std::acosf(dot);
+        float ang = std::acos(dot);
 
         return VectorMath::toQuaternion(rotAxis, ang);
     }
 
     Quaternionr toQuaternion(const Vector3r& axis, float angle) {
-        auto s = std::sinf(angle / 2);
+        auto s = std::sin(angle / 2.0f);
         auto u = axis.normalized();
-        return Quaternionr(std::cosf(angle / 2), u.x() * s, u.y() * s, u.z() * s);
+        return Quaternionr(std::cos(angle / 2.0f), u.x() * s, u.y() * s, u.z() * s);
     }
 
     void lookAtTest()

--- a/build.sh
+++ b/build.sh
@@ -7,24 +7,19 @@ pushd "$SCRIPT_DIR"  >/dev/null
 set -e
 # set -x
 
-#check for correct verion of llvm
-if [[ ! -d "llvm-source-50" ]]; then
-    if [[ -d "llvm-source-39" ]]; then
-        echo "Hello there! We just upgraded AirSim to Unreal Engine 4.18."
-        echo "Here are few easy steps for upgrade so everything is new and shiny :)"
-        echo "https://github.com/Microsoft/AirSim/blob/master/docs/unreal_upgrade.md"
-        exit 1
-    else
-        echo "The llvm-souce-50 folder was not found! Mystery indeed."
-    fi
-fi
+gccBuild=false
+# Parse command line arguments
+while [[ $# -gt 0 ]]
+do
+key="$1"
 
-# check for libc++
-if [[ !(-d "./llvm-build/output/lib") ]]; then
-    echo "ERROR: clang++ and libc++ is necessary to compile AirSim and run it in Unreal engine"
-    echo "Please run setup.sh first."
-    exit 1
-fi
+case $key in
+    --gcc)
+    gccBuild=true
+    shift # past argument
+    ;;
+esac
+done
 
 # check for rpclib
 if [ ! -d "./external/rpclib/rpclib-2.2.1" ]; then
@@ -33,42 +28,61 @@ if [ ! -d "./external/rpclib/rpclib-2.2.1" ]; then
     exit 1
 fi
 
-# check for cmake build
-if [ ! -d "./cmake_build" ]; then
-    echo "ERROR: cmake build was not found."
-    echo "please run setup.sh first and then run build.sh again."
-    exit 1
-fi
-
-
-# set up paths of cc and cxx compiler
-if [ "$1" == "gcc" ]; then
-    export CC="gcc"
-    export CXX="g++"
-else
+# check for local cmake build created by setup.sh
+if [ -d "./cmake_build" ]; then
     if [ "$(uname)" == "Darwin" ]; then
         CMAKE="$(greadlink -f cmake_build/bin/cmake)"
-
-        export CC=/usr/local/opt/llvm-5.0/bin/clang-5.0
-        export CXX=/usr/local/opt/llvm-5.0/bin/clang++-5.0
     else
         CMAKE="$(readlink -f cmake_build/bin/cmake)"
+    fi
+else
+    CMAKE=$(which cmake)
+fi
 
+# set up paths of cc and cxx compiler
+if $gccBuild; then
+    # variable for build output
+    build_dir=build_gcc_debug    
+    export CC="gcc-8"
+    export CXX="g++-8"
+else
+    #check for correct verion of llvm
+    if [[ ! -d "llvm-source-50" ]]; then
+        if [[ -d "llvm-source-39" ]]; then
+            echo "Hello there! We just upgraded AirSim to Unreal Engine 4.18."
+            echo "Here are few easy steps for upgrade so everything is new and shiny :)"
+            echo "https://github.com/Microsoft/AirSim/blob/master/docs/unreal_upgrade.md"
+            exit 1
+        else
+            echo "The llvm-souce-50 folder was not found! Mystery indeed."
+        fi
+    fi
+
+    # check for libc++
+    if [[ !(-d "./llvm-build/output/lib") ]]; then
+        echo "ERROR: clang++ and libc++ is necessary to compile AirSim and run it in Unreal engine"
+        echo "Please run setup.sh first."
+        exit 1
+    fi
+
+    # variable for build output
+    build_dir=build_debug
+    if [ "$(uname)" == "Darwin" ]; then        
+        export CC=/usr/local/opt/llvm-5.0/bin/clang-5.0
+        export CXX=/usr/local/opt/llvm-5.0/bin/clang++-5.0
+    else        
         export CC="clang-5.0"
         export CXX="clang++-5.0"
     fi
 fi
 
 #install EIGEN library
-if [[ !(-d "./AirLib/deps/eigen3/Eigen") ]]; then 
+if [[ !(-d "./AirLib/deps/eigen3/Eigen") ]]; then
     echo "eigen is not installed. Please run setup.sh first."
     exit 1
 fi
 
-
-# variable for build output
-build_dir=build_debug
-echo "putting build in build_debug folder, to clean, just delete the directory..."
+echo "putting build in $build_dir folder, to clean, just delete the directory..."
 
 # this ensures the cmake files will be built in our $build_dir instead.
 if [[ -f "./cmake/CMakeCache.txt" ]]; then

--- a/cmake/cmake-modules/CommonSetup.cmake
+++ b/cmake/cmake-modules/CommonSetup.cmake
@@ -61,7 +61,7 @@ macro(CommonSetup)
             # other flags used in Unreal: -funwind-tables  -fdiagnostics-format=msvc -fno-inline  -Werror -fno-omit-frame-pointer  -fstack-protector -O2
             # TODO: add back -Wunused-parameter -Wno-documentation after rpclib can be compiled
             set(CMAKE_CXX_FLAGS "\
-                -std=c++14 -ggdb -Wall -Wextra -Wstrict-aliasing -Wunreachable-code -Wcast-qual -Wctor-dtor-privacy \
+                -std=c++17 -ggdb -Wall -Wextra -Wstrict-aliasing -Wunreachable-code -Wcast-qual -Wctor-dtor-privacy \
                 -Wdisabled-optimization -Wformat=2 -Winit-self -Wmissing-include-dirs -Wswitch-default \
                 -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wstrict-overflow=5 -Wswitch-default -Wundef \
                 -Wno-variadic-macros -Wno-parentheses -Wno-unused-function -Wno-unused -Wno-documentation -fdiagnostics-show-option \

--- a/cmake/cmake-modules/CommonSetup.cmake
+++ b/cmake/cmake-modules/CommonSetup.cmake
@@ -61,7 +61,7 @@ macro(CommonSetup)
             # other flags used in Unreal: -funwind-tables  -fdiagnostics-format=msvc -fno-inline  -Werror -fno-omit-frame-pointer  -fstack-protector -O2
             # TODO: add back -Wunused-parameter -Wno-documentation after rpclib can be compiled
             set(CMAKE_CXX_FLAGS "\
-                -std=c++17 -ggdb -Wall -Wextra -Wstrict-aliasing -Wunreachable-code -Wcast-qual -Wctor-dtor-privacy \
+                -std=c++14 -ggdb -Wall -Wextra -Wstrict-aliasing -Wunreachable-code -Wcast-qual -Wctor-dtor-privacy \
                 -Wdisabled-optimization -Wformat=2 -Winit-self -Wmissing-include-dirs -Wswitch-default \
                 -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wstrict-overflow=5 -Wswitch-default -Wundef \
                 -Wno-variadic-macros -Wno-parentheses -Wno-unused-function -Wno-unused -Wno-documentation -fdiagnostics-show-option \

--- a/docs/build_linux.md
+++ b/docs/build_linux.md
@@ -27,8 +27,17 @@ Please see instructions [here](https://github.com/Microsoft/AirSim/blob/master/d
    # go to the folder where you clone GitHub projects
    git clone https://github.com/Microsoft/AirSim.git
    cd AirSim
+
+  By default AirSim recommends using clang 5 to build the binaries as those will be compatible with Unreal.  The setup script
+  will install the right version of cmake, llvm, and eigen:
    ./setup.sh
    ./build.sh
+   ```
+
+  Optionally, if you need GCC binaries for some other reason, you can simply add gcc to the setup and build invocation, like this:
+   ```bash
+   ./setup.sh --gcc
+   ./build.sh --gcc
    ```
 
 ### Build Unreal Environment

--- a/setup.sh
+++ b/setup.sh
@@ -13,11 +13,26 @@ set -e
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 pushd "$SCRIPT_DIR" >/dev/null
 
-#Parse command line arguments
 downloadHighPolySuv=true
-if [[ $1 == "--no-full-poly-car" ]]; then
+gccBuild=false
+MIN_CMAKE_VERSION=3.10.0
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+    --no-full-poly-car)
     downloadHighPolySuv=false
-fi
+    shift # past value
+    ;;
+    --gcc)
+    gccBuild=true
+    shift # past argument
+    ;;
+esac
+done
 
 #give user perms to access USB port - this is not needed if not using PX4 HIL
 #TODO: figure out how to do below in travis
@@ -44,39 +59,50 @@ else #linux
 
     #install clang and build tools
     sudo apt-get install -y build-essential
-    VERSION=$(lsb_release -rs | cut -d. -f1)
-    # Since Ubuntu 17 clang-5.0 is part of the core repository
-    # See https://packages.ubuntu.com/search?keywords=clang-5.0
-    if [ "$VERSION" -lt "17" ]; then
+
+    if $gccBuild; then
+        sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+        sudo apt-get -y update
+        sudo apt-get install -y gcc-8 g++-8
+    else
         wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
         sudo apt-get update
+        sudo apt-get install -y clang-5.0 clang++-5.0
+        export C_COMPILER=clang-5.0
+        export COMPILER=clang++-5.0
     fi
-    sudo apt-get install -y clang-5.0 clang++-5.0
     sudo apt-get install -y unzip
 
-    export C_COMPILER=clang-5.0
-    export COMPILER=clang++-5.0
 fi
 
+cmake_ver=$(cmake --version 2>&1 | head -n1 | cut -d ' ' -f3 | awk '{print $NF}')
+cmake_path=$(which cmake)
+if [[ "$cmake_path" == "" ]] ; then
+   cmake_ver=0
+fi
 #download cmake - we need v3.9+ which is not out of box in Ubuntu 16.04
-if [[ ! -d "cmake_build/bin" ]]; then
-    echo "Downloading cmake..."
-    wget https://cmake.org/files/v3.10/cmake-3.10.2.tar.gz \
-        -O cmake.tar.gz
-    tar -xzf cmake.tar.gz
-    rm cmake.tar.gz
-    rm -rf ./cmake_build
-    mv ./cmake-3.10.2 ./cmake_build
-    pushd cmake_build
-    ./bootstrap
-    make
-    popd
-fi
-
-if [ "$(uname)" == "Darwin" ]; then
-    CMAKE="$(greadlink -f cmake_build/bin/cmake)"
+if [[ $(python $SCRIPT_DIR/tools/version.py $cmake_ver $MIN_CMAKE_VERSION) ]]; then
+    if [[ ! -d "cmake_build/bin" ]]; then
+        echo "Downloading cmake..."
+        wget https://cmake.org/files/v3.10/cmake-3.10.2.tar.gz \
+            -O cmake.tar.gz
+        tar -xzf cmake.tar.gz
+        rm cmake.tar.gz
+        rm -rf ./cmake_build
+        mv ./cmake-3.10.2 ./cmake_build
+        pushd cmake_build
+        ./bootstrap
+        make
+        popd
+    fi
+    if [ "$(uname)" == "Darwin" ]; then
+        CMAKE="$(greadlink -f cmake_build/bin/cmake)"
+    else
+        CMAKE="$(readlink -f cmake_build/bin/cmake)"
+    fi
 else
-    CMAKE="$(readlink -f cmake_build/bin/cmake)"
+    echo "Already have good version of cmake: $cmake_ver"
+    CMAKE=$(which cmake)
 fi
 
 # Download rpclib
@@ -105,7 +131,7 @@ if [ ! -d "Unreal/Plugins/AirSim/Content/VehicleAdv/SUV/v1.2.0" ]; then
         echo "Downloading high-poly car assets.... The download is ~37MB and can take some time."
         echo "To install without this assets, re-run setup.sh with the argument --no-full-poly-car"
         echo "*********************************************************************************************"
-        
+
         if [ -d "suv_download_tmp" ]; then
             rm -rf "suv_download_tmp"
         fi
@@ -114,16 +140,16 @@ if [ ! -d "Unreal/Plugins/AirSim/Content/VehicleAdv/SUV/v1.2.0" ]; then
         wget  https://github.com/Microsoft/AirSim/releases/download/v1.2.0/car_assets.zip
         if [ -d "../Unreal/Plugins/AirSim/Content/VehicleAdv/SUV" ]; then
             rm -rf "../Unreal/Plugins/AirSim/Content/VehicleAdv/SUV"
-        fi        
+        fi
         unzip car_assets.zip -d ../Unreal/Plugins/AirSim/Content/VehicleAdv
         cd ..
-        rm -rf "suv_download_tmp" 
+        rm -rf "suv_download_tmp"
     else
         echo "Not downloading high-poly car asset. The default unreal vehicle will be used."
     fi
 fi
 
-# Below is alternative way to get cland by downloading binaries
+# Below is alternative way to get clang by downloading binaries
 # get clang, libc++
 # sudo rm -rf llvm-build
 # mkdir -p llvm-build/output
@@ -134,35 +160,48 @@ fi
 # #sudo apt-get install -y clang-3.9-doc libclang-common-3.9-dev libclang-3.9-dev libclang1-3.9 libclang1-3.9-dbg libllvm-3.9-ocaml-dev libllvm3.9 libllvm3.9-dbg lldb-3.9 llvm-3.9 llvm-3.9-dev llvm-3.9-doc llvm-3.9-examples llvm-3.9-runtime clang-format-3.9 python-clang-3.9 libfuzzer-3.9-dev
 
 #get libc++ source
-if [[ ! -d "llvm-source-50" ]]; then 
-    git clone --depth=1 -b release_50  https://github.com/llvm-mirror/llvm.git llvm-source-50
-    git clone --depth=1 -b release_50  https://github.com/llvm-mirror/libcxx.git llvm-source-50/projects/libcxx
-    git clone --depth=1 -b release_50  https://github.com/llvm-mirror/libcxxabi.git llvm-source-50/projects/libcxxabi
-else
-    echo "folder llvm-source-50 already exists, skipping git clone..."
+if ! $gccBuild; then
+    echo Installing llvm 5
+    if [[ ! -d "llvm-source-50" ]]; then
+        git clone --depth=1 -b release_50  https://github.com/llvm-mirror/llvm.git llvm-source-50
+        git clone --depth=1 -b release_50  https://github.com/llvm-mirror/libcxx.git llvm-source-50/projects/libcxx
+        git clone --depth=1 -b release_50  https://github.com/llvm-mirror/libcxxabi.git llvm-source-50/projects/libcxxabi
+    else
+        echo "folder llvm-source-50 already exists, skipping git clone..."
+    fi
+    #build libc++
+    if [ "$(uname)" == "Darwin" ]; then 
+        rm -rf llvm-build
+    else
+        sudo rm -rf llvm-build
+    fi
+    mkdir -p llvm-build
+    pushd llvm-build >/dev/null
+
+    "$CMAKE" -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_CXX_COMPILER=${COMPILER} \
+          -LIBCXX_ENABLE_EXPERIMENTAL_LIBRARY=ON -DLIBCXX_INSTALL_EXPERIMENTAL_LIBRARY=ON \
+          -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=./output \
+                ../llvm-source-50
+
+    make cxx
+
+    #install libc++ locally in output folder
+    if [ "$(uname)" == "Darwin" ]; then
+        make install-libcxx install-libcxxabi
+    else
+        sudo make install-libcxx install-libcxxabi
+    fi
+
+    popd >/dev/null
 fi
 
-#build libc++
-rm -rf llvm-build
-mkdir -p llvm-build
-pushd llvm-build >/dev/null
+echo Installing EIGEN library...
 
-
-"$CMAKE" -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_CXX_COMPILER=${COMPILER} \
-      -LIBCXX_ENABLE_EXPERIMENTAL_LIBRARY=OFF -DLIBCXX_INSTALL_EXPERIMENTAL_LIBRARY=OFF \
-      -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=./output \
-            ../llvm-source-50
-
-make cxx
-
-#install libc++ locally in output folder
-make install-libcxx install-libcxxabi
-
-popd >/dev/null
-
-#install EIGEN library
-
-rm -rf ./AirLib/deps/eigen3/Eigen
+if [ "$(uname)" == "Darwin" ]; then
+    rm -rf ./AirLib/deps/eigen3/Eigen
+else
+    sudo rm -rf ./AirLib/deps/eigen3/Eigen
+fi
 echo "downloading eigen..."
 wget http://bitbucket.org/eigen/eigen/get/3.3.2.zip
 unzip 3.3.2.zip -d temp_eigen

--- a/setup.sh
+++ b/setup.sh
@@ -8,7 +8,7 @@ if [[ -d "llvm-source-39" ]]; then
 fi
 
 set -x
-set -e
+# set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 pushd "$SCRIPT_DIR" >/dev/null
@@ -16,6 +16,7 @@ pushd "$SCRIPT_DIR" >/dev/null
 downloadHighPolySuv=true
 gccBuild=false
 MIN_CMAKE_VERSION=3.10.0
+MIN_GCC_VERSION=6.0.0
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]
@@ -34,37 +35,39 @@ case $key in
 esac
 done
 
-#give user perms to access USB port - this is not needed if not using PX4 HIL
-#TODO: figure out how to do below in travis
-if [ "$(uname)" == "Darwin" ]; then # osx
-    if [[ ! -z "${whoami}" ]]; then #this happens when running in travis
-        sudo dseditgroup -o edit -a `whoami` -t user dialout
+if $gccBuild; then
+    # gcc tools
+    gcc_ver=$(gcc --version 2>&1 | head -n1 | cut -d ' ' -f4 | awk '{print $NF}')
+    gcc_path=$(which cmake)
+    if [[ "$gcc_path" == "" ]] ; then
+        gcc_ver=0
     fi
-
-    #below takes way too long
-    # brew install llvm@3.9
-    brew tap llvm-hs/homebrew-llvm
-    brew install llvm-5.0
-
-    brew install wget
-    brew install coreutils
-
-    export C_COMPILER=/usr/local/opt/llvm-5.0/bin/clang-5.0
-    export COMPILER=/usr/local/opt/llvm-5.0/bin/clang++-5.0
-else #linux
-    if [[ ! -z "${whoami}" ]]; then #this happens when running in travis
-        sudo /usr/sbin/useradd -G dialout $USER
-        sudo usermod -a -G dialout $USER
-    fi
-
-    #install clang and build tools
-    sudo apt-get install -y build-essential
-
-    if $gccBuild; then
-        sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-        sudo apt-get -y update
-        sudo apt-get install -y gcc-8 g++-8
+    if [[ $(python $SCRIPT_DIR/tools/version.py $gcc_ver $MIN_GCC_VERSION) ]]; then
+        if [ "$(uname)" == "Darwin" ]; then # osx
+            brew update
+            brew install gcc-6 g++-6
+        else
+            sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+            sudo apt-get -y update
+            sudo apt-get install -y gcc-6 g++-6
+        fi
     else
+        echo "Already have good version of gcc: $gcc_ver"
+    fi
+else
+    # llvm tools
+    if [ "$(uname)" == "Darwin" ]; then # osx
+        brew update
+
+        # brew install llvm@3.9
+        brew tap llvm-hs/homebrew-llvm
+        brew install llvm-5.0
+        export C_COMPILER=/usr/local/opt/llvm-5.0/bin/clang-5.0
+        export COMPILER=/usr/local/opt/llvm-5.0/bin/clang++-5.0
+
+    else #linux
+        #install clang and build tools
+
         VERSION=$(lsb_release -rs | cut -d. -f1)
         # Since Ubuntu 17 clang-5.0 is part of the core repository
         # See https://packages.ubuntu.com/search?keywords=clang-5.0
@@ -76,38 +79,59 @@ else #linux
         export C_COMPILER=clang-5.0
         export COMPILER=clang++-5.0
     fi
+fi
+
+#give user perms to access USB port - this is not needed if not using PX4 HIL
+#TODO: figure out how to do below in travis
+if [ "$(uname)" == "Darwin" ]; then # osx
+    if [[ ! -z "${whoami}" ]]; then #this happens when running in travis
+        sudo dseditgroup -o edit -a `whoami` -t user dialout
+    fi
+
+    brew install wget
+    brew install coreutils
+    brew install cmake  # should get cmake 3.8
+
+else #linux
+    if [[ ! -z "${whoami}" ]]; then #this happens when running in travis
+        sudo /usr/sbin/useradd -G dialout $USER
+        sudo usermod -a -G dialout $USER
+    fi
+
+    #install additional tools
+    sudo apt-get install -y build-essential
     sudo apt-get install -y unzip
 
-fi
+    cmake_ver=$(cmake --version 2>&1 | head -n1 | cut -d ' ' -f3 | awk '{print $NF}')
+    cmake_path=$(which cmake)
+    if [[ "$cmake_path" == "" ]] ; then
+        cmake_ver=0
+    fi
 
-cmake_ver=$(cmake --version 2>&1 | head -n1 | cut -d ' ' -f3 | awk '{print $NF}')
-cmake_path=$(which cmake)
-if [[ "$cmake_path" == "" ]] ; then
-   cmake_ver=0
-fi
-#download cmake - we need v3.9+ which is not out of box in Ubuntu 16.04
-if [[ $(python $SCRIPT_DIR/tools/version.py $cmake_ver $MIN_CMAKE_VERSION) ]]; then
-    if [[ ! -d "cmake_build/bin" ]]; then
-        echo "Downloading cmake..."
-        wget https://cmake.org/files/v3.10/cmake-3.10.2.tar.gz \
-            -O cmake.tar.gz
-        tar -xzf cmake.tar.gz
-        rm cmake.tar.gz
-        rm -rf ./cmake_build
-        mv ./cmake-3.10.2 ./cmake_build
-        pushd cmake_build
-        ./bootstrap
-        make
-        popd
-    fi
-    if [ "$(uname)" == "Darwin" ]; then
-        CMAKE="$(greadlink -f cmake_build/bin/cmake)"
+    #download cmake - v3.10.2 is not out of box in Ubuntu 16.04
+    if [[ $(python $SCRIPT_DIR/tools/version.py $cmake_ver $MIN_CMAKE_VERSION) ]]; then
+        if [[ ! -d "cmake_build/bin" ]]; then
+            echo "Downloading cmake..."
+            wget https://cmake.org/files/v3.10/cmake-3.10.2.tar.gz \
+                -O cmake.tar.gz
+            tar -xzf cmake.tar.gz
+            rm cmake.tar.gz
+            rm -rf ./cmake_build
+            mv ./cmake-3.10.2 ./cmake_build
+            pushd cmake_build
+            ./bootstrap
+            make
+            popd
+        fi
+        if [ "$(uname)" == "Darwin" ]; then
+            CMAKE="$(greadlink -f cmake_build/bin/cmake)"
+        else
+            CMAKE="$(readlink -f cmake_build/bin/cmake)"
+        fi
     else
-        CMAKE="$(readlink -f cmake_build/bin/cmake)"
+        echo "Already have good version of cmake: $cmake_ver"
+        CMAKE=$(which cmake)
     fi
-else
-    echo "Already have good version of cmake: $cmake_ver"
-    CMAKE=$(which cmake)
 fi
 
 # Download rpclib
@@ -127,31 +151,31 @@ if [ ! -d "external/rpclib/rpclib-2.2.1" ]; then
 fi
 
 # Download high-polycount SUV model
-if [ ! -d "Unreal/Plugins/AirSim/Content/VehicleAdv" ]; then
-    mkdir -p "Unreal/Plugins/AirSim/Content/VehicleAdv"
-fi
-if [ ! -d "Unreal/Plugins/AirSim/Content/VehicleAdv/SUV/v1.2.0" ]; then
-    if $downloadHighPolySuv; then
-        echo "*********************************************************************************************"
-        echo "Downloading high-poly car assets.... The download is ~37MB and can take some time."
-        echo "To install without this assets, re-run setup.sh with the argument --no-full-poly-car"
-        echo "*********************************************************************************************"
-
-        if [ -d "suv_download_tmp" ]; then
-            rm -rf "suv_download_tmp"
-        fi
-        mkdir -p "suv_download_tmp"
-        cd suv_download_tmp
-        wget  https://github.com/Microsoft/AirSim/releases/download/v1.2.0/car_assets.zip
-        if [ -d "../Unreal/Plugins/AirSim/Content/VehicleAdv/SUV" ]; then
-            rm -rf "../Unreal/Plugins/AirSim/Content/VehicleAdv/SUV"
-        fi
-        unzip car_assets.zip -d ../Unreal/Plugins/AirSim/Content/VehicleAdv
-        cd ..
-        rm -rf "suv_download_tmp"
-    else
-        echo "Not downloading high-poly car asset. The default unreal vehicle will be used."
+if $downloadHighPolySuv; then
+    if [ ! -d "Unreal/Plugins/AirSim/Content/VehicleAdv" ]; then
+        mkdir -p "Unreal/Plugins/AirSim/Content/VehicleAdv"
     fi
+    if [ ! -d "Unreal/Plugins/AirSim/Content/VehicleAdv/SUV/v1.2.0" ]; then
+            echo "*********************************************************************************************"
+            echo "Downloading high-poly car assets.... The download is ~37MB and can take some time."
+            echo "To install without this assets, re-run setup.sh with the argument --no-full-poly-car"
+            echo "*********************************************************************************************"
+
+            if [ -d "suv_download_tmp" ]; then
+                rm -rf "suv_download_tmp"
+            fi
+            mkdir -p "suv_download_tmp"
+            cd suv_download_tmp
+            wget  https://github.com/Microsoft/AirSim/releases/download/v1.2.0/car_assets.zip
+            if [ -d "../Unreal/Plugins/AirSim/Content/VehicleAdv/SUV" ]; then
+                rm -rf "../Unreal/Plugins/AirSim/Content/VehicleAdv/SUV"
+            fi
+            unzip car_assets.zip -d ../Unreal/Plugins/AirSim/Content/VehicleAdv
+            cd ..
+            rm -rf "suv_download_tmp"
+    fi
+else
+    echo "### Not downloading high-poly car asset (--no-full-poly-car). The default unreal vehicle will be used."
 fi
 
 # Below is alternative way to get clang by downloading binaries
@@ -166,7 +190,7 @@ fi
 
 #get libc++ source
 if ! $gccBuild; then
-    echo Installing llvm 5
+    echo "### Installing llvm 5 libc++ library..."
     if [[ ! -d "llvm-source-50" ]]; then
         git clone --depth=1 -b release_50  https://github.com/llvm-mirror/llvm.git llvm-source-50
         git clone --depth=1 -b release_50  https://github.com/llvm-mirror/libcxx.git llvm-source-50/projects/libcxx
@@ -200,7 +224,7 @@ if ! $gccBuild; then
     popd >/dev/null
 fi
 
-echo Installing EIGEN library...
+echo "Installing EIGEN library..."
 
 if [ "$(uname)" == "Darwin" ]; then
     rm -rf ./AirLib/deps/eigen3/Eigen

--- a/tools/version.py
+++ b/tools/version.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+####################################################################################################
+#
+#  Project:  Embedded Learning Library (ELL)
+#  File:     version.py
+#  Authors:  Chris Lovett
+#
+#  Requires: Python 3.4+
+#
+####################################################################################################
+import argparse
+import sys
+
+
+def check_versions(v1, v2):
+    v1parts = [int(x) for x in v1.split('.')]
+    v2parts = [int(x) for x in v2.split('.')]
+    i = 0
+    while i < len(v1parts) and i < len(v2parts):
+        if v1parts[i] < v2parts[i]:
+            return False
+        i += 1
+
+    if i == len(v1parts) and i < len(v2parts):
+        return False
+
+    return True
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser("Version checking, returns error code if version 1 is less than version 2")
+
+    # required arguments
+    parser.add_argument("version1", help="first version number to compare")
+    parser.add_argument("version2", help="second version number to compare")
+
+    args = parser.parse_args()
+
+    rc = check_versions(args.version1, args.version2)
+    if not rc:
+        print("version {} insufficient, must be at least {}".format(args.version1, args.version2))
+        sys.exit(-1)
+
+    sys.exit(0)


### PR DESCRIPTION
I added "--gcc" option to setup.sh which bypasses install of LLVM 5 and "./build.sh --gcc" now works properly.  Fixed GCC compile issues involving std::sinf, std::cosf, etc.  And added a version check so cmake is only installed if user doesn't already have the right version.  