### PR TITLE
Fix Unity build: Change resetImpl to reset in WorldSimApi

### DIFF
--- a/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.cpp
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.cpp
@@ -15,7 +15,7 @@ bool WorldSimApi::isPaused() const
 	return simmode_->isPaused();
 }
 
-void WorldSimApi::resetImplementation()
+void WorldSimApi::reset()
 {
 	simmode_->reset();
 }

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.h
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.h
@@ -13,7 +13,7 @@ public:
 	WorldSimApi(SimModeBase* simmode, std::string vehicle_name);
 	virtual ~WorldSimApi();
 	virtual bool isPaused() const override;
-	virtual void resetImplementation() override;
+	virtual void reset() override;
 	virtual void pause(bool is_paused) override;
 	virtual void continueForTime(double seconds) override;
         virtual void setTimeOfDay(bool is_enabled, const std::string& start_datetime, bool is_start_datetime_dst,


### PR DESCRIPTION
Fixes https://github.com/microsoft/AirSim/issues/2199
Tested till compilation only on Windows 10 and Ubuntu 16.04

There was no corresponding change in the Unreal WorldSim files therefore seems to be the correct fix.