### PR TITLE
Restructure of Car Vehicle for external firmware control

### DIFF
--- a/AirLib/include/vehicles/car/CarApiFactory.hpp
+++ b/AirLib/include/vehicles/car/CarApiFactory.hpp
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef msr_airlib_vehicles_CarApiFactory_hpp
+#define msr_airlib_vehicles_CarApiFactory_hpp
+
+#include "vehicles/car/firmwares/physxcar/PhysXCarApi.hpp"
+
+namespace msr { namespace airlib {
+
+class CarApiFactory {
+public:
+    static std::unique_ptr<CarApiBase> createApi(const AirSimSettings::VehicleSetting* vehicle_setting, 
+                                                 std::shared_ptr<SensorFactory> sensor_factory, 
+                                                 const Kinematics::State& state, const Environment& environment, 
+                                                 const msr::airlib::GeoPoint& home_geopoint)
+    {
+        if (vehicle_setting->vehicle_type == "" || //default config
+            vehicle_setting->vehicle_type == AirSimSettings::kVehicleTypePhysXCar) {
+            return std::unique_ptr<CarApiBase>(new PhysXCarApi(vehicle_setting, sensor_factory, 
+                                                               state, environment, home_geopoint));
+        }
+        else
+            throw std::runtime_error(Utils::stringf(
+                    "Cannot create vehicle config because vehicle name '%s' is not recognized",
+                    vehicle_setting->vehicle_name.c_str()));
+    }
+};
+
+}} // namespace
+
+#endif

--- a/AirLib/include/vehicles/car/api/CarApiBase.hpp
+++ b/AirLib/include/vehicles/car/api/CarApiBase.hpp
@@ -58,6 +58,10 @@ public:
         Kinematics::State kinematics_estimated;
         uint64_t timestamp;
 
+        CarState()
+        {
+        }
+
         CarState(float speed_val, int gear_val, float rpm_val, float maxrpm_val, bool handbrake_val, 
             const Kinematics::State& kinematics_estimated_val, uint64_t timestamp_val)
             : speed(speed_val), gear(gear_val), rpm(rpm_val), maxrpm(maxrpm_val), handbrake(handbrake_val), 
@@ -127,8 +131,9 @@ public:
     }
 
     virtual void setCarControls(const CarControls& controls) = 0;
-    virtual CarState getCarState() const = 0;
-    virtual const CarApiBase::CarControls& getCarControls() const = 0;
+    virtual void updateCarState(const CarState& state) = 0;
+    virtual const CarState& getCarState() const = 0;
+    virtual const CarControls& getCarControls() const = 0;
 
     virtual ~CarApiBase() = default;
 

--- a/AirLib/include/vehicles/car/firmwares/physxcar/PhysXCarApi.hpp
+++ b/AirLib/include/vehicles/car/firmwares/physxcar/PhysXCarApi.hpp
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef msr_airlib_PhysXCarController_hpp
+#define msr_airlib_PhysXCarController_hpp
+
+#include "vehicles/car/api/CarApiBase.hpp"
+
+namespace msr { namespace airlib {
+
+class PhysXCarApi : public CarApiBase {
+public:
+    PhysXCarApi(const AirSimSettings::VehicleSetting* vehicle_setting, std::shared_ptr<SensorFactory> sensor_factory, 
+                const Kinematics::State& state, const Environment& environment, const msr::airlib::GeoPoint& home_geopoint)
+    : CarApiBase(vehicle_setting, sensor_factory, state, environment),
+      home_geopoint_(home_geopoint), state_(state)
+    {}
+
+    ~PhysXCarApi()
+    {}
+
+protected:
+    virtual void resetImplementation() override
+    {
+        CarApiBase::resetImplementation();
+    }
+
+public:
+    virtual void update() override
+    {
+        CarApiBase::update();
+    }
+
+    virtual const SensorCollection& getSensors() const override
+    {
+        return CarApiBase::getSensors();
+    }
+
+    // VehicleApiBase Implementation
+    virtual void enableApiControl(bool is_enabled) override
+    {
+        if (api_control_enabled_ != is_enabled) {
+            last_controls_ = CarControls();
+            api_control_enabled_ = is_enabled;
+        }
+    }
+
+    virtual bool isApiControlEnabled() const override
+    {
+        return api_control_enabled_;
+    }
+
+    virtual GeoPoint getHomeGeoPoint() const override
+    {
+        return home_geopoint_;
+    }
+
+    virtual bool armDisarm(bool arm) override
+    {
+        //TODO: implement arming for car
+        unused(arm);
+        return true;
+    }
+
+
+public:
+    virtual void setCarControls(const CarControls& controls) override
+    {
+        last_controls_ = controls;  
+    }
+
+    virtual void updateCarState(const CarState& car_state) override
+    {
+        last_car_state_ = car_state;
+    }
+
+    virtual const CarState& getCarState() const override
+    {
+        return last_car_state_;
+    }
+
+    virtual const CarControls& getCarControls() const override
+    {
+        return last_controls_;
+    }
+
+private:
+    bool api_control_enabled_ = false;
+    GeoPoint home_geopoint_;
+    CarControls last_controls_;
+    const Kinematics::State& state_;
+    CarState last_car_state_;
+
+};
+
+}}
+
+#endif

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/Vehicles/Car/CarPawnApi.cpp
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/Vehicles/Car/CarPawnApi.cpp
@@ -2,38 +2,23 @@
 #include "../../PInvokeWrapper.h"
 
 
