### PR TITLE
Rework travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,73 +1,56 @@
 language: cpp
-#git:
-# shorten this if we can nail down submodule depth
-#  depth: 3
 
-fast_finish: false
-
-matrix:
+jobs:
   allow_failures:
     - env: ALLOW_FAILURES=true
 
   include:
-    # linux version have unique dependencies, so we set them up individually
-    - os: linux
-      dist: trusty
-      sudo: required
-      services:
-        - docker
-    #- os: windows
-    # dotnet: 2.1.5
-    # services:
-    #   - docker
-        
+    - name: Ubuntu 18.04
+      os: linux
+      dist: bionic
 
-    # OS X CMake
-    #- os: osx
-    #  sudo: required
-    #  osx_image: xcode8.2
-    #  compiler:
-    #    - clang
-    #  env:
-    #    - TOOL="cmake"
-    #    - DESCRIPTION="OS X build/test via CMake"
+    - name: Ubuntu 16.04
+      os: linux
+      dist: xenial
 
-# docker exec xenial apt-get -y install clang libclang-3.8-dev;
-install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      docker pull ubuntu:xenial;
-      docker run -d --name xenial -dti ubuntu:xenial bash;
-      docker ps -a;
-      docker exec xenial mkdir /build;
-      docker cp . xenial:/build;
-      docker exec xenial apt-get update;
-      docker exec xenial apt-get -y upgrade;
-      docker exec xenial apt-get -y install git wget unzip sudo;
-      docker exec xenial apt-get -y install build-essential software-properties-common cmake;
-      docker exec xenial apt-get update;
-    elif [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
-      echo "No install osx actions--using repo";
-    elif [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ "$TOOL" == "cmake" ]]; then
-      echo "No install Windows actions--using repo";
-    fi
+    - name: Windows 10
+      os: windows
+      env:
+        - MSBUILD_PATH="c:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin"
+        - PATH_FIX="C:\Windows\System32"
+
+    - name: MacOS
+      os: osx
+      env:
+        - TOOL="cmake"
+        - DESCRIPTION="OS X build/test via CMake"
+        - LLVM_PACKAGE="clang+llvm-5.0.2-x86_64-apple-darwin"
+        - CIINSTALL=yes
+
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      echo "No pre-install linux actions--using docker";
+      sudo apt-get update;
+      sudo apt-get -y install git wget unzip;
+      sudo apt-get -y install build-essential software-properties-common cmake rsync libboost-all-dev;
     elif [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ "$TOOL" == "cmake" ]]; then
-      echo "No pre-install osx actions";
+      wget http://releases.llvm.org/5.0.2/${LLVM_PACKAGE}.tar.xz;
+      tar -xf ${LLVM_PACKAGE}.tar.xz;
+      export LLVM_DIR=${TRAVIS_BUILD_DIR}/${LLVM_PACKAGE};
     fi
 
-#docker exec xenial /bin/sh -c "export EIGEN3_INCLUDE_DIR=/build/eigen/eigen3 && cd /build/cmake && sh ./build.sh && cmake . && make";
 script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      docker exec -t xenial /build/setup.sh;
