### PR TITLE
Fix unused parameter and override warnings

### DIFF
--- a/AirLib/include/physics/Environment.hpp
+++ b/AirLib/include/physics/Environment.hpp
@@ -78,7 +78,7 @@ public:
         return current_;
     }
 
-    virtual void update()
+    virtual void update() override
     {
         updateState(current_, home_geo_point_);
     }
@@ -91,6 +91,7 @@ protected:
 
     virtual void failResetUpdateOrdering(std::string err) override
     {
+        unused(err);
         //Do nothing.
         //The environment gets reset() twice without an update() inbetween,
         //via MultirotorPawnSimApi::reset() and CarSimApi::reset(), because


### PR DESCRIPTION
Warnings seen when building on Linux - Ubuntu 16.04, Clang 5.0 (Curiously, doesn't come on Windows)

```
In file included from /home/rajat/AirSim/HelloCar/main.cpp:12:
In file included from /home/rajat/AirSim/AirLib/include/vehicles/car/api/CarRpcLibClient.hpp:10:
In file included from /home/rajat/AirSim/AirLib/include/vehicles/car/api/CarApiBase.hpp:9:
In file included from /home/rajat/AirSim/AirLib/include/api/VehicleApiBase.hpp:14:
In file included from /home/rajat/AirSim/AirLib/include/sensors/SensorCollection.hpp:8:
In file included from /home/rajat/AirSim/AirLib/include/sensors/SensorBase.hpp:10:
/home/rajat/AirSim/AirLib/include/physics/Environment.hpp:81:18: warning: 'update' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    virtual void update()
                 ^
/home/rajat/AirSim/AirLib/include/common/UpdatableObject.hpp:47:18: note: overridden virtual function is here
    virtual void update()
                 ^
In file included from /home/rajat/AirSim/HelloCar/main.cpp:12:
In file included from /home/rajat/AirSim/AirLib/include/vehicles/car/api/CarRpcLibClient.hpp:10:
In file included from /home/rajat/AirSim/AirLib/include/vehicles/car/api/CarApiBase.hpp:9:
In file included from /home/rajat/AirSim/AirLib/include/api/VehicleApiBase.hpp:14:
In file included from /home/rajat/AirSim/AirLib/include/sensors/SensorCollection.hpp:8:
In file included from /home/rajat/AirSim/AirLib/include/sensors/SensorBase.hpp:10:
/home/rajat/AirSim/AirLib/include/physics/Environment.hpp:92:54: warning: unused parameter 'err' [-Wunused-parameter]
    virtual void failResetUpdateOrdering(std::string err) override
```