### PR TITLE
Fix - comparing with uninitialized member variable

### DIFF
--- a/AirLib/include/vehicles/multirotor/firmwares/simple_flight/firmware/PositionController.hpp
+++ b/AirLib/include/vehicles/multirotor/firmwares/simple_flight/firmware/PositionController.hpp
@@ -25,7 +25,7 @@ public:
 
     virtual void initialize(unsigned int axis, const IGoal* goal, const IStateEstimator* state_estimator) override
     {
-        if (axis_ == 2)
+        if (axis == 2)
             throw std::invalid_argument("PositionController does not support yaw axis i.e. " + std::to_string(axis));
 
         axis_ = axis;


### PR DESCRIPTION
In PositionController::initialize, passed parameter **axis** (not member variable **axis_**) should be compared.