### PR TITLE
FastPhysicsEngine: body isGrounded logic fix

### DIFF
--- a/AirLib/include/physics/FastPhysicsEngine.hpp
+++ b/AirLib/include/physics/FastPhysicsEngine.hpp
@@ -324,10 +324,10 @@ private:
         const Wrench body_wrench = getBodyWrench(body, current.pose.orientation);
 
         if (body.isGrounded()) {
-            // make it stick to the ground until we see body wrench force greater than gravity.
+            // make it stick to the ground until we see body wrench specific force greater than gravity.
             float normalizedForce = body_wrench.force.squaredNorm();
             float normalizedGravity = body.getEnvironment().getState().gravity.squaredNorm();
-            if (normalizedForce >= normalizedGravity)
+            if (normalizedForce/body.getMass()/body.getMass() >= normalizedGravity)
             {
                 //throttledLogOutput("*** Losing ground lock due to body_wrench " + VectorMath::toString(body_wrench.force), 0.1);
 				body.setGrounded(false);

--- a/AirLib/include/physics/FastPhysicsEngine.hpp
+++ b/AirLib/include/physics/FastPhysicsEngine.hpp
@@ -324,10 +324,11 @@ private:
         const Wrench body_wrench = getBodyWrench(body, current.pose.orientation);
 
         if (body.isGrounded()) {
-            // make it stick to the ground until we see body wrench specific force greater than gravity.
-            float normalizedForce = body_wrench.force.squaredNorm();
-            float normalizedGravity = body.getEnvironment().getState().gravity.squaredNorm();
-            if (normalizedForce/body.getMass()/body.getMass() >= normalizedGravity)
+            // make it stick to the ground until the magnitude of net external force on body exceeds its weight.
+            float external_force_magnitude = body_wrench.force.squaredNorm();
+            Vector3r weight = body.getMass() * body.getEnvironment().getState().gravity;
+            float weight_magnitude = weight.squaredNorm();
+            if (external_force_magnitude >= weight_magnitude)
             {
                 //throttledLogOutput("*** Losing ground lock due to body_wrench " + VectorMath::toString(body_wrench.force), 0.1);
 				body.setGrounded(false);


### PR DESCRIPTION
adding on to #2357 
Made code readable (a double division by mass might leave one scratching their head)