### PR TITLE
Add placeholder for simSwapTexture in Unity for compilation

### DIFF
--- a/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.cpp
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.cpp
@@ -52,6 +52,14 @@ void WorldSimApi::printLogMessage(const std::string& message, const std::string&
 	PrintLogMessage(message.c_str(), message_param.c_str(), vehicle_name_.c_str(), severity);
 }
 
+std::unique_ptr<std::vector<std::string>> swapTextures(const std::string& tag, int tex_id, int component_id, int material_id)
+{
+    std::unique_ptr<std::vector<std::string>> swappedObjectNames(new std::vector<std::string>());
+    throw std::invalid_argument(common_utils::Utils::stringf(
+        "simSwapTextures is not supported on Unity").c_str());
+    return swappedObjectNames;
+}
+
 std::vector<std::string> WorldSimApi::listSceneObjects(const std::string& name_regex) const
 {
 	std::vector<std::string> result;

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.h
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.h
@@ -3,6 +3,7 @@
 #include "api/WorldSimApiBase.hpp"
 #include "./SimMode/SimModeBase.h"
 #include "AirSimStructs.hpp"
+#include <memory>
 
 class WorldSimApi : public msr::airlib::WorldSimApiBase
 {
@@ -16,8 +17,8 @@ public:
 	virtual void reset() override;
 	virtual void pause(bool is_paused) override;
 	virtual void continueForTime(double seconds) override;
-        virtual void setTimeOfDay(bool is_enabled, const std::string& start_datetime, bool is_start_datetime_dst,
-            float celestial_clock_speed, float update_interval_secs, bool move_sun);
+    virtual void setTimeOfDay(bool is_enabled, const std::string& start_datetime, bool is_start_datetime_dst,
+                                float celestial_clock_speed, float update_interval_secs, bool move_sun);
 
     virtual void enableWeather(bool enable);
     virtual void setWeatherParameter(WeatherParameter param, float val);
@@ -27,6 +28,8 @@ public:
 	virtual void printLogMessage(const std::string& message,
 		const std::string& message_param = "", unsigned char severity = 0) override;
 
+    virtual std::unique_ptr<std::vector<std::string>> swapTextures(const std::string& tag, int tex_id = 0,
+                                                                int component_id = 0, int material_id = 0) override;
 	virtual std::vector<std::string> listSceneObjects(const std::string& name_regex) const override;
 	virtual Pose getObjectPose(const std::string& object_name) const override;
 	virtual bool setObjectPose(const std::string& object_name, const Pose& pose, bool teleport) override;


### PR DESCRIPTION
WIP for now, even though it compiles, starting Unity project gives errors
Even though the branch name says Windows, only works for Linux currently, still fails in Windows with linking error
```
WorldSimApi.obj : error LNK2001: unresolved external symbol "public: virtual class std::unique_ptr<class std::vector<class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> >,class std::allocator<class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > > >,struct std::default_delete<class std::vector<class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> >,class std::allocator<class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > > > > > __cdecl WorldSimApi::swapTextures(class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &,int,int,int)" (?swapTextures@WorldSimApi@@UEAA?AV?$unique_ptr@V?$vector@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$allocator@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@2@@std@@U?$default_delete@V?$vector@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$allocator@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@2@@std@@@2@@std@@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@3@HHH@Z) [C:\Users\travis\build\rajat2004\AirSim\Unity\AirLibWrapper\AirsimWrapper\AirsimWrapper.vcxproj]

C:\Users\travis\build\rajat2004\AirSim\Unity\AirLibWrapper\x64\Release\AirsimWrapper.dll : fatal error LNK1120: 1 unresolved externals [C:\Users\travis\build\rajat2004\AirSim\Unity\AirLibWrapper\AirsimWrapper\AirsimWrapper.vcxproj]
```

Caught while looking at https://github.com/microsoft/AirSim/pull/2356