### PR TITLE
comparison force vs gravity fixed in FastPhysicsEngine.hpp

### DIFF
--- a/AirLib/include/physics/FastPhysicsEngine.hpp
+++ b/AirLib/include/physics/FastPhysicsEngine.hpp
@@ -324,10 +324,10 @@ private:
         const Wrench body_wrench = getBodyWrench(body, current.pose.orientation);
 
         if (body.isGrounded()) {
-            // make it stick to the ground until we see body wrench force greater than gravity.
+            // make it stick to the ground until we see body wrench specific force greater than gravity.
             float normalizedForce = body_wrench.force.squaredNorm();
             float normalizedGravity = body.getEnvironment().getState().gravity.squaredNorm();
-            if (normalizedForce >= normalizedGravity)
+            if (normalizedForce/body.getMass()/body.getMass() >= normalizedGravity)
             {
                 //throttledLogOutput("*** Losing ground lock due to body_wrench " + VectorMath::toString(body_wrench.force), 0.1);
 				body.setGrounded(false);


### PR DESCRIPTION
This pull request fixes issue #2345 and #2341 
In `FastPhysicsEngine.hpp` the squared norm of the gravitational acceleration was compared to body wrench squared norm, leading to improper physical behavior for thrusts and masses different from the original quadcopter in AirSim, since it is not much different from 1 kg, thus hiding the issue. 
With this pull request, the gravitational acceleration is compared to the specific bodywrench squared, leading to proper physical behavior. 