-CarPawnApi::CarPawnApi(CarPawn* pawn, const msr::airlib::Kinematics::State* pawn_kinematics, const msr::airlib::GeoPoint& home_geopoint,
-	const msr::airlib::AirSimSettings::VehicleSetting* vehicle_setting, std::shared_ptr<msr::airlib::SensorFactory> sensor_factory,
-	const std::string car_name,
-	const msr::airlib::Kinematics::State& state, const msr::airlib::Environment& environment)
-	: msr::airlib::CarApiBase(vehicle_setting, sensor_factory, state, environment),
-	pawn_(pawn), pawn_kinematics_(pawn_kinematics), home_geopoint_(home_geopoint), car_name_(car_name)
+CarPawnApi::CarPawnApi(CarPawn* pawn, const msr::airlib::Kinematics::State* pawn_kinematics,
+	const std::string car_name, msr::airlib::CarApiBase* vehicle_api)
+	: pawn_(pawn), pawn_kinematics_(pawn_kinematics), car_name_(car_name), vehicle_api_(vehicle_api)
 {
 }
 
-bool CarPawnApi::armDisarm(bool arm)
-{
-	//TODO: implement arming for car
-	unused(arm);
-	return true;
-}
-
-void CarPawnApi::setCarControls(const CarApiBase::CarControls& controls)
+void CarPawnApi::updateMovement(const msr::airlib::CarApiBase::CarControls& controls)
 {
 	last_controls_ = controls;
 	SetCarApiControls(controls, car_name_.c_str());
-}
-
-const msr::airlib::CarApiBase::CarControls& CarPawnApi::getCarControls() const
-{
-	return last_controls_;
 }
 
 msr::airlib::CarApiBase::CarState CarPawnApi::getCarState() const
 {
 	AirSimCarState carState = GetCarState(car_name_.c_str());
 
-	CarApiBase::CarState state(
+	msr::airlib::CarApiBase::CarState state(
 		carState.speed,
 		carState.gear,
 		carState.engineRotationSpeed,
@@ -46,36 +31,18 @@ msr::airlib::CarApiBase::CarState CarPawnApi::getCarState() const
 	return state;
 }
 
-void CarPawnApi::resetImplementation()
+void CarPawnApi::reset()
 {
-	msr::airlib::CarApiBase::resetImplementation();
+	vehicle_api_->reset();
 
-	last_controls_ = CarControls();
-	setCarControls(CarControls());
+	last_controls_ = msr::airlib::CarApiBase::CarControls();
+	updateMovement(msr::airlib::CarApiBase::CarControls());
 }
 
 void CarPawnApi::update()
 {
-	msr::airlib::CarApiBase::update();
-}
-
-msr::airlib::GeoPoint CarPawnApi::getHomeGeoPoint() const
-{
-	return home_geopoint_;
-}
-
-void CarPawnApi::enableApiControl(bool is_enabled)
-{
-	if (api_control_enabled_ != is_enabled) {
-		last_controls_ = CarControls();
-		api_control_enabled_ = is_enabled;
-		SetEnableApi(is_enabled, car_name_.c_str());
-	}
-}
-
-bool CarPawnApi::isApiControlEnabled() const
-{
-	return api_control_enabled_;
+	vehicle_api_->updateCarState(getCarState());
+	vehicle_api_->update();
 }
 
 CarPawnApi::~CarPawnApi() = default;

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/Vehicles/Car/CarPawnApi.h
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/Vehicles/Car/CarPawnApi.h
@@ -4,32 +4,27 @@
 #include "physics/Kinematics.hpp"
 #include "CarPawn.h"
 
-class CarPawnApi : public msr::airlib::CarApiBase
+class CarPawnApi
 {
 public:
-	typedef msr::airlib::ImageCaptureBase ImageCaptureBase;
+    typedef msr::airlib::ImageCaptureBase ImageCaptureBase;
 
 public:
-	CarPawnApi(CarPawn* pawn, const msr::airlib::Kinematics::State* pawn_kinematics, const msr::airlib::GeoPoint& home_geopoint,
-		const msr::airlib::AirSimSettings::VehicleSetting* vehicle_setting, std::shared_ptr<msr::airlib::SensorFactory> sensor_factory,
-		const std::string car_name,
-		const msr::airlib::Kinematics::State& state, const msr::airlib::Environment& environment);
-	virtual void setCarControls(const CarApiBase::CarControls& controls) override;
-	virtual CarApiBase::CarState getCarState() const override;
-	virtual void resetImplementation() override;
-	virtual void update() override;
-	virtual msr::airlib::GeoPoint getHomeGeoPoint() const override;
-	virtual void enableApiControl(bool is_enabled) override;
-	virtual bool isApiControlEnabled() const override;
-	virtual bool armDisarm(bool arm) override;
-	virtual const CarApiBase::CarControls& getCarControls() const override;
-	virtual ~CarPawnApi();
+    CarPawnApi(CarPawn* pawn, const msr::airlib::Kinematics::State* pawn_kinematics, 
+               const std::string car_name, msr::airlib::CarApiBase* vehicle_api);
+
+    void updateMovement(const msr::airlib::CarApiBase::CarControls& controls);
+    msr::airlib::CarApiBase::CarState getCarState() const;
+
+    void reset();
+    void update();
+
+    virtual ~CarPawnApi();
 
 private:
-	bool api_control_enabled_ = false;
-	CarControls last_controls_;
-	CarPawn* pawn_;
-	const msr::airlib::Kinematics::State* pawn_kinematics_;
-	msr::airlib::GeoPoint  home_geopoint_;
-	std::string car_name_;
+    msr::airlib::CarApiBase::CarControls last_controls_;
+    CarPawn* pawn_;
+    const msr::airlib::Kinematics::State* pawn_kinematics_;
+    std::string car_name_;
+    msr::airlib::CarApiBase* vehicle_api_;
 };

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/Vehicles/Car/CarPawnSimApi.cpp
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/Vehicles/Car/CarPawnSimApi.cpp
@@ -8,12 +8,12 @@
 
 
 CarPawnSimApi::CarPawnSimApi(const Params& params,
-	const CarPawnApi::CarControls&  keyboard_controls, std::string car_name)
+	const msr::airlib::CarApiBase::CarControls& keyboard_controls, std::string car_name)
 	: PawnSimApi(params), params_(params),
 	keyboard_controls_(keyboard_controls), car_name_(car_name)
 {
 	createVehicleApi(static_cast<CarPawn*>(params.pawn), params.home_geopoint);
-	joystick_controls_ = CarPawnApi::CarControls();
+	joystick_controls_ = msr::airlib::CarApiBase::CarControls();
 }
 
 void CarPawnSimApi::initialize()
@@ -23,16 +23,16 @@ void CarPawnSimApi::initialize()
     createVehicleApi(static_cast<CarPawn*>(params_.pawn), params_.home_geopoint);
 
     //TODO: should do reset() here?
-    joystick_controls_ = CarPawnApi::CarControls();
+    joystick_controls_ = msr::airlib::CarApiBase::CarControls();
 }
 
 void CarPawnSimApi::createVehicleApi(CarPawn* pawn, const msr::airlib::GeoPoint& home_geopoint)
 {
-	std::shared_ptr<UnitySensorFactory> sensor_factory = std::make_shared<UnitySensorFactory>(car_name_, &getNedTransform());
+    std::shared_ptr<UnitySensorFactory> sensor_factory = std::make_shared<UnitySensorFactory>(car_name_, &getNedTransform());
 
-	vehicle_api_ = std::unique_ptr<msr::airlib::CarApiBase>(new CarPawnApi(pawn, getGroundTruthKinematics(), home_geopoint,
-		getVehicleSetting(), sensor_factory, car_name_,
-		(*getGroundTruthKinematics()), (*getGroundTruthEnvironment())));
+    vehicle_api_ = CarApiFactory::createApi(getVehicleSetting(), sensor_factory, (*getGroundTruthKinematics()), 
+                                            (*getGroundTruthEnvironment()), home_geopoint);
+    phys_api_ = std::unique_ptr<CarPawnApi>(new CarPawnApi(pawn, getGroundTruthKinematics(), car_name_, vehicle_api_.get()));
 }
 
 std::string CarPawnSimApi::getRecordFileLine(bool is_header_line) const
