### PR TITLE
Remove semicolon to fix compiler warning

### DIFF
--- a/AirLib/include/common/common_utils/Utils.hpp
+++ b/AirLib/include/common/common_utils/Utils.hpp
@@ -450,7 +450,7 @@ public:
     static std::size_t length(const T(&)[N])
     {
         return N;
-    };
+    }
 
     static void saveToFile(string file_name, const char* data, uint size)
     {


### PR DESCRIPTION
The length function in Utils had a trailing semicolon at the end of the function triggering a compiler warning (g++ 5.5 with the -pedantic flag)