-      docker exec -t xenial /build/build.sh;
-    elif [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
-      .\\build.cmd;
-      .\\Unity\\build.cmd;
-    elif  [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      git submodule update --init --recursive;
       ./setup.sh;
       ./build.sh;
+      cd Unity && ./build.sh 2> Unity_error.txt || (tail -n 100 Unity_error.txt && exit 1);
+    elif [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
+      export PATH=$MSBUILD_PATH:$PATH_FIX:$PATH;
+      cmd.exe //C 'C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat' amd64 '&&'
+      build.cmd '&&'
+      cd Unity '&&' build.cmd;
+    elif  [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      ./setup.sh;
+      ./build.sh;
+      cd Unity && ./build.sh 2> Unity_error.txt || (tail -n 100 Unity_error.txt && exit 1);
     fi

--- a/Unity/build.sh
+++ b/Unity/build.sh
@@ -9,8 +9,13 @@ fi
 
 
 cd linux-build;
-export CC="clang-5.0"
-export CXX="clang++-5.0"
+if [[ -n $CIINSTALL ]]; then # use downloaded binaries on Travis
+    export CC=${LLVM_DIR}/bin/clang
+    export CXX=${LLVM_DIR}/bin/clang++
+else
+    export CC="clang-5.0"
+    export CXX="clang++-5.0"
+fi
 
 if [ "$(uname)" == "Darwin" ]; then
     CMAKE="$(greadlink -f ../../cmake_build/bin/cmake)"
@@ -25,7 +30,7 @@ if [ ! -d "../UnityDemo/Assets/Plugins" ]; then
 fi
 
 if [ "$(uname)" == "Darwin" ]; then
-	cp AirsimWrapper.bundle ../UnityDemo/Assets/Plugins;
+	cp -r AirsimWrapper.bundle ../UnityDemo/Assets/Plugins;
 else
 	cp libAirsimWrapper.so ../UnityDemo/Assets/Plugins;
 fi

--- a/build.sh
+++ b/build.sh
@@ -84,8 +84,15 @@ else
     # variable for build output
     build_dir=build_debug
     if [ "$(uname)" == "Darwin" ]; then
-        export CC=/usr/local/opt/llvm-5.0/bin/clang-5.0
-        export CXX=/usr/local/opt/llvm-5.0/bin/clang++-5.0
+
+        if [[ -n $CIINSTALL ]]; then # use downloaded binaries on Travis
+            export CC=${LLVM_DIR}/bin/clang
+            export CXX=${LLVM_DIR}/bin/clang++
+        else
+            export CC=/usr/local/opt/llvm-5.0/bin/clang-5.0
+            export CXX=/usr/local/opt/llvm-5.0/bin/clang++-5.0
+        fi
+
     else
         export CC="clang-5.0"
         export CXX="clang++-5.0"

--- a/setup.sh
+++ b/setup.sh
@@ -209,12 +209,9 @@ if ! $gccBuild; then
     else
         echo "folder llvm-source-50 already exists, skipping git clone..."
     fi
-    #build libc++
-    if [ "$(uname)" == "Darwin" ]; then
-        rm -rf llvm-build
-    else
-        rm -rf llvm-build
-    fi
+
+    # build libc++
+    rm -rf llvm-build
     mkdir -p llvm-build
     pushd llvm-build >/dev/null
 
@@ -225,23 +222,15 @@ if ! $gccBuild; then
 
     make cxx -j`nproc`
 
-    #install libc++ locally in output folder
-    if [ "$(uname)" == "Darwin" ]; then
-        make install-libcxx install-libcxxabi
-    else
-        make install-libcxx install-libcxxabi
-    fi
+    # install libc++ locally in output folder
+    make install-libcxx install-libcxxabi
 
     popd >/dev/null
 fi
 
 echo "Installing EIGEN library..."
 
-if [ "$(uname)" == "Darwin" ]; then
-    rm -rf ./AirLib/deps/eigen3/Eigen
-else
-    rm -rf ./AirLib/deps/eigen3/Eigen
-fi
+rm -rf ./AirLib/deps/eigen3/Eigen
 echo "downloading eigen..."
 wget -O eigen3.zip https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.zip
 unzip eigen3.zip -d temp_eigen

--- a/setup.sh
+++ b/setup.sh
@@ -60,13 +60,19 @@ if $gccBuild; then
 else
     # llvm tools
     if [ "$(uname)" == "Darwin" ]; then # osx
-        brew update
 
-        # brew install llvm@3.9
-        brew tap llvm-hs/homebrew-llvm
-        brew install llvm-5.0
-        export C_COMPILER=/usr/local/opt/llvm-5.0/bin/clang-5.0
-        export COMPILER=/usr/local/opt/llvm-5.0/bin/clang++-5.0
+        if [[ -n $CIINSTALL ]]; then # use downloaded binaries on Travis
+            export C_COMPILER=${LLVM_DIR}/bin/clang
+            export COMPILER=${LLVM_DIR}/bin/clang++
+        else
+            brew update
+
+            # brew install llvm@3.9
+            brew tap llvm-hs/homebrew-llvm
+            brew install llvm-5.0
+            export C_COMPILER=/usr/local/opt/llvm-5.0/bin/clang-5.0
+            export COMPILER=/usr/local/opt/llvm-5.0/bin/clang++-5.0
+        fi
 
     else #linux
         #install clang and build tools


### PR DESCRIPTION
Remove docker build, add Ubuntu 18.04, 16.04, and Windows, macOS builds using `build.sh` as well as `Unity/build.sh`

This should help in catching breaking changes on different OSes, as well as on Unreal vs Unity
Unfortunately adding Unreal inside Travis doesn't seem possible

Should GCC build be added also?
Unity compilation throws about 340 warnings, which exceeds the Travis output log size (4 MB), seems like incorrect flags are being applied to the Unity build (Created issue https://github.com/microsoft/AirSim/issues/2478 for discussion)

Needs #2333 and #2328 (if only #2333 is there, CMake won't be downloaded when it's not required and without the fix of build.sh in #2328, cmake won't be found)