### PR TITLE
Remove unnecessary sudo that causes failure to set up in Ubuntu 18.04

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -203,7 +203,7 @@ if ! $gccBuild; then
     if [ "$(uname)" == "Darwin" ]; then
         rm -rf llvm-build
     else
-        sudo rm -rf llvm-build
+        rm -rf llvm-build
     fi
     mkdir -p llvm-build
     pushd llvm-build >/dev/null
@@ -219,7 +219,7 @@ if ! $gccBuild; then
     if [ "$(uname)" == "Darwin" ]; then
         make install-libcxx install-libcxxabi
     else
-        sudo make install-libcxx install-libcxxabi
+        make install-libcxx install-libcxxabi
     fi
 
     popd >/dev/null
@@ -230,7 +230,7 @@ echo "Installing EIGEN library..."
 if [ "$(uname)" == "Darwin" ]; then
     rm -rf ./AirLib/deps/eigen3/Eigen
 else
-    sudo rm -rf ./AirLib/deps/eigen3/Eigen
+    rm -rf ./AirLib/deps/eigen3/Eigen
 fi
 echo "downloading eigen..."
 wget https://gitlab.com/libeigen/eigen/-/archive/3.3.2/eigen-3.3.2.zip


### PR DESCRIPTION
I tried to build AirSim on Ubuntu 18.04, but the `setup.sh` script failed at compiling and installing clang with the following error message:

```
[...]
Built target cxx_objects                                                                                                         
Built target cxxabi_objects                                                                                                                  
Built target cxxabi_shared                                                                                                         
Built target cxx_shared                                                                                                   
Built target cxx_static                                                                                           
Built target cxx                                                                                                   
Scanning dependencies of target cxx-headers                                                                               
CMake Error: Cannot open file for write: /auto/homes/jb2270/l310_project/AirSimClang/llvm-build/projects/libcxx/include/CMakeFiles/cxx-header
s.dir/depend.make.tmp                                                                                            
CMake Error: : System Error: Permission denied                                                                
projects/libcxx/include/CMakeFiles/cxx-headers.dir/build.make:70: recipe for target 'projects/libcxx/include/CMakeFiles/cxx-headers.dir/depen
d' failed                                                                                                                    
make[3]: *** [projects/libcxx/include/CMakeFiles/cxx-headers.dir/depend] Error 2                                       
CMakeFiles/Makefile2:14215: recipe for target 'projects/libcxx/include/CMakeFiles/cxx-headers.dir/all' failed          
make[2]: *** [projects/libcxx/include/CMakeFiles/cxx-headers.dir/all] Error 2                                         
CMakeFiles/Makefile2:14427: recipe for target 'projects/libcxx/lib/CMakeFiles/install-libcxx.dir/rule' failed           
make[1]: *** [projects/libcxx/lib/CMakeFiles/install-libcxx.dir/rule] Error 2                                              
Makefile:4255: recipe for target 'install-libcxx' failed                                                           
make: *** [install-libcxx] Error 2                                                                                 
[...]
```
The setup script itself weirdly did not really failed, it ran through anyways. Only when trying to run `build.sh` it complained with `ERROR: clang++ and libc++ is necessary to compile AirSim and run it in Unreal engine. Please run setup.sh first`. The reason for that is that for some reason the installation is attempted as sudo, but this does not really make sense and leads to the error message. Therefore I removed the sudo for all local operations. Both setup and build now runs successfully.