@@ -45,7 +45,7 @@ std::string CarPawnSimApi::getRecordFileLine(bool is_header_line) const
 	}
 
 	const msr::airlib::Kinematics::State* kinematics = getGroundTruthKinematics();
-	const auto state = vehicle_api_->getCarState();
+	const auto state = phys_api_->getCarState();
 
 	common_line
 		.append(std::to_string(current_controls_.throttle)).append("\t")
@@ -154,11 +154,13 @@ void CarPawnSimApi::updateCarControls()
 	{
 		//all car controls from anywhere must be routed through API component
 		vehicle_api_->setCarControls(current_controls_);
+		phys_api_->updateMovement(current_controls_);
 	}
 	else
 	{
 		PrintLogMessage("Control Mode: ", "API", getVehicleName().c_str(), ErrorLogSeverity::Information);
 		current_controls_ = vehicle_api_->getCarControls();
+		phys_api_->updateMovement(current_controls_);
 	}
 }
 
@@ -169,13 +171,13 @@ void CarPawnSimApi::resetImplementation()
 	Reset(getVehicleName().c_str());
 
 	PawnSimApi::resetImplementation();
-	vehicle_api_->reset();
+	phys_api_->reset();
 }
 
 //physics tick
 void CarPawnSimApi::update()
 {
-	vehicle_api_->update();
+	phys_api_->update();
 	PawnSimApi::update();
 }
 

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/Vehicles/Car/CarPawnSimApi.h
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/Vehicles/Car/CarPawnSimApi.h
@@ -4,6 +4,7 @@
 #include "CarPawnApi.h"
 #include "../../PawnSimApi.h"
 #include "vehicles/car/api/CarApiBase.hpp"
