### PR TITLE
Fix for moveByVelocity() persistence bug

### DIFF
--- a/AirLib/include/vehicles/multirotor/firmwares/simple_flight/AirSimSimpleFlightBoard.hpp
+++ b/AirLib/include/vehicles/multirotor/firmwares/simple_flight/AirSimSimpleFlightBoard.hpp
@@ -65,6 +65,11 @@ public:
         return input_channels_[index];
     }
 
+    virtual float getAvgMotorOutput() const override
+	{
+		return ((getMotorControlSignal(0) + getMotorControlSignal(1) + getMotorControlSignal(2) + getMotorControlSignal(3)) / 4);
+	}
+
     virtual bool isRcConnected() const override
     {
         return is_connected_;

--- a/AirLib/include/vehicles/multirotor/firmwares/simple_flight/firmware/OffboardApi.hpp
+++ b/AirLib/include/vehicles/multirotor/firmwares/simple_flight/firmware/OffboardApi.hpp
@@ -219,7 +219,9 @@ private:
         // if we are not trying to move by setting motor outputs
         if (takenoff_)
         {
-            if (!isGreaterThanArmedThrottle(goal_.throttle())) {
+            //if (!isGreaterThanArmedThrottle(goal_.throttle())) {
+            float checkThrottle = rc_.getMotorOutput();
+            if (!isGreaterThanArmedThrottle(checkThrottle)) {
                 // and we are not currently moving (based on current velocities)
                 auto angular = state_estimator_->getAngularVelocity();
                 auto velocity = state_estimator_->getLinearVelocity();
@@ -238,9 +240,10 @@ private:
         // if we are not trying to move by setting motor outputs
         if (!takenoff_)
         {
+            float checkThrottle = rc_.getMotorOutput();
             //TODO: better handling of landed & takenoff states 
-            if (isGreaterThanArmedThrottle(goal_.throttle()) &&
-                std::abs(state_estimator_->getLinearVelocity().z()) > 0.01f) {
+            if (isGreaterThanArmedThrottle(checkThrottle) &&
+              std::abs(state_estimator_->getLinearVelocity().z()) > 0.01f) {
                 takenoff_ = true;
                 landed_ = false;
             }

--- a/AirLib/include/vehicles/multirotor/firmwares/simple_flight/firmware/RemoteControl.hpp
+++ b/AirLib/include/vehicles/multirotor/firmwares/simple_flight/firmware/RemoteControl.hpp
@@ -148,6 +148,11 @@ public:
         return allow_api_control_;
     }
 
+    float getMotorOutput()
+    {
+	return board_inputs_->getAvgMotorOutput();
+    }
+
 private:
     enum class RcRequestType {
         None, ArmRequest, DisarmRequest, NeutralRequest

--- a/AirLib/include/vehicles/multirotor/firmwares/simple_flight/firmware/interfaces/IBoardInputPins.hpp
+++ b/AirLib/include/vehicles/multirotor/firmwares/simple_flight/firmware/interfaces/IBoardInputPins.hpp
@@ -8,6 +8,7 @@ class IBoardInputPins {
 public:
     virtual float readChannel(uint16_t index) const = 0; //output -1 to 1
     virtual bool isRcConnected() const = 0;
+    virtual float getAvgMotorOutput() const = 0;
 };
 
 }


### PR DESCRIPTION
This PR attempts to fix the issue with moveByVelocity() commands persisting even after the commanded duration has ended. This behavior can be avoided by monitoring the vehicle thrust directly to decide whether the vehicle is in a 'taken-off' or 'landed' mode, instead of using goal values as it is written currently.