### PR TITLE
Fix missing DistanceSensorData type and wrong param name in getDistanceSensorData()

### DIFF
--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -156,7 +156,7 @@ class VehicleClient:
     def getGpsData(self, gps_name = '', vehicle_name = ''):
         return GpsData.from_msgpack(self.client.call('getGpsData', gps_name, vehicle_name))
 
-    def getDistanceSensorData(self, lidar_name = '', vehicle_name = ''):
+    def getDistanceSensorData(self, distance_sensor_name = '', vehicle_name = ''):
         return DistanceSensorData.from_msgpack(self.client.call('getDistanceSensorData', distance_sensor_name, vehicle_name))
 
     def getLidarData(self, lidar_name = '', vehicle_name = ''):

--- a/PythonClient/airsim/types.py
+++ b/PythonClient/airsim/types.py
@@ -397,3 +397,10 @@ class GpsData(MsgpackMixin):
     time_stamp = np.uint64(0)
     gnss = GnssReport()
     is_valid = False
+
+class DistanceSensorData(MsgpackMixin):
+    time_stamp = np.uint64(0)
+    distance = Quaternionr()
+    min_distance = Quaternionr()
+    max_distance = Quaternionr()
+    relative_pose = Pose()


### PR DESCRIPTION
* Wrong variable name in getDistanceSensor()
* Missing type for DistanceSensorData

Fixes #2117 

There is also a lack of documentation on how to use the distance sensors, would be nice if someone could fix that too. Already mentioned in #1673.