### PR TITLE
added time dilation to pause entire world on simPause()

### DIFF
--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
@@ -27,6 +27,8 @@ void WorldSimApi::reset()
 void WorldSimApi::pause(bool is_paused)
 {
     simmode_->pause(is_paused);
+	auto time_dilation = is_paused ? 0.0 : 1.0 ;
+	simmode_->GetWorld()->SetGlobalTimeDilation(time_dilation);
 }
 
 void WorldSimApi::continueForTime(double seconds)


### PR DESCRIPTION
This will close a lot of issues requesting simPause to pause all animations in the world along with the player controlled character.