### PR TITLE
Fix for low-repro reset bug.

### DIFF
--- a/AirLib/include/api/VehicleApiBase.hpp
+++ b/AirLib/include/api/VehicleApiBase.hpp
@@ -37,11 +37,6 @@ public:
     virtual bool armDisarm(bool arm) = 0;
     virtual GeoPoint getHomeGeoPoint() const = 0;
 
-    //default implementation so derived class doesn't have to call on UpdatableObject
-    virtual void reset() override
-    {
-        UpdatableObject::reset();
-    }
     virtual void update() override
     {
         UpdatableObject::update();

--- a/AirLib/include/api/VehicleSimApiBase.hpp
+++ b/AirLib/include/api/VehicleSimApiBase.hpp
@@ -17,11 +17,6 @@ class VehicleSimApiBase : public msr::airlib::UpdatableObject {
 public:
     virtual ~VehicleSimApiBase() = default;
 
-    //default implementation so derived class doesn't have to call on UpdatableObject
-    virtual void reset() override
-    {
-        UpdatableObject::reset();
-    }
     virtual void update() override
     {
         UpdatableObject::update();

--- a/AirLib/include/common/DelayLine.hpp
+++ b/AirLib/include/common/DelayLine.hpp
@@ -11,7 +11,7 @@
 namespace msr { namespace airlib {
 
 template<typename T>
-class DelayLine : UpdatableObject {
+class DelayLine : public UpdatableObject {
 public:
     DelayLine()
     {}
@@ -33,10 +33,8 @@ public:
     }
 
     //*** Start: UpdatableState implementation ***//
-    virtual void reset() override
-    {
-        UpdatableObject::reset();
-
+     virtual void resetImplementation() override
+     {
         values_.clear();
         times_.clear();
         last_time_ = 0;

--- a/AirLib/include/common/FirstOrderFilter.hpp
+++ b/AirLib/include/common/FirstOrderFilter.hpp
@@ -12,7 +12,7 @@
 namespace msr { namespace airlib {
 
 template <typename T>
-class FirstOrderFilter : UpdatableObject {
+class FirstOrderFilter : public UpdatableObject {
     /*
     This class can be used to apply a first order filter on a signal.
     It allows different acceleration and deceleration time constants.
@@ -42,10 +42,8 @@ public:
     }
 
     //*** Start: UpdatableState implementation ***//
-    virtual void reset() override
+    virtual void resetImplementation() override
     {
-        UpdatableObject::reset();
-
         last_time_ = clock()->nowNanos();
         input_ = initial_input_;
         output_ = initial_output_;

--- a/AirLib/include/common/FrequencyLimiter.hpp
+++ b/AirLib/include/common/FrequencyLimiter.hpp
@@ -10,7 +10,7 @@
 
 namespace msr { namespace airlib {
 
-class FrequencyLimiter : UpdatableObject {
+class FrequencyLimiter : public UpdatableObject {
 public:
     FrequencyLimiter(real_T frequency = Utils::max<float>(), real_T startup_delay = 0)
     {
@@ -24,13 +24,8 @@ public:
     }
 
     //*** Start: UpdatableState implementation ***//
-    virtual void reset() override
+    virtual void resetImplementation() override
     {
-        //disable checks for reset/update sequence because
-        //this object may get created but not used
-        clearResetUpdateAsserts();  
-        UpdatableObject::reset();
-
         last_time_ = clock()->nowNanos();
         first_time_ = last_time_;
 
@@ -45,6 +40,13 @@ public:
         update_count_ = 0;
         interval_complete_ = false;
         startup_complete_ = false;
+    }
+
+    virtual void failResetUpdateOrdering(std::string err) override
+    {
+        // Do nothing.
+        // Disable checks for reset/update sequence because
+        // this object may get created but not used.
     }
 
     virtual void update() override

--- a/AirLib/include/common/GaussianMarkov.hpp
+++ b/AirLib/include/common/GaussianMarkov.hpp
@@ -11,7 +11,7 @@
 
 namespace msr { namespace airlib {
 
-class GaussianMarkov : UpdatableObject {
+class GaussianMarkov : public UpdatableObject {
 public:
     GaussianMarkov()
     {}
@@ -32,10 +32,8 @@ public:
     }
 
     //*** Start: UpdatableState implementation ***//
-    virtual void reset() override
+    virtual void resetImplementation() override
     {
-        UpdatableObject::reset();
-
         last_time_ = clock()->nowNanos();
         output_ = initial_output_;
         rand_.reset();

--- a/AirLib/include/common/StateReporterWrapper.hpp
+++ b/AirLib/include/common/StateReporterWrapper.hpp
@@ -37,17 +37,19 @@ public:
     }
 
     //*** Start: UpdatableState implementation ***//
-    virtual void reset() override
+    virtual void resetImplementation() override
     {
-        //disable checks for reset/update sequence because
-        //this object may get created but not used
-        clearResetUpdateAsserts();  
-        UpdatableObject::reset();
-
         last_time_ = clock()->nowNanos();
         clearReport();
         dt_stats_.clear();
         report_freq_.reset();
+    }
+
+    virtual void failResetUpdateOrdering(std::string err) override
+    {
+        // Do nothing.
+        // Disable checks for reset/update sequence because
+        // this object may get created but not used.
     }
 
     virtual void update() override

--- a/AirLib/include/common/UpdatableContainer.hpp
+++ b/AirLib/include/common/UpdatableContainer.hpp
@@ -31,10 +31,8 @@ public: //limited container interface
 
 public:
     //*** Start: UpdatableState implementation ***//
-    virtual void reset() override
+    virtual void resetImplementation() override
     {
-        UpdatableObject::reset();
-
         for (TUpdatableObjectPtr& member : members_)
             member->reset();
     }

--- a/AirLib/include/physics/Environment.hpp
+++ b/AirLib/include/physics/Environment.hpp
@@ -78,17 +78,24 @@ public:
         return current_;
     }
 
-    //*** Start: UpdatableState implementation ***//
-    virtual void reset()
-    {
-        current_ = initial_;
-    }
-
     virtual void update()
     {
         updateState(current_, home_geo_point_);
     }
-    //*** End: UpdatableState implementation ***//
+
+protected:
+    virtual void resetImplementation() override
+    {
+        current_ = initial_;
+    }
+
+    virtual void failResetUpdateOrdering(std::string err) override
+    {
+        //Do nothing.
+        //The environment gets reset() twice without an update() inbetween,
+        //via MultirotorPawnSimApi::reset() and CarSimApi::reset(), because
+        //those functions directly reset an environment, and also call other reset()s that reset the same environment.
+    }
 
 private:
     static void updateState(State& state, const HomeGeoPoint& home_geo_point)

--- a/AirLib/include/physics/FastPhysicsEngine.hpp
+++ b/AirLib/include/physics/FastPhysicsEngine.hpp
@@ -24,10 +24,8 @@ public:
     }
 
     //*** Start: UpdatableState implementation ***//
-    virtual void reset() override
+    virtual void resetImplementation() override
     {
-        PhysicsEngineBase::reset();
-
         for (PhysicsBody* body_ptr : *this) {
             initPhysicsBody(body_ptr);
         }

--- a/AirLib/include/physics/Kinematics.hpp
+++ b/AirLib/include/physics/Kinematics.hpp
@@ -38,11 +38,8 @@ public:
         initial_ = initial;
     }
 
-    //*** Start: UpdatableState implementation ***//
-    virtual void reset() override
+    virtual void resetImplementation() override
     {
-        UpdatableObject::reset();
-
         current_ = initial_;
     }
 

--- a/AirLib/include/physics/PhysicsBody.hpp
+++ b/AirLib/include/physics/PhysicsBody.hpp
@@ -95,10 +95,8 @@ public: //methods
 
 
     //*** Start: UpdatableState implementation ***//
-    virtual void reset() override
+    virtual void resetImplementation() override
     {
-        UpdatableObject::reset();
-
         if (environment_)
             environment_->reset();
         wrench_ = Wrench::zero();

--- a/AirLib/include/physics/PhysicsBodyVertex.hpp
+++ b/AirLib/include/physics/PhysicsBodyVertex.hpp
@@ -43,12 +43,9 @@ public:
         drag_factor_ = drag_factor;
     }
 
-
     //*** Start: UpdatableState implementation ***//
-    virtual void reset() override
+    virtual void resetImplementation() override
     {
-        UpdatableObject::reset();
-
         position_ = initial_position_;
         normal_ = initial_normal_;
 

--- a/AirLib/include/physics/PhysicsEngineBase.hpp
+++ b/AirLib/include/physics/PhysicsEngineBase.hpp
@@ -12,11 +12,6 @@ namespace msr { namespace airlib {
 
 class PhysicsEngineBase : public UpdatableObject {
 public:
-    virtual void reset() override
-    {
-        UpdatableObject::reset();
-    }
-
     virtual void update() override
     {
         UpdatableObject::update();

--- a/AirLib/include/physics/World.hpp
+++ b/AirLib/include/physics/World.hpp
@@ -27,9 +27,9 @@ public:
 
     //override updatable interface so we can synchronize physics engine
     //*** Start: UpdatableState implementation ***//
-    virtual void reset() override
+    virtual void resetImplementation() override
     {
-        UpdatableContainer::reset();
+        UpdatableContainer::resetImplementation();
         
         if (physics_engine_)
             physics_engine_->reset();

--- a/AirLib/include/sensors/SensorCollection.hpp
+++ b/AirLib/include/sensors/SensorCollection.hpp
@@ -12,7 +12,7 @@
 
 namespace msr { namespace airlib {
 
-class SensorCollection : UpdatableObject {
+class SensorCollection : public UpdatableObject {
 public: //types
     typedef SensorBase* SensorBasePtr;
 public:
@@ -68,10 +68,8 @@ public:
     }
     
     //*** Start: UpdatableState implementation ***//
-    virtual void reset() override
+    virtual void resetImplementation() override
     {
-        UpdatableObject::reset();
-
         for (auto& pair : sensors_) {
             pair.second->reset();
         }

--- a/AirLib/include/sensors/barometer/BarometerSimple.hpp
+++ b/AirLib/include/sensors/barometer/BarometerSimple.hpp
@@ -36,10 +36,8 @@ public:
     }
 
     //*** Start: UpdatableState implementation ***//
-    virtual void reset() override
+    virtual void resetImplementation() override
     {
-        BarometerBase::reset();
-
         pressure_factor_.reset();
         //correlated_noise_.reset();
         uncorrelated_noise_.reset();

--- a/AirLib/include/sensors/distance/DistanceSimple.hpp
+++ b/AirLib/include/sensors/distance/DistanceSimple.hpp
@@ -32,13 +32,10 @@ public:
     }
 
     //*** Start: UpdatableState implementation ***//
-    virtual void reset() override
+    virtual void resetImplementation() override
     {
-        DistanceBase::reset();
-
         //correlated_noise_.reset();
         uncorrelated_noise_.reset();
-
 
         freq_limiter_.reset();
         delay_line_.reset();

--- a/AirLib/include/sensors/gps/GpsSimple.hpp
+++ b/AirLib/include/sensors/gps/GpsSimple.hpp
@@ -33,10 +33,8 @@ public: //methods
     }
 
     //*** Start: UpdatableState implementation ***//
-    virtual void reset() override
+    virtual void resetImplementation() override
     {
-        GpsBase::reset();
-
         freq_limiter_.reset();
         delay_line_.reset();
 

--- a/AirLib/include/sensors/imu/ImuSimple.hpp
+++ b/AirLib/include/sensors/imu/ImuSimple.hpp
@@ -25,10 +25,8 @@ public:
     }
 
     //*** Start: UpdatableState implementation ***//
-    virtual void reset() override
+    virtual void resetImplementation() override
     {
-        ImuBase::reset();
-
         last_time_ = clock()->nowNanos();
 
         state_.gyroscope_bias = params_.gyro.turn_on_bias;

--- a/AirLib/include/sensors/lidar/LidarSimple.hpp
+++ b/AirLib/include/sensors/lidar/LidarSimple.hpp
@@ -26,10 +26,8 @@ public:
     }
 
     //*** Start: UpdatableState implementation ***//
-    virtual void reset() override
+    virtual void resetImplementation() override
     {
-        LidarBase::reset();
-
         freq_limiter_.reset();
         last_time_ = clock()->nowNanos();
 

--- a/AirLib/include/sensors/magnetometer/MagnetometerSimple.hpp
+++ b/AirLib/include/sensors/magnetometer/MagnetometerSimple.hpp
@@ -32,10 +32,8 @@ public:
     }
 
     //*** Start: UpdatableObject implementation ***//
-    virtual void reset() override
+    virtual void resetImplementation() override
     {
-        MagnetometerBase::reset();
-
         //Ground truth is reset before sensors are reset
         updateReference(getGroundTruth());
         noise_vec_.reset();

--- a/AirLib/include/vehicles/car/api/CarApiBase.hpp
+++ b/AirLib/include/vehicles/car/api/CarApiBase.hpp
@@ -78,20 +78,13 @@ public:
         initialize(vehicle_setting, sensor_factory, state, environment);
     }
 
-    //default implementation so derived class doesn't have to call on VehicleApiBase
-    virtual void reset() override
-    {
-        VehicleApiBase::reset();
-
-        //reset sensors last after their ground truth has been reset
-        getSensors().reset();
-    }
     virtual void update() override
     {
         VehicleApiBase::update();
 
         getSensors().update();
     }
+
     void reportState(StateReporter& reporter) override
     {
         getSensors().reportState(reporter);
@@ -142,6 +135,13 @@ public:
     std::shared_ptr<const SensorFactory> sensor_factory_;
     SensorCollection sensors_; //maintains sensor type indexed collection of sensors
     vector<unique_ptr<SensorBase>> sensor_storage_; //RAII for created sensors
+
+protected:
+    virtual void resetImplementation() override
+    {
+        //reset sensors last after their ground truth has been reset
+        getSensors().reset();
+    }
 };
 
 

--- a/AirLib/include/vehicles/multirotor/MultiRotor.hpp
+++ b/AirLib/include/vehicles/multirotor/MultiRotor.hpp
@@ -26,10 +26,10 @@ public:
     }
 
     //*** Start: UpdatableState implementation ***//
-    virtual void reset() override
+    virtual void resetImplementation() override
     {
         //reset rotors, kinematics and environment
-        PhysicsBody::reset();
+        PhysicsBody::resetImplementation();
 
         //reset sensors last after their ground truth has been reset
         resetSensors();

--- a/AirLib/include/vehicles/multirotor/Rotor.hpp
+++ b/AirLib/include/vehicles/multirotor/Rotor.hpp
@@ -66,9 +66,9 @@ public: //methods
 
        
     //*** Start: UpdatableState implementation ***//
-    virtual void reset() override
+    virtual void resetImplementation() override
     {
-        PhysicsBodyVertex::reset();
+        PhysicsBodyVertex::resetImplementation();
 
         //update environmental factors before we call base
         updateEnvironmentalFactors();

--- a/AirLib/include/vehicles/multirotor/api/MultirotorApiBase.hpp
+++ b/AirLib/include/vehicles/multirotor/api/MultirotorApiBase.hpp
@@ -69,7 +69,7 @@ public: //optional overrides
         unused(environment);
     }
 
-    virtual void reset() override;
+    virtual void resetImplementation() override;
 
 
 public: //these APIs uses above low level APIs

--- a/AirLib/include/vehicles/multirotor/firmwares/arducopter/ArduCopterApi.hpp
+++ b/AirLib/include/vehicles/multirotor/firmwares/arducopter/ArduCopterApi.hpp
@@ -49,9 +49,9 @@ public:
 
 
 public: 
-    virtual void reset() override
+    virtual void resetImplementation() override
     {
-        MultirotorApiBase::reset();
+        MultirotorApiBase::resetImplementation();
 
         // Reset state
     }

--- a/AirLib/include/vehicles/multirotor/firmwares/mavlink/MavLinkMultirotorApi.hpp
+++ b/AirLib/include/vehicles/multirotor/firmwares/mavlink/MavLinkMultirotorApi.hpp
@@ -73,9 +73,9 @@ public: //methods
     }
 
     //reset PX4 stack
-    virtual void reset() override
+    virtual void resetImplementation() override
     {
-        MultirotorApiBase::reset();
+        MultirotorApiBase::resetImplementation();
 
         resetState();
         was_reset_ = true;

--- a/AirLib/include/vehicles/multirotor/firmwares/simple_flight/SimpleFlightApi.hpp
+++ b/AirLib/include/vehicles/multirotor/firmwares/simple_flight/SimpleFlightApi.hpp
@@ -44,9 +44,9 @@ public:
 
 
 public: //VehicleApiBase implementation
-    virtual void reset() override
+    virtual void resetImplementation() override
     {
-        MultirotorApiBase::reset();
+        MultirotorApiBase::resetImplementation();
 
         firmware_->reset();
     }

--- a/AirLib/src/api/RpcLibServerBase.cpp
+++ b/AirLib/src/api/RpcLibServerBase.cpp
@@ -9,7 +9,6 @@
 
 #include "api/RpcLibServerBase.hpp"
 
-
 #include "common/Common.hpp"
 STRICT_MODE_OFF
 
@@ -30,6 +29,7 @@ STRICT_MODE_OFF
 #include "common/common_utils/WindowsApisCommonPost.hpp"
 
 #include "api/RpcLibAdapatorsBase.hpp"
+#include <functional>
 
 STRICT_MODE_ON
 
@@ -141,11 +141,19 @@ RpcLibServerBase::RpcLibServerBase(ApiProvider* api_provider, const std::string&
     });    
 
     pimpl_->server.bind("reset", [&]() -> void {
+        //Exit if already resetting.
+        static bool resetInProgress;
+        if (resetInProgress)
+            return;
+
+        //Reset
+        resetInProgress = true;
         auto* sim_world_api = getWorldSimApi();
         if (sim_world_api)
             sim_world_api->reset();
         else
             getVehicleApi("")->reset();
+            resetInProgress = false;
     });
 
     pimpl_->server.bind("simPrintLogMessage", [&](const std::string& message, const std::string& message_param, unsigned char severity) -> void {

--- a/AirLib/src/vehicles/multirotor/api/MultirotorApiBase.cpp
+++ b/AirLib/src/vehicles/multirotor/api/MultirotorApiBase.cpp
@@ -13,12 +13,10 @@
 
 namespace msr { namespace airlib {
 
-void MultirotorApiBase::reset()
+void MultirotorApiBase::resetImplementation()
 {
     cancelLastTask();
     SingleTaskCall lock(this); //cancel previous tasks
-
-    VehicleApiBase::reset();
 }
 
 bool MultirotorApiBase::takeoff(float timeout_sec)

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/PawnSimApi.cpp
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/PawnSimApi.cpp
@@ -146,9 +146,8 @@ AirSimPose PawnSimApi::GetInitialPose()
 	return AirSimPose(state_.start_location, state_.start_rotation);
 }
 
-void PawnSimApi::reset()
+void PawnSimApi::resetImplementation()
 {
-	VehicleSimApiBase::reset();
 	state_ = initial_state_;
 	rc_data_ = msr::airlib::RCData();
     kinematics_->reset();

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/PawnSimApi.h
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/PawnSimApi.h
@@ -64,7 +64,7 @@ protected:
 public:
     virtual void initialize() override;
 	PawnSimApi(const Params& params);
-	virtual void reset() override;
+	virtual void resetImplementation() override;
 	virtual void update() override;
 	virtual const UnityImageCapture* getImageCapture() const override;
 	virtual std::vector<ImageCaptureBase::ImageResponse> getImages(const std::vector<ImageCaptureBase::ImageRequest>& request) const override;

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/Vehicles/Car/CarPawnApi.cpp
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/Vehicles/Car/CarPawnApi.cpp
@@ -46,9 +46,9 @@ msr::airlib::CarApiBase::CarState CarPawnApi::getCarState() const
 	return state;
 }
 
-void CarPawnApi::reset()
+void CarPawnApi::resetImplementation()
 {
-	msr::airlib::CarApiBase::reset();
+	msr::airlib::CarApiBase::resetImplementation();
 
 	last_controls_ = CarControls();
 	setCarControls(CarControls());

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/Vehicles/Car/CarPawnApi.h
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/Vehicles/Car/CarPawnApi.h
@@ -16,7 +16,7 @@ public:
 		const msr::airlib::Kinematics::State& state, const msr::airlib::Environment& environment);
 	virtual void setCarControls(const CarApiBase::CarControls& controls) override;
 	virtual CarApiBase::CarState getCarState() const override;
-	virtual void reset() override;
+	virtual void resetImplementation() override;
 	virtual void update() override;
 	virtual msr::airlib::GeoPoint getHomeGeoPoint() const override;
 	virtual void enableApiControl(bool is_enabled) override;

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/Vehicles/Car/CarPawnSimApi.cpp
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/Vehicles/Car/CarPawnSimApi.cpp
@@ -163,12 +163,12 @@ void CarPawnSimApi::updateCarControls()
 }
 
 //*** Start: UpdatableState implementation ***//
-void CarPawnSimApi::reset()
+void CarPawnSimApi::resetImplementation()
 {
 	setPose(UnityUtilities::Convert_to_Pose(GetInitialPose()), false);
 	Reset(getVehicleName().c_str());
 
-	PawnSimApi::reset();
+	PawnSimApi::resetImplementation();
 	vehicle_api_->reset();
 }
 

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/Vehicles/Car/CarPawnSimApi.h
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/Vehicles/Car/CarPawnSimApi.h
@@ -21,7 +21,7 @@ public:
     virtual void initialize() override;
 	CarPawnSimApi(const Params& params, const CarPawnApi::CarControls&  keyboard_controls, std::string car_name);
 	virtual ~CarPawnSimApi() = default;
-	virtual void reset() override;
+	virtual void resetImplementation() override;
 	virtual void update() override;
 	//virtual void reportState(StateReporter& reporter) override;
 	virtual std::string getRecordFileLine(bool is_header_line) const override;

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/Vehicles/Multirotor/MultirotorPawnSimApi.cpp
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/Vehicles/Multirotor/MultirotorPawnSimApi.cpp
@@ -138,9 +138,9 @@ void MultirotorPawnSimApi::setPose(const Pose& pose, bool ignore_collision)
 }
 
 //*** Start: UpdatableState implementation ***//
-void MultirotorPawnSimApi::reset()
+void MultirotorPawnSimApi::resetImplementation()
 {
-	PawnSimApi::reset();
+	PawnSimApi::resetImplementation();
 
 	vehicle_api_->reset();
 	phys_vehicle_->reset();

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/Vehicles/Multirotor/MultirotorPawnSimApi.h
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/Vehicles/Multirotor/MultirotorPawnSimApi.h
@@ -25,7 +25,7 @@ public:
 	virtual ~MultirotorPawnSimApi() = default;
 	virtual void updateRenderedState(float dt) override;
 	virtual void updateRendering(float dt) override;
-	virtual void reset() override;
+	virtual void resetImplementation() override;
 	virtual void update() override;
 	virtual void reportState(StateReporter& reporter) override;
 	virtual UpdatableObject* getPhysicsBody() override;

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.cpp
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.cpp
@@ -15,7 +15,7 @@ bool WorldSimApi::isPaused() const
 	return simmode_->isPaused();
 }
 
-void WorldSimApi::reset()
+void WorldSimApi::resetImplementation()
 {
 	simmode_->reset();
 }

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.h
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.h
@@ -13,7 +13,7 @@ public:
 	WorldSimApi(SimModeBase* simmode, std::string vehicle_name);
 	virtual ~WorldSimApi();
 	virtual bool isPaused() const override;
-	virtual void reset() override;
+	virtual void resetImplementation() override;
 	virtual void pause(bool is_paused) override;
 	virtual void continueForTime(double seconds) override;
         virtual void setTimeOfDay(bool is_enabled, const std::string& start_datetime, bool is_start_datetime_dst,

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
@@ -287,10 +287,8 @@ int PawnSimApi::getCameraCount()
     return cameras_.valsSize();
 }
 
-void PawnSimApi::reset()
+void PawnSimApi::resetImplementation()
 {
-    VehicleSimApiBase::reset();
-
     state_ = initial_state_;
     rc_data_ = msr::airlib::RCData();
     params_.pawn->SetActorLocationAndRotation(state_.start_location, state_.start_rotation, false, nullptr, ETeleportType::TeleportPhysics);

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.h
@@ -68,7 +68,7 @@ public: //types
 public: //implementation of VehicleSimApiBase
     virtual void initialize() override;
 
-    virtual void reset() override;
+    virtual void resetImplementation() override;
     virtual void update() override;
 
     virtual const UnrealImageCapture* getImageCapture() const override;

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnApi.cpp
@@ -54,9 +54,9 @@ msr::airlib::CarApiBase::CarState CarPawnApi::getCarState() const
     return state;
 }
 
-void CarPawnApi::reset()
+void CarPawnApi::resetImplementation()
 {
-    msr::airlib::CarApiBase::reset();
+    msr::airlib::CarApiBase::resetImplementation();
 
     last_controls_ = CarControls();
     auto phys_comps = UAirBlueprintLib::getPhysicsComponents(pawn_);

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnApi.h
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnApi.h
@@ -18,7 +18,6 @@ public:
 
     virtual CarApiBase::CarState getCarState() const override;
 
-    virtual void reset() override;
     virtual void update() override;
 
     virtual msr::airlib::GeoPoint getHomeGeoPoint() const override;
@@ -30,6 +29,9 @@ public:
     virtual const CarApiBase::CarControls& getCarControls() const override;
 
     virtual ~CarPawnApi();
+
+protected:
+    virtual void resetImplementation() override;
 
 private:
     UWheeledVehicleMovementComponent* movement_;

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnSimApi.cpp
@@ -159,9 +159,9 @@ void CarPawnSimApi::updateCarControls()
 }
 
 //*** Start: UpdatableState implementation ***//
-void CarPawnSimApi::reset()
+void CarPawnSimApi::resetImplementation()
 {
-    PawnSimApi::reset();
+    PawnSimApi::resetImplementation();
 
     vehicle_api_->reset();
 }

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnSimApi.h
@@ -29,7 +29,7 @@ public:
     CarPawnSimApi(const Params& params,
         const CarPawnApi::CarControls&  keyboard_controls, UWheeledVehicleMovementComponent* movement);
 
-    virtual void reset() override;
+    virtual void resetImplementation() override;
     virtual void update() override;
 
     virtual std::string getRecordFileLine(bool is_header_line) const override;

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Multirotor/MultirotorPawnSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Multirotor/MultirotorPawnSimApi.cpp
@@ -137,9 +137,9 @@ void MultirotorPawnSimApi::setPose(const Pose& pose, bool ignore_collision)
 }
 
 //*** Start: UpdatableState implementation ***//
-void MultirotorPawnSimApi::reset()
+void MultirotorPawnSimApi::resetImplementation()
 {
-    PawnSimApi::reset();
+    PawnSimApi::resetImplementation();
 
     vehicle_api_->reset();
     phys_vehicle_->reset();

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Multirotor/MultirotorPawnSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Multirotor/MultirotorPawnSimApi.h
@@ -38,7 +38,7 @@ public:
 
     //PhysicsBody interface
     //this just wrapped around MultiRotor physics body
-    virtual void reset() override;
+    virtual void resetImplementation() override;
     virtual void update() override;
     virtual void reportState(StateReporter& reporter) override;
     virtual UpdatableObject* getPhysicsBody() override;


### PR DESCRIPTION
original PR by @ironclownfish https://github.com/microsoft/AirSim/pull/1970
recreating coz of recursive git rebase and/or merge errors

Changed virtual void UpdatableObject::reset() to void UpdatableObject::reset(), and added a new function: UpdatableObject::resetImplementation(), which is called by UpdatableObject::reset().

reset() overrides always had to call super to get the base class functionality. Now the base class functionality is inherent in the reset() call. This allows the addition of a reset_in_progress flag in a single place, rather than in every reset() override. This new flag is used to make reset() reentrant, which fixes the bug.

Also removed all extraneous calls to super from reset() overrides (which are now resetImplementation() overrides). Moved other UpdatableObject reset/update failure cases into a virtual function: failResetUpdateOrdering(), so they can be disabled by overriding the function. This is a little cleaner, and the old way of disabling didn't work with the new reset stuff.