+#include "vehicles/car/CarApiFactory.hpp"
 
 class CarPawnSimApi : public PawnSimApi
 {
@@ -19,9 +20,9 @@ private:
 
 public:
     virtual void initialize() override;
-	CarPawnSimApi(const Params& params, const CarPawnApi::CarControls&  keyboard_controls, std::string car_name);
+    CarPawnSimApi(const Params& params, const msr::airlib::CarApiBase::CarControls& keyboard_controls, std::string car_name);
 	virtual ~CarPawnSimApi() = default;
-	virtual void resetImplementation() override;
+
 	virtual void update() override;
 	//virtual void reportState(StateReporter& reporter) override;
 	virtual std::string getRecordFileLine(bool is_header_line) const override;
@@ -33,15 +34,19 @@ public:
 		return vehicle_api_.get();
 	}
 
+protected:
+	virtual void resetImplementation() override;
+
 private:
     Params params_;
 
 	std::unique_ptr<msr::airlib::CarApiBase> vehicle_api_;
+	std::unique_ptr<CarPawnApi> phys_api_;
 	std::vector<std::string> vehicle_api_messages_;
-	CarPawnApi::CarControls joystick_controls_;
-	CarPawnApi::CarControls current_controls_;
+	msr::airlib::CarApiBase::CarControls joystick_controls_;
+	msr::airlib::CarApiBase::CarControls current_controls_;
 	std::string car_name_;
 
 	//storing reference from pawn
-	const CarPawnApi::CarControls& keyboard_controls_;
+	const msr::airlib::CarApiBase::CarControls& keyboard_controls_;
 };

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnApi.cpp
@@ -3,23 +3,14 @@
 
 #include "PhysXVehicleManager.h"
 
