### PR TITLE
Fix losing physics after setting pose

### DIFF
--- a/AirLib/include/physics/FastPhysicsEngine.hpp
+++ b/AirLib/include/physics/FastPhysicsEngine.hpp
@@ -69,6 +69,7 @@ private:
     {
         TTimeDelta dt = clock()->updateSince(body.last_kinematics_time);
 
+        body.lock();
         //get current kinematics state of the body - this state existed since last dt seconds
         const Kinematics::State& current = body.getKinematics();
         Kinematics::State next;
@@ -95,6 +96,7 @@ private:
 
         body.setWrench(next_wrench);
         body.updateKinematics(next);
+        body.unlock();
 
 
 		//TODO: this is now being done in PawnSimApi::update. We need to re-think this sequence

--- a/AirLib/include/physics/PhysicsBody.hpp
+++ b/AirLib/include/physics/PhysicsBody.hpp
@@ -225,6 +225,16 @@ public: //methods
 		grounded_ = grounded;
 	}
 
+	void lock()
+	{
+		mutex_.lock();
+	}
+
+	void unlock()
+	{
+		mutex_.unlock();
+	}
+
 public:
     //for use in physics engine: //TODO: use getter/setter or friend method?
     TTimePoint last_kinematics_time;
@@ -243,6 +253,7 @@ private:
     CollisionResponse collision_response_;
 
 	bool grounded_ = false;
+	std::mutex mutex_;
 };
 
 }} //namespace

--- a/AirLib/src/vehicles/multirotor/api/MultirotorApiBase.cpp
+++ b/AirLib/src/vehicles/multirotor/api/MultirotorApiBase.cpp
@@ -269,7 +269,7 @@ bool MultirotorApiBase::moveOnPath(const vector<Vector3r>& path, float velocity,
     float goal_dist = 0;
 
     //until we are at the end of the path (last seg is always zero size)
-    while (!waiter.isTimeout() && (next_path_loc.seg_index < path_segs.size()-1 || goal_dist > 0)
+    while (!waiter.isTimeout() && (next_path_loc.seg_index < path_segs.size()-1 || goal_dist >= 0)
         ) { //current position is approximately at the last end point
 
         float seg_velocity = path_segs.at(next_path_loc.seg_index).seg_velocity;

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Multirotor/MultirotorPawnSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Multirotor/MultirotorPawnSimApi.h
@@ -72,7 +72,7 @@ private:
     //when pose needs to set from non-physics thread, we set it as pending
     bool pending_pose_collisions_;
     enum class PendingPoseStatus {
-        NonePending, RenderStatePending, RenderPending
+        NonePending, RenderPending
     } pending_pose_status_;
     Pose pending_phys_pose_; //force new pose through API
 


### PR DESCRIPTION
Fixes #1272
Fixes #1856
Fixes #1246
Fixes #3049 : After using `simSetVehiclePose` in multirotor mode, the drone can't be controlled by most of the vehicle commands.
It is because when starting playing, the physical body is set to be grounded. Then we set pose directly, but the `body.isGrounded()` is still true, which causes `FastPhysicsEngine` not working as expected.
