### PR TITLE
Fix home position stability check

### DIFF
--- a/PythonClient/multirotor/orbit.py
+++ b/PythonClient/multirotor/orbit.py
@@ -53,10 +53,10 @@ class OrbitNavigator:
         start = time.time()
         count = 0
         while count < 100:
-            pos = self.home
+            pos = self.client.getMultirotorState().kinematics_estimated.position
             if abs(pos.z_val - self.home.z_val) > 1:                                
                 count = 0
-                self.home = pos
+                self.home = self.client.getMultirotorState().kinematics_estimated.position
                 if time.time() - start > 10:
                     print("Drone position is drifting, we are waiting for it to settle down...")
                     start = time


### PR DESCRIPTION
By doing `pos = self.home` both are pointing to the same address (which we can see by printing their [`id`](https://docs.python.org/3/library/functions.html#id) or seeing that checking if `pos is self.home` always returns True).

Thus, the `if` statement on line 57 is always going to the `else` branch:

https://github.com/microsoft/AirSim/blob/c6f0729006ecd6d792a750edc7e27021469c5649/PythonClient/multirotor/orbit.py#L56-L57