### PR TITLE
Prevent Environment from crashing when there is no sun UObject in the scene

### DIFF
--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
@@ -160,7 +160,8 @@ void ASimModeBase::initializeTimeOfDay()
         UObjectProperty* sun_prop = Cast<UObjectProperty>(p);
         UObject* sun_obj = sun_prop->GetObjectPropertyValue_InContainer(sky_sphere_);
         sun_ = Cast<ADirectionalLight>(sun_obj);
-        default_sun_rotation_ = sun_->GetActorRotation();
+		if (sun_)
+			default_sun_rotation_ = sun_->GetActorRotation();
     }
 }
 


### PR DESCRIPTION
Indoor environments with no sun will crash when AirSim attempts to set the default sun rotation, as `sun_ = nullptr` in those situations.