-CarPawnApi::CarPawnApi(ACarPawn* pawn, const msr::airlib::Kinematics::State* pawn_kinematics, const msr::airlib::GeoPoint& home_geopoint,
-    const msr::airlib::AirSimSettings::VehicleSetting* vehicle_setting, std::shared_ptr<msr::airlib::SensorFactory> sensor_factory, 
-    const msr::airlib::Kinematics::State& state, const msr::airlib::Environment& environment)
-    : msr::airlib::CarApiBase(vehicle_setting, sensor_factory, state, environment),
-    pawn_(pawn), pawn_kinematics_(pawn_kinematics), home_geopoint_(home_geopoint)
+CarPawnApi::CarPawnApi(ACarPawn* pawn, const msr::airlib::Kinematics::State* pawn_kinematics,
+                       msr::airlib::CarApiBase* vehicle_api)
+    : pawn_(pawn), pawn_kinematics_(pawn_kinematics), vehicle_api_(vehicle_api)
 {
     movement_ = pawn->GetVehicleMovement();
 }
 
-bool CarPawnApi::armDisarm(bool arm)
-{
-    //TODO: implement arming for car
-    unused(arm);
-    return true;
-}
-
-void CarPawnApi::setCarControls(const CarApiBase::CarControls& controls)
+void CarPawnApi::updateMovement(const msr::airlib::CarApiBase::CarControls& controls)
 {
     last_controls_ = controls;
 
@@ -35,14 +26,9 @@ void CarPawnApi::setCarControls(const CarApiBase::CarControls& controls)
     movement_->SetUseAutoGears(!controls.is_manual_gear);
 }
 
