### PR TITLE
pause the whole simulation for simpause, add simpause to cv mode

### DIFF
--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeWorldBase.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeWorldBase.cpp
@@ -78,6 +78,7 @@ bool ASimModeWorldBase::isPaused() const
 void ASimModeWorldBase::pause(bool is_paused)
 {
     physics_world_->pause(is_paused);
+    UGameplayStatics::SetGlobalTimeDilation(this->GetWorld(), is_paused ? 0.0 : 1.0);
 }
 
 void ASimModeWorldBase::continueForTime(double seconds)

--- a/Unreal/Plugins/AirSim/Source/Vehicles/ComputerVision/SimModeComputerVision.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/ComputerVision/SimModeComputerVision.cpp
@@ -76,3 +76,13 @@ msr::airlib::VehicleApiBase* ASimModeComputerVision::getVehicleApi(const PawnSim
     //we don't have real vehicle so no vehicle API
     return nullptr;
 }
+
+bool ASimModeComputerVision::isPaused() const
+{
+    return  UGameplayStatics::GetGlobalTimeDilation(this->GetWorld()) < 1e-3;
+}
+
+void ASimModeComputerVision::pause(bool is_paused)
+{
+    UGameplayStatics::SetGlobalTimeDilation(this->GetWorld(), is_paused ? 0.0 : 1.0);
+}

--- a/Unreal/Plugins/AirSim/Source/Vehicles/ComputerVision/SimModeComputerVision.h
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/ComputerVision/SimModeComputerVision.h
@@ -30,4 +30,7 @@ protected:
         const PawnSimApi::Params& pawn_sim_api_params) const override;
     virtual msr::airlib::VehicleApiBase* getVehicleApi(const PawnSimApi::Params& pawn_sim_api_params,
         const PawnSimApi* sim_api) const override;
+
+    virtual bool isPaused() const override; 
+    virtual void pause(bool is_paused) override;
 };


### PR DESCRIPTION
The simPause API only paused the physical engine of the vehicle, and does not support CV mode. This pull request modifies the simPause function with UGameplayStatics::SetGlobalTimeDilation, which pause the entire simulation of the Unreal Engine.  Also added simPause API for the CV mode. 
Related issues:
https://github.com/microsoft/AirSim/issues/1309
https://github.com/microsoft/AirSim/issues/1494