### PR TITLE
fixed type naming error created by PR #2011

### DIFF
--- a/Unreal/Plugins/AirSim/Source/UnrealSensors/UnrealLidarSensor.cpp
+++ b/Unreal/Plugins/AirSim/Source/UnrealSensors/UnrealLidarSensor.cpp
@@ -42,7 +42,7 @@ void UnrealLidarSensor::createLasers()
 
 // returns a point-cloud for the tick
 void UnrealLidarSensor::getPointCloud(const msr::airlib::Pose& lidar_pose, const msr::airlib::Pose& vehicle_pose,
-    const msr::airlib::TTimeDelta delta_time, msr::airlib::vector<msr::airlib::real_T>& point_cloud, vector<int>& segmentation_cloud)
+    const msr::airlib::TTimeDelta delta_time, msr::airlib::vector<msr::airlib::real_T>& point_cloud, msr::airlib::vector<int>& segmentation_cloud)
 {
     point_cloud.clear();
     segmentation_cloud.clear();

--- a/Unreal/Plugins/AirSim/Source/UnrealSensors/UnrealLidarSensor.h
+++ b/Unreal/Plugins/AirSim/Source/UnrealSensors/UnrealLidarSensor.h
@@ -21,7 +21,7 @@ public:
 
 protected:
     virtual void getPointCloud(const msr::airlib::Pose& lidar_pose, const msr::airlib::Pose& vehicle_pose,
-        msr::airlib::TTimeDelta delta_time, msr::airlib::vector<msr::airlib::real_T>& point_cloud, vector<int>& segmentation_cloud) override;
+        msr::airlib::TTimeDelta delta_time, msr::airlib::vector<msr::airlib::real_T>& point_cloud, msr::airlib::vector<int>& segmentation_cloud) override;
 
 private:
     using Vector3r = msr::airlib::Vector3r;


### PR DESCRIPTION
Changed type definition in UnrealLidarSensor::getPointCloud from vector to msr::airlib::vector