### PR TITLE
Updated eigen links to gitlab URLs

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -143,7 +143,7 @@ IF NOT EXIST Unreal\Plugins\AirSim\Content\VehicleAdv\SUV\v1.2.0 (
 REM //---------- get Eigen library ----------
 IF NOT EXIST AirLib\deps mkdir AirLib\deps
 IF NOT EXIST AirLib\deps\eigen3 (
-    powershell -command "& { [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; iwr http://bitbucket.org/eigen/eigen/get/3.3.2.zip -OutFile eigen3.zip }"
+    powershell -command "& { [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; iwr https://gitlab.com/libeigen/eigen/-/archive/3.3.2/eigen-3.3.2.zip -OutFile eigen3.zip }"
     powershell -command "& { Expand-Archive -Path eigen3.zip -DestinationPath AirLib\deps }"
     powershell -command "& { Move-Item -Path AirLib\deps\eigen* -Destination AirLib\deps\del_eigen }"
     REM move AirLib\deps\eigen* AirLib\deps\del_eigen

--- a/setup.sh
+++ b/setup.sh
@@ -233,12 +233,12 @@ else
     sudo rm -rf ./AirLib/deps/eigen3/Eigen
 fi
 echo "downloading eigen..."
-wget http://bitbucket.org/eigen/eigen/get/3.3.2.zip
-unzip 3.3.2.zip -d temp_eigen
+wget https://gitlab.com/libeigen/eigen/-/archive/3.3.2/eigen-3.3.2.zip
+unzip eigen-3.3.2.zip -d temp_eigen
 mkdir -p AirLib/deps/eigen3
 mv temp_eigen/eigen*/Eigen AirLib/deps/eigen3
 rm -rf temp_eigen
-rm 3.3.2.zip
+rm eigen-3.3.2.zip
 
 popd >/dev/null
 


### PR DESCRIPTION
Eigen has decided to move away from bitbucket and it is now hosted on gitlab. 

http://eigen.tuxfamily.org/index.php?title=News:Migration_to_GitLab.com_scheduled_on_the_December_4th

Links to the eigen archive have been updated in Windows/Linux build scripts. 