### PR TITLE
changed api_port from uint16 to int to fix type conversion warning  #2191 #2190

### DIFF
--- a/AirLib/include/common/AirSimSettings.hpp
+++ b/AirLib/include/common/AirSimSettings.hpp
@@ -329,7 +329,7 @@ public: //fields
     int initial_view_mode = 3; //ECameraDirectorMode::CAMERA_DIRECTOR_MODE_FLY_WITH_ME
     bool enable_rpc = true;
     std::string api_server_address = "";
-	uint16_t api_port = RpcLibPort;
+	int api_port = RpcLibPort;
     std::string physics_engine_name = "";
 
     std::string clock_type = "";


### PR DESCRIPTION
Warnings are treated as errors in our build tools. RpcLibPort is defined as an int, changed api_port to match that definition.