-const msr::airlib::CarApiBase::CarControls& CarPawnApi::getCarControls() const
-{
-    return last_controls_;
-}
-
 msr::airlib::CarApiBase::CarState CarPawnApi::getCarState() const
 {
-    CarApiBase::CarState state(
+    msr::airlib::CarApiBase::CarState state(
         movement_->GetForwardSpeed() / 100, //cm/s -> m/s
         movement_->GetCurrentGear(),
         movement_->GetEngineRotationSpeed(),
@@ -54,11 +40,11 @@ msr::airlib::CarApiBase::CarState CarPawnApi::getCarState() const
     return state;
 }
 
-void CarPawnApi::resetImplementation()
+void CarPawnApi::reset()
 {
-    msr::airlib::CarApiBase::resetImplementation();
+    vehicle_api_->reset();
 
-    last_controls_ = CarControls();
+    last_controls_ = msr::airlib::CarApiBase::CarControls();
     auto phys_comps = UAirBlueprintLib::getPhysicsComponents(pawn_);
     UAirBlueprintLib::RunCommandOnGameThread([this, &phys_comps]() {
         for (auto* phys_comp : phys_comps) {
@@ -69,16 +55,17 @@ void CarPawnApi::resetImplementation()
         movement_->ResetMoveState();
         movement_->SetActive(false);
         movement_->SetActive(true, true);
-        setCarControls(CarControls());
+        vehicle_api_->setCarControls(msr::airlib::CarApiBase::CarControls());
+        updateMovement(msr::airlib::CarApiBase::CarControls());
 
-	auto pv = movement_->PVehicle;
-	if (pv) {
-	  pv->mWheelsDynData.setToRestState();
-	}
-	auto pvd = movement_->PVehicleDrive;
-	if (pvd) {
-	  pvd->mDriveDynData.setToRestState();
-	}
+        auto pv = movement_->PVehicle;
+        if (pv) {
+            pv->mWheelsDynData.setToRestState();
+        }
+        auto pvd = movement_->PVehicleDrive;
+        if (pvd) {
+            pvd->mDriveDynData.setToRestState();
+        }
     }, true);
 
     UAirBlueprintLib::RunCommandOnGameThread([this, &phys_comps]() {
@@ -89,25 +76,8 @@ void CarPawnApi::resetImplementation()
 
 void CarPawnApi::update()
 {
-    msr::airlib::CarApiBase::update();
-}
-
-msr::airlib::GeoPoint CarPawnApi::getHomeGeoPoint() const
-{
-    return home_geopoint_;
-}
-
-void CarPawnApi::enableApiControl(bool is_enabled)
-{
-    if (api_control_enabled_ != is_enabled) {
-        last_controls_ = CarControls();
-        api_control_enabled_ = is_enabled;
-    }
-}
-
-bool CarPawnApi::isApiControlEnabled() const
-{
-    return api_control_enabled_;
+    vehicle_api_->updateCarState(getCarState());
+    vehicle_api_->update();
 }
 
 CarPawnApi::~CarPawnApi() = default;

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnApi.h
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnApi.h
@@ -6,38 +6,26 @@
 #include "CarPawn.h"
 
 
-class CarPawnApi : public msr::airlib::CarApiBase {
+class CarPawnApi {
 public:
     typedef msr::airlib::ImageCaptureBase ImageCaptureBase;
 
-    CarPawnApi(ACarPawn* pawn, const msr::airlib::Kinematics::State* pawn_kinematics, const msr::airlib::GeoPoint& home_geopoint,
-        const msr::airlib::AirSimSettings::VehicleSetting* vehicle_setting, std::shared_ptr<msr::airlib::SensorFactory> sensor_factory,
-        const msr::airlib::Kinematics::State& state, const msr::airlib::Environment& environment);
+    CarPawnApi(ACarPawn* pawn, const msr::airlib::Kinematics::State* pawn_kinematics, 
+                msr::airlib::CarApiBase* vehicle_api);
 
-    virtual void setCarControls(const CarApiBase::CarControls& controls) override;
+    void updateMovement(const msr::airlib::CarApiBase::CarControls& controls);
 
-    virtual CarApiBase::CarState getCarState() const override;
+    msr::airlib::CarApiBase::CarState getCarState() const;
 
-    virtual void update() override;
-
-    virtual msr::airlib::GeoPoint getHomeGeoPoint() const override;
-
-    virtual void enableApiControl(bool is_enabled) override;
-    virtual bool isApiControlEnabled() const override;
-    virtual bool armDisarm(bool arm) override;
-
-    virtual const CarApiBase::CarControls& getCarControls() const override;
+    void reset();
+    void update();
 
     virtual ~CarPawnApi();
 
-protected:
-    virtual void resetImplementation() override;
-
 private:
     UWheeledVehicleMovementComponent* movement_;
-    bool api_control_enabled_ = false;
-    CarControls last_controls_;
+    msr::airlib::CarApiBase::CarControls last_controls_;
     ACarPawn* pawn_;
     const msr::airlib::Kinematics::State* pawn_kinematics_;
-    msr::airlib::GeoPoint  home_geopoint_;
+    msr::airlib::CarApiBase* vehicle_api_;
 };

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnSimApi.cpp
@@ -7,7 +7,7 @@
 using namespace msr::airlib;
 
 CarPawnSimApi::CarPawnSimApi(const Params& params,
-    const CarPawnApi::CarControls&  keyboard_controls, UWheeledVehicleMovementComponent* movement)
+    const msr::airlib::CarApiBase::CarControls& keyboard_controls, UWheeledVehicleMovementComponent* movement)
     : PawnSimApi(params), params_(params),
       keyboard_controls_(keyboard_controls)
 {
@@ -20,16 +20,17 @@ void CarPawnSimApi::initialize()
     createVehicleApi(static_cast<ACarPawn*>(params_.pawn), params_.home_geopoint);
 
     //TODO: should do reset() here?
-    joystick_controls_ = CarPawnApi::CarControls();
+    joystick_controls_ = msr::airlib::CarApiBase::CarControls();
 }
 
 void CarPawnSimApi::createVehicleApi(ACarPawn* pawn, const msr::airlib::GeoPoint& home_geopoint)
 {
     //create vehicle params
     std::shared_ptr<UnrealSensorFactory> sensor_factory = std::make_shared<UnrealSensorFactory>(getPawn(), &getNedTransform());
-    vehicle_api_ = std::unique_ptr<CarApiBase>(new CarPawnApi(pawn, getGroundTruthKinematics(), home_geopoint,
-        getVehicleSetting(), sensor_factory, 
-        (*getGroundTruthKinematics()), (*getGroundTruthEnvironment())));
+
+    vehicle_api_ = CarApiFactory::createApi(getVehicleSetting(), sensor_factory, (*getGroundTruthKinematics()), 
+                                            (*getGroundTruthEnvironment()), home_geopoint);
+    phys_api_ = std::unique_ptr<CarPawnApi>(new CarPawnApi(pawn, getGroundTruthKinematics(), vehicle_api_.get()));
 }
 
 std::string CarPawnSimApi::getRecordFileLine(bool is_header_line) const
@@ -41,7 +42,7 @@ std::string CarPawnSimApi::getRecordFileLine(bool is_header_line) const
     }
 
     const msr::airlib::Kinematics::State* kinematics = getGroundTruthKinematics();
-    const auto state = vehicle_api_->getCarState();
+    const auto state = phys_api_->getCarState();
 
     common_line
         .append(std::to_string(current_controls_.throttle)).append("\t")
@@ -146,10 +147,12 @@ void CarPawnSimApi::updateCarControls()
     if (!vehicle_api_->isApiControlEnabled()) {
         //all car controls from anywhere must be routed through API component
         vehicle_api_->setCarControls(current_controls_);
+        phys_api_->updateMovement(current_controls_);
     }
     else {
         UAirBlueprintLib::LogMessageString("Control Mode: ", "API", LogDebugLevel::Informational);
         current_controls_ = vehicle_api_->getCarControls();
+        phys_api_->updateMovement(current_controls_);
     }
     UAirBlueprintLib::LogMessageString("Accel: ", std::to_string(current_controls_.throttle), LogDebugLevel::Informational);
     UAirBlueprintLib::LogMessageString("Break: ", std::to_string(current_controls_.brake), LogDebugLevel::Informational);
@@ -163,13 +166,13 @@ void CarPawnSimApi::resetImplementation()
 {
     PawnSimApi::resetImplementation();
 
-    vehicle_api_->reset();
+    phys_api_->reset();
 }
 
 //physics tick
 void CarPawnSimApi::update()
 {
-    vehicle_api_->update();
+    phys_api_->update();
 
     PawnSimApi::update();
 }

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnSimApi.h
@@ -8,9 +8,10 @@
 #include "PawnEvents.h"
 #include "PawnSimApi.h"
 #include "vehicles/car/api/CarApiBase.hpp"
-#include "physics//Kinematics.hpp"
+#include "physics/Kinematics.hpp"
 #include "common/Common.hpp"
 #include "common/CommonStructs.hpp"
+#include "vehicles/car/CarApiFactory.hpp"
 
 class CarPawnSimApi : public PawnSimApi
 {
@@ -27,9 +28,8 @@ public:
     //VehicleSimApiBase interface
     //implements game interface to update pawn
     CarPawnSimApi(const Params& params,
-        const CarPawnApi::CarControls&  keyboard_controls, UWheeledVehicleMovementComponent* movement);
+        const msr::airlib::CarApiBase::CarControls& keyboard_controls, UWheeledVehicleMovementComponent* movement);
 
-    virtual void resetImplementation() override;
     virtual void update() override;
 
     virtual std::string getRecordFileLine(bool is_header_line) const override;
@@ -47,6 +47,9 @@ public:
         return vehicle_api_.get();
     }
 
+protected:
+    virtual void resetImplementation() override;
+
 private:
     void createVehicleApi(ACarPawn* pawn, const msr::airlib::GeoPoint& home_geopoint);
     void updateCarControls();
@@ -55,11 +58,12 @@ private:
     Params params_;
 
     std::unique_ptr<msr::airlib::CarApiBase> vehicle_api_;
+    std::unique_ptr<CarPawnApi> phys_api_;
     std::vector<std::string> vehicle_api_messages_;
 
     //storing reference from pawn
-    const CarPawnApi::CarControls& keyboard_controls_;
+    const msr::airlib::CarApiBase::CarControls& keyboard_controls_;
 
-    CarPawnApi::CarControls joystick_controls_;
-    CarPawnApi::CarControls current_controls_;
+    msr::airlib::CarApiBase::CarControls joystick_controls_;
+    msr::airlib::CarApiBase::CarControls current_controls_;
 };


### PR DESCRIPTION
This PR restructures the Car vehicle code to make it similar to Multirotor in terms of adding support for external firmware control of the car vehicle
An example of how to add external firmware control can be seen here - https://github.com/microsoft/AirSim/commit/a5dce95d82506741412f26072e3d4b7e6f20cdd9 (ArduPilot's Rover vehicle, the entire branch is https://github.com/microsoft/AirSim/compare/master...rajat2004:pr-ardurover2)
(Didn't open PR for the entire thing since would be more difficult to review)

This PR has been tested to be working with manual control from the keyboard on Ubuntu 16.04 and Windows 10, with the below Python APIs on Ubuntu *(Unreal Engine)*

Things tested to be working - 
* Movement APIs - `hello_car.py`
* getCarState - `car_monitor.py`
* Pause - `pause_continue_car.py`
* Multi-vehicle - `multi_agent_car.py`
* ClockSpeed

Unity - Compilation only till now, real testing soon to follow

There are a few more things which can be cleaned up more, such as removing the `CarState` and `CarControls` from `CarApiBase`
Feedback on the approach by the other devs is very much needed!