### PR TITLE
Added ability to get position vertex buffer of static meshes from the unreal scene

### DIFF
--- a/AirLib/include/api/RpcLibAdapatorsBase.hpp
+++ b/AirLib/include/api/RpcLibAdapatorsBase.hpp
@@ -694,6 +694,70 @@ public:
             return d;
         }
     };
+
+	struct MeshResponse {
+		Vector3r position;
+		Quaternionr orientation;
+
+		std::vector<float> vertices;
+		std::vector<uint32_t> indices;
+		std::string name;
+
+		MSGPACK_DEFINE_MAP(position, orientation, vertices, indices, name);
+
+		MeshResponse()
+		{}
+
+		MeshResponse(const msr::airlib::MeshResponse& s)
+		{
+			position = Vector3r(s.position);
+			orientation = Quaternionr(s.orientation);
+
+			vertices = s.vertices;
+			indices = s.indices;
+
+			if (vertices.size() == 0)
+				vertices.push_back(0);
+			if (indices.size() == 0)
+				indices.push_back(0);
+
+			name = s.name;
+		}
+
+		msr::airlib::MeshResponse to() const
+		{
+			msr::airlib::MeshResponse d;
+			d.position = position.to();
+			d.orientation = orientation.to();
+			d.vertices = vertices;
+			d.indices = indices;
+			d.name = name;
+
+			return d;
+		}
+
+		static std::vector<msr::airlib::MeshResponse> to(
+			const std::vector<MeshResponse>& response_adapter
+		) {
+			std::vector<msr::airlib::MeshResponse> response;
+			for (const auto& item : response_adapter)
+				response.push_back(item.to());
+
+			return response;
+		}
+		static std::vector<MeshResponse> from(
+			const std::vector<msr::airlib::MeshResponse>& response
+		) {
+			std::vector<MeshResponse> response_adapter;
+			for (const auto& item : response)
+				response_adapter.push_back(MeshResponse(item));
+
+			return response_adapter;
+		}
+
+	};
+
+
 };
 
 }} //namespace

--- a/AirLib/include/api/RpcLibAdapatorsBase.hpp
+++ b/AirLib/include/api/RpcLibAdapatorsBase.hpp
@@ -695,67 +695,65 @@ public:
         }
     };
 
-	struct MeshResponse {
-		Vector3r position;
-		Quaternionr orientation;
+    struct MeshPositionVertexBuffersResponse {
+        Vector3r position;
+        Quaternionr orientation;
 
-		std::vector<float> vertices;
-		std::vector<uint32_t> indices;
-		std::string name;
+        std::vector<float> vertices;
+        std::vector<uint32_t> indices;
+        std::string name;
 
-		MSGPACK_DEFINE_MAP(position, orientation, vertices, indices, name);
+        MSGPACK_DEFINE_MAP(position, orientation, vertices, indices, name);
 
-		MeshResponse()
-		{}
+        MeshPositionVertexBuffersResponse()
+        {}
 
-		MeshResponse(const msr::airlib::MeshResponse& s)
-		{
-			position = Vector3r(s.position);
-			orientation = Quaternionr(s.orientation);
+        MeshPositionVertexBuffersResponse(const msr::airlib::MeshPositionVertexBuffersResponse& s)
+        {
+            position = Vector3r(s.position);
+            orientation = Quaternionr(s.orientation);
 
-			vertices = s.vertices;
-			indices = s.indices;
+            vertices = s.vertices;
+            indices = s.indices;
 
-			if (vertices.size() == 0)
-				vertices.push_back(0);
-			if (indices.size() == 0)
-				indices.push_back(0);
+            if (vertices.size() == 0)
+                vertices.push_back(0);
+            if (indices.size() == 0)
+                indices.push_back(0);
 
-			name = s.name;
-		}
+            name = s.name;
+        }
 
-		msr::airlib::MeshResponse to() const
-		{
-			msr::airlib::MeshResponse d;
-			d.position = position.to();
-			d.orientation = orientation.to();
-			d.vertices = vertices;
-			d.indices = indices;
-			d.name = name;
+        msr::airlib::MeshPositionVertexBuffersResponse to() const
+        {
+            msr::airlib::MeshPositionVertexBuffersResponse d;
+            d.position = position.to();
+            d.orientation = orientation.to();
+            d.vertices = vertices;
+            d.indices = indices;
+            d.name = name;
 
-			return d;
-		}
+            return d;
+        }
 
-		static std::vector<msr::airlib::MeshResponse> to(
-			const std::vector<MeshResponse>& response_adapter
-		) {
-			std::vector<msr::airlib::MeshResponse> response;
-			for (const auto& item : response_adapter)
-				response.push_back(item.to());
+        static std::vector<msr::airlib::MeshPositionVertexBuffersResponse> to(
+            const std::vector<MeshPositionVertexBuffersResponse>& response_adapter) {
+            std::vector<msr::airlib::MeshPositionVertexBuffersResponse> response;
+            for (const auto& item : response_adapter)
+                response.push_back(item.to());
 
-			return response;
-		}
-		static std::vector<MeshResponse> from(
-			const std::vector<msr::airlib::MeshResponse>& response
-		) {
-			std::vector<MeshResponse> response_adapter;
-			for (const auto& item : response)
-				response_adapter.push_back(MeshResponse(item));
+            return response;
+        }
 
-			return response_adapter;
-		}
+        static std::vector<MeshPositionVertexBuffersResponse> from(
+            const std::vector<msr::airlib::MeshPositionVertexBuffersResponse>& response) {
+            std::vector<MeshPositionVertexBuffersResponse> response_adapter;
+            for (const auto& item : response)
+                response_adapter.push_back(MeshPositionVertexBuffersResponse(item));
 
-	};
+            return response_adapter;
+        }
+    };
 
 
 };

--- a/AirLib/include/api/RpcLibClientBase.hpp
+++ b/AirLib/include/api/RpcLibClientBase.hpp
@@ -92,6 +92,8 @@ public:
     vector<ImageCaptureBase::ImageResponse> simGetImages(vector<ImageCaptureBase::ImageRequest> request, const std::string& vehicle_name = "");
     vector<uint8_t> simGetImage(const std::string& camera_name, ImageCaptureBase::ImageType type, const std::string& vehicle_name = "");
 
+	vector<MeshResponse> simGetMeshes();
+
     CollisionInfo simGetCollisionInfo(const std::string& vehicle_name = "") const;
 
     CameraInfo simGetCameraInfo(const std::string& camera_name, const std::string& vehicle_name = "") const;

--- a/AirLib/include/api/RpcLibClientBase.hpp
+++ b/AirLib/include/api/RpcLibClientBase.hpp
@@ -92,7 +92,7 @@ public:
     vector<ImageCaptureBase::ImageResponse> simGetImages(vector<ImageCaptureBase::ImageRequest> request, const std::string& vehicle_name = "");
     vector<uint8_t> simGetImage(const std::string& camera_name, ImageCaptureBase::ImageType type, const std::string& vehicle_name = "");
 
-	vector<MeshResponse> simGetMeshes();
+    vector<MeshPositionVertexBuffersResponse> simGetMeshPositionVertexBuffers();
 
     CollisionInfo simGetCollisionInfo(const std::string& vehicle_name = "") const;
 

--- a/AirLib/include/api/WorldSimApiBase.hpp
+++ b/AirLib/include/api/WorldSimApiBase.hpp
@@ -57,6 +57,7 @@ public:
     virtual bool setObjectPose(const std::string& object_name, const Pose& pose, bool teleport) = 0;
 
 	virtual std::unique_ptr<std::vector<std::string>> swapTextures(const std::string& tag, int tex_id = 0, int component_id = 0, int material_id = 0) = 0;
+	virtual vector<MeshResponse> getMeshes() const = 0;
 };
 
 

--- a/AirLib/include/api/WorldSimApiBase.hpp
+++ b/AirLib/include/api/WorldSimApiBase.hpp
@@ -57,7 +57,7 @@ public:
     virtual bool setObjectPose(const std::string& object_name, const Pose& pose, bool teleport) = 0;
 
 	virtual std::unique_ptr<std::vector<std::string>> swapTextures(const std::string& tag, int tex_id = 0, int component_id = 0, int material_id = 0) = 0;
-	virtual vector<MeshResponse> getMeshes() const = 0;
+    virtual vector<MeshPositionVertexBuffersResponse> getMeshPositionVertexBuffers() const = 0;
 };
 
 

--- a/AirLib/include/common/CommonStructs.hpp
+++ b/AirLib/include/common/CommonStructs.hpp
@@ -305,5 +305,15 @@ struct LidarData {
     {}
 };
 
+struct MeshResponse {
+
+	Vector3r position;
+	Quaternionr orientation;
+
+	std::vector<float> vertices;
+	std::vector<uint32_t> indices;
+	std::string name;
+};
+
 }} //namespace
 #endif

--- a/AirLib/include/common/CommonStructs.hpp
+++ b/AirLib/include/common/CommonStructs.hpp
@@ -296,7 +296,6 @@ struct RCData {
 };
 
 struct LidarData {
-
     TTimePoint time_stamp = 0;
     vector<real_T> point_cloud;
     Pose pose;
@@ -305,14 +304,13 @@ struct LidarData {
     {}
 };
 
-struct MeshResponse {
+struct MeshPositionVertexBuffersResponse {
+    Vector3r position;
+    Quaternionr orientation;
 
-	Vector3r position;
-	Quaternionr orientation;
-
-	std::vector<float> vertices;
-	std::vector<uint32_t> indices;
-	std::string name;
+    std::vector<float> vertices;
+    std::vector<uint32_t> indices;
+    std::string name;
 };
 
 }} //namespace

--- a/AirLib/src/api/RpcLibClientBase.cpp
+++ b/AirLib/src/api/RpcLibClientBase.cpp
@@ -237,6 +237,11 @@ vector<uint8_t> RpcLibClientBase::simGetImage(const std::string& camera_name, Im
     return result;
 }
 
+vector<MeshResponse> RpcLibClientBase::simGetMeshes() {
+	const auto& response_adaptor = pimpl_->client.call("simGetMeshes").as<vector<RpcLibAdapatorsBase::MeshResponse>>();
+	return RpcLibAdapatorsBase::MeshResponse::to(response_adaptor);
+}
+
 void RpcLibClientBase::simPrintLogMessage(const std::string& message, std::string message_param, unsigned char  severity)
 {
     pimpl_->client.call("simPrintLogMessage", message, message_param, severity);

--- a/AirLib/src/api/RpcLibClientBase.cpp
+++ b/AirLib/src/api/RpcLibClientBase.cpp
@@ -237,9 +237,10 @@ vector<uint8_t> RpcLibClientBase::simGetImage(const std::string& camera_name, Im
     return result;
 }
 
-vector<MeshResponse> RpcLibClientBase::simGetMeshes() {
-	const auto& response_adaptor = pimpl_->client.call("simGetMeshes").as<vector<RpcLibAdapatorsBase::MeshResponse>>();
-	return RpcLibAdapatorsBase::MeshResponse::to(response_adaptor);
+vector<MeshPositionVertexBuffersResponse> RpcLibClientBase::simGetMeshPositionVertexBuffers()
+{
+    const auto& response_adaptor = pimpl_->client.call("simGetMeshPositionVertexBuffers").as<vector<RpcLibAdapatorsBase::MeshPositionVertexBuffersResponse>>();
+    return RpcLibAdapatorsBase::MeshPositionVertexBuffersResponse::to(response_adaptor);
 }
 
 void RpcLibClientBase::simPrintLogMessage(const std::string& message, std::string message_param, unsigned char  severity)

--- a/AirLib/src/api/RpcLibServerBase.cpp
+++ b/AirLib/src/api/RpcLibServerBase.cpp
@@ -137,6 +137,11 @@ RpcLibServerBase::RpcLibServerBase(ApiProvider* api_provider, const std::string&
         return result;
     });
 
+	pimpl_->server.bind("simGetMeshes", [&]() ->vector<RpcLibAdapatorsBase::MeshResponse> {
+		const auto& response = getWorldSimApi()->getMeshes();
+		return RpcLibAdapatorsBase::MeshResponse::from(response);
+	});
+
     pimpl_->server.
         bind("simSetVehiclePose", [&](const RpcLibAdapatorsBase::Pose &pose, bool ignore_collision, const std::string& vehicle_name) -> void {
         getVehicleSimApi(vehicle_name)->setPose(pose.to(), ignore_collision);

--- a/AirLib/src/api/RpcLibServerBase.cpp
+++ b/AirLib/src/api/RpcLibServerBase.cpp
@@ -137,10 +137,10 @@ RpcLibServerBase::RpcLibServerBase(ApiProvider* api_provider, const std::string&
         return result;
     });
 
-	pimpl_->server.bind("simGetMeshes", [&]() ->vector<RpcLibAdapatorsBase::MeshResponse> {
-		const auto& response = getWorldSimApi()->getMeshes();
-		return RpcLibAdapatorsBase::MeshResponse::from(response);
-	});
+    pimpl_->server.bind("simGetMeshPositionVertexBuffers", [&]() ->vector<RpcLibAdapatorsBase::MeshPositionVertexBuffersResponse> {
+        const auto& response = getWorldSimApi()->getMeshPositionVertexBuffers();
+        return RpcLibAdapatorsBase::MeshPositionVertexBuffersResponse::from(response);
+    });
 
     pimpl_->server.
         bind("simSetVehiclePose", [&](const RpcLibAdapatorsBase::Pose &pose, bool ignore_collision, const std::string& vehicle_name) -> void {

--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -115,9 +115,9 @@ class VehicleClient:
         return [ImageResponse.from_msgpack(response_raw) for response_raw in responses_raw]
 
     # gets the static meshes in the unreal scene
-    def simGetMeshes(self):
-        responses_raw = self.client.call('simGetMeshes')
-        return [MeshResponse.from_msgpack(response_raw) for response_raw in responses_raw]
+    def simGetMeshPositionVertexBuffers(self):
+        responses_raw = self.client.call('simGetMeshPositionVertexBuffers')
+        return [MeshPositionVertexBuffersResponse.from_msgpack(response_raw) for response_raw in responses_raw]
 
     def simGetCollisionInfo(self, vehicle_name = ''):
         return CollisionInfo.from_msgpack(self.client.call('simGetCollisionInfo', vehicle_name))

--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -114,6 +114,11 @@ class VehicleClient:
         responses_raw = self.client.call('simGetImages', requests, vehicle_name)
         return [ImageResponse.from_msgpack(response_raw) for response_raw in responses_raw]
 
+    # gets the static meshes in the unreal scene
+    def simGetMeshes(self):
+        responses_raw = self.client.call('simGetMeshes')
+        return [MeshResponse.from_msgpack(response_raw) for response_raw in responses_raw]
+
     def simGetCollisionInfo(self, vehicle_name = ''):
         return CollisionInfo.from_msgpack(self.client.call('simGetCollisionInfo', vehicle_name))
 

--- a/PythonClient/airsim/types.py
+++ b/PythonClient/airsim/types.py
@@ -498,3 +498,10 @@ class PositionControllerGains():
     
     def to_lists(self):
         return [self.x_gains.kp, self.y_gains.kp, self.z_gains.kp], [self.x_gains.ki, self.y_gains.ki, self.z_gains.ki], [self.x_gains.kd, self.y_gains.kd, self.z_gains.kd]
+
+class MeshResponse(MsgpackMixin):
+    position = Vector3r()
+    orientation = Quaternionr()
+    vertices = 0.0
+    indices = 0.0
+    name = ''

--- a/PythonClient/airsim/types.py
+++ b/PythonClient/airsim/types.py
@@ -499,7 +499,7 @@ class PositionControllerGains():
     def to_lists(self):
         return [self.x_gains.kp, self.y_gains.kp, self.z_gains.kp], [self.x_gains.ki, self.y_gains.ki, self.z_gains.ki], [self.x_gains.kd, self.y_gains.kd, self.z_gains.kd]
 
-class MeshResponse(MsgpackMixin):
+class MeshPositionVertexBuffersResponse(MsgpackMixin):
     position = Vector3r()
     orientation = Quaternionr()
     vertices = 0.0

--- a/PythonClient/setup.py
+++ b/PythonClient/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="airsim",
-    version="1.2.6",
+    version="1.2.7",
     author="Shital Shah",
     author_email="shitals@microsoft.com",
     description="Open source simulator based on Unreal Engine for autonomous vehicles from Microsoft AI & Research",

--- a/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
+++ b/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
@@ -352,124 +352,127 @@ std::vector<std::string> UAirBlueprintLib::ListMatchingActors(const UObject *con
     return results;
 }
 
-std::vector<msr::airlib::MeshResponse> UAirBlueprintLib::GetStaticMeshComponents() {
-	std::vector<msr::airlib::MeshResponse> meshes;
-	int num_meshes = 0;
-	for (TObjectIterator<UStaticMeshComponent> comp; comp; ++comp)
-	{
-		*comp;
+std::vector<msr::airlib::MeshPositionVertexBuffersResponse> UAirBlueprintLib::GetStaticMeshComponents()
+{
+    std::vector<msr::airlib::MeshPositionVertexBuffersResponse> meshes;
+    int num_meshes = 0;
+    for (TObjectIterator<UStaticMeshComponent> comp; comp; ++comp)
+    {
+        *comp;
 
-		std::string name = common_utils::Utils::toLower(GetMeshName(*comp));
-		//The skybox is ignored here as it is huge, and really is of no use to the end user typically. Also the associated meshes with the cameras
-		if (name == "" || common_utils::Utils::startsWith(name, "default_") || common_utils::Utils::startsWith(name, "sky") || common_utils::Utils::startsWith(name, "camera")) {
-			continue;
-		}
+        std::string name = common_utils::Utils::toLower(GetMeshName(*comp));
+        //The skybox is ignored here as it is huge, and really is of no use to the end user typically. Also the associated meshes with the cameras
+        if (name == "" || common_utils::Utils::startsWith(name, "default_") 
+            || common_utils::Utils::startsWith(name, "sky") 
+            || common_utils::Utils::startsWith(name, "camera"))
+        {
+            continue;
+        }
 
-		//Various checks if there is even a valid mesh
-		if (!comp->GetStaticMesh()) continue;
-		if (!comp->GetStaticMesh()->RenderData) continue;
-		if (comp->GetStaticMesh()->RenderData->LODResources.Num() == 0) continue;
+        //Various checks if there is even a valid mesh
+        if (!comp->GetStaticMesh()) continue;
+        if (!comp->GetStaticMesh()->RenderData) continue;
+        if (comp->GetStaticMesh()->RenderData->LODResources.Num() == 0) continue;
 
-		msr::airlib::MeshResponse mesh;
-		mesh.name = name;
+        msr::airlib::MeshPositionVertexBuffersResponse mesh;
+        mesh.name = name;
 
-		FVector pos = comp->GetComponentLocation();
-		FQuat att = comp->GetComponentQuat();
-		mesh.position[0] = pos.X;
-		mesh.position[1] = pos.Y;
-		mesh.position[2] = pos.Z;
-		mesh.orientation.w() = att.W;
-		mesh.orientation.x() = att.X;
-		mesh.orientation.y() = att.Y;
-		mesh.orientation.z() = att.Z;
+        FVector pos = comp->GetComponentLocation();
+        FQuat att = comp->GetComponentQuat();
+        mesh.position[0] = pos.X;
+        mesh.position[1] = pos.Y;
+        mesh.position[2] = pos.Z;
+        mesh.orientation.w() = att.W;
+        mesh.orientation.x() = att.X;
+        mesh.orientation.y() = att.Y;
+        mesh.orientation.z() = att.Z;
 
-		FPositionVertexBuffer* vertex_buffer = &comp->GetStaticMesh()->RenderData->LODResources[0].VertexBuffers.PositionVertexBuffer;
-		if (vertex_buffer)
-		{
-			const int32 vertex_count = vertex_buffer->VertexBufferRHI->GetSize();
-			TArray<FVector> vertices;
-			vertices.SetNum(vertex_count);
-			FVector* data = vertices.GetData();
-			ENQUEUE_UNIQUE_RENDER_COMMAND_TWOPARAMETER(
-				GetVertexBuffer,
-				FPositionVertexBuffer*, vertex_buffer, vertex_buffer,
-				FVector*, data, data,
-				{
-					FVector* indices = (FVector*)RHILockVertexBuffer(vertex_buffer->VertexBufferRHI, 0, vertex_buffer->VertexBufferRHI->GetSize(), RLM_ReadOnly);
-					memcpy(data, indices, vertex_buffer->VertexBufferRHI->GetSize());
-					RHIUnlockVertexBuffer(vertex_buffer->VertexBufferRHI);
-				});
+        FPositionVertexBuffer* vertex_buffer = &comp->GetStaticMesh()->RenderData->LODResources[0].VertexBuffers.PositionVertexBuffer;
+        if (vertex_buffer)
+        {
+            const int32 vertex_count = vertex_buffer->VertexBufferRHI->GetSize();
+            TArray<FVector> vertices;
+            vertices.SetNum(vertex_count);
+            FVector* data = vertices.GetData();
+            ENQUEUE_UNIQUE_RENDER_COMMAND_TWOPARAMETER(
+                GetVertexBuffer,
+                FPositionVertexBuffer*, vertex_buffer, vertex_buffer,
+                FVector*, data, data,
+                {
+                    FVector* indices = (FVector*)RHILockVertexBuffer(vertex_buffer->VertexBufferRHI, 0, vertex_buffer->VertexBufferRHI->GetSize(), RLM_ReadOnly);
+                    memcpy(data, indices, vertex_buffer->VertexBufferRHI->GetSize());
+                    RHIUnlockVertexBuffer(vertex_buffer->VertexBufferRHI);
+                });
 
+            const FRawStaticIndexBuffer& IndexBuffer = comp->GetStaticMesh()->RenderData->LODResources[0].IndexBuffer;
 
-			const FRawStaticIndexBuffer& IndexBuffer = comp->GetStaticMesh()->RenderData->LODResources[0].IndexBuffer;
+            FStaticMeshLODResources& lod = comp->GetStaticMesh()->RenderData->LODResources[0];
+            int num_indices = lod.IndexBuffer.IndexBufferRHI->GetSize() / lod.IndexBuffer.IndexBufferRHI->GetStride();
 
-			FStaticMeshLODResources& lod = comp->GetStaticMesh()->RenderData->LODResources[0];
-			int num_indices = lod.IndexBuffer.IndexBufferRHI->GetSize() / lod.IndexBuffer.IndexBufferRHI->GetStride();
-			if (lod.IndexBuffer.IndexBufferRHI->GetStride() == 2) {
-				TArray<uint16_t> indices_vec;
-				indices_vec.SetNum(num_indices);
-				uint16_t* data_ptr = indices_vec.GetData();
-				ENQUEUE_UNIQUE_RENDER_COMMAND_TWOPARAMETER(
-					GetIndexBuffer,
-					FRawStaticIndexBuffer*, IndexBuffer, &lod.IndexBuffer,
-					uint16_t*, data, data_ptr,
-					{
-						uint16_t* indices = (uint16_t*)RHILockIndexBuffer(IndexBuffer->IndexBufferRHI, 0, IndexBuffer->IndexBufferRHI->GetSize(), RLM_ReadOnly);
-						memcpy(data, indices, IndexBuffer->IndexBufferRHI->GetSize());
-						RHIUnlockIndexBuffer(IndexBuffer->IndexBufferRHI);
-					});
+            if (lod.IndexBuffer.IndexBufferRHI->GetStride() == 2) {
+                TArray<uint16_t> indices_vec;
+                indices_vec.SetNum(num_indices);
+                uint16_t* data_ptr = indices_vec.GetData();
+                ENQUEUE_UNIQUE_RENDER_COMMAND_TWOPARAMETER(
+                    GetIndexBuffer,
+                    FRawStaticIndexBuffer*, IndexBuffer, &lod.IndexBuffer,
+                    uint16_t*, data, data_ptr,
+                    {
+                        uint16_t* indices = (uint16_t*)RHILockIndexBuffer(IndexBuffer->IndexBufferRHI, 0, IndexBuffer->IndexBufferRHI->GetSize(), RLM_ReadOnly);
+                        memcpy(data, indices, IndexBuffer->IndexBufferRHI->GetSize());
+                        RHIUnlockIndexBuffer(IndexBuffer->IndexBufferRHI);
+                    });
 
-				//Need to force the render command to go through cause on the next iteration the buffer no longer exists
-				FlushRenderingCommands();
+                //Need to force the render command to go through cause on the next iteration the buffer no longer exists
+                FlushRenderingCommands();
 
-				mesh.indices.resize(num_indices);
-				for (int idx = 0; idx < num_indices; ++idx) {
-					mesh.indices[idx] = indices_vec[idx];
-				}
+                mesh.indices.resize(num_indices);
+                for (int idx = 0; idx < num_indices; ++idx) {
+                    mesh.indices[idx] = indices_vec[idx];
+                }
+            }
 
+            else { //stride ==4
+                TArray<uint32_t> indices_vec;
+                indices_vec.SetNum(num_indices);
+                uint32_t* data_ptr = indices_vec.GetData();
+                ENQUEUE_UNIQUE_RENDER_COMMAND_TWOPARAMETER(
+                    GetIndexBuffer,
+                    FRawStaticIndexBuffer*, IndexBuffer, &lod.IndexBuffer,
+                    uint32_t*, data, data_ptr,
+                    {
+                        uint32_t* indices = (uint32_t*)RHILockIndexBuffer(IndexBuffer->IndexBufferRHI, 0, IndexBuffer->IndexBufferRHI->GetSize(), RLM_ReadOnly);
+                        memcpy(data, indices, IndexBuffer->IndexBufferRHI->GetSize());
+                        RHIUnlockIndexBuffer(IndexBuffer->IndexBufferRHI);
+                    });
 
-			}
-			else { //stride ==4
-				TArray<uint32_t> indices_vec;
-				indices_vec.SetNum(num_indices);
-				uint32_t* data_ptr = indices_vec.GetData();
-				ENQUEUE_UNIQUE_RENDER_COMMAND_TWOPARAMETER(
-					GetIndexBuffer,
-					FRawStaticIndexBuffer*, IndexBuffer, &lod.IndexBuffer,
-					uint32_t*, data, data_ptr,
-					{
-						uint32_t* indices = (uint32_t*)RHILockIndexBuffer(IndexBuffer->IndexBufferRHI, 0, IndexBuffer->IndexBufferRHI->GetSize(), RLM_ReadOnly);
-						memcpy(data, indices, IndexBuffer->IndexBufferRHI->GetSize());
-						RHIUnlockIndexBuffer(IndexBuffer->IndexBufferRHI);
-					});
+                FlushRenderingCommands();
 
-				FlushRenderingCommands();
+                mesh.indices.resize(num_indices);
+                for (int idx = 0; idx < num_indices; ++idx) {
+                    mesh.indices[idx] = indices_vec[idx];
+                }
+            }
 
-				mesh.indices.resize(num_indices);
-				for (int idx = 0; idx < num_indices; ++idx) {
-					mesh.indices[idx] = indices_vec[idx];
-				}
-			}
+            //Unreal stores more vertices than triangles. So here we find the highest referenced vertex and ignore any after that
+            auto result_iter = std::max_element(mesh.indices.begin(), mesh.indices.end());
+            auto max_triangle_index = std::distance(mesh.indices.begin(), result_iter);
 
-			//Unreal stores more vertices than triangles. So here we find the highest referenced vertex and ignore any after that
-			auto result_iter = std::max_element(mesh.indices.begin(), mesh.indices.end());
-			auto max_triangle_index = std::distance(mesh.indices.begin(), result_iter);
+            mesh.vertices.resize(max_triangle_index * 3);
+            int aligned_index = 0;
+            FTransform transform = comp->GetComponentTransform();
+            for(int vertex_idx=0;vertex_idx<max_triangle_index;++vertex_idx){
+                FVector transformed_vec = pos + transform.TransformVector(vertices[vertex_idx]);
+                mesh.vertices[aligned_index++] = transformed_vec.X;
+                mesh.vertices[aligned_index++] = transformed_vec.Y;
+                mesh.vertices[aligned_index++] = transformed_vec.Z;
+            }
+        }
 
-			mesh.vertices.resize(max_triangle_index * 3);
-			int aligned_index = 0;
-			FTransform transform = comp->GetComponentTransform();
-			for(int vertex_idx=0;vertex_idx<max_triangle_index;++vertex_idx){
-				FVector transformed_vec = pos + transform.TransformVector(vertices[vertex_idx]);
-				mesh.vertices[aligned_index++] = transformed_vec.X;
-				mesh.vertices[aligned_index++] = transformed_vec.Y;
-				mesh.vertices[aligned_index++] = transformed_vec.Z;
-			}
-		}
+        meshes.push_back(mesh);
+    }
 
-		meshes.push_back(mesh);
-	}
-
-	return meshes;
+    return meshes;
 }
 
 bool UAirBlueprintLib::HasObstacle(const AActor* actor, const FVector& start, const FVector& end, const AActor* ignore_actor, ECollisionChannel collision_channel)

--- a/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
+++ b/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
@@ -383,7 +383,7 @@ std::vector<msr::airlib::MeshResponse> UAirBlueprintLib::GetStaticMeshComponents
 		mesh.orientation.y() = att.Y;
 		mesh.orientation.z() = att.Z;
 
-		FPositionVertexBuffer* vertex_buffer = &comp->GetStaticMesh()->RenderData->LODResources[0].PositionVertexBuffer;
+		FPositionVertexBuffer* vertex_buffer = &comp->GetStaticMesh()->RenderData->LODResources[0].VertexBuffers.PositionVertexBuffer;
 		if (vertex_buffer)
 		{
 			const int32 vertex_count = vertex_buffer->VertexBufferRHI->GetSize();

--- a/Unreal/Plugins/AirSim/Source/AirBlueprintLib.h
+++ b/Unreal/Plugins/AirSim/Source/AirBlueprintLib.h
@@ -183,6 +183,8 @@ public:
     static IImageWrapperModule* getImageWrapperModule();
     static void CompressImageArray(int32 width, int32 height, const TArray<FColor> &src, TArray<uint8> &dest);
 
+	static std::vector<msr::airlib::MeshResponse> GetStaticMeshComponents();
+
 private:
     template<typename T>
     static void InitializeObjectStencilID(T* mesh, bool ignore_existing = true)

--- a/Unreal/Plugins/AirSim/Source/AirBlueprintLib.h
+++ b/Unreal/Plugins/AirSim/Source/AirBlueprintLib.h
@@ -183,7 +183,7 @@ public:
     static IImageWrapperModule* getImageWrapperModule();
     static void CompressImageArray(int32 width, int32 height, const TArray<FColor> &src, TArray<uint8> &dest);
 
-	static std::vector<msr::airlib::MeshResponse> GetStaticMeshComponents();
+	static std::vector<msr::airlib::MeshPositionVertexBuffersResponse> GetStaticMeshComponents();
 
 private:
     template<typename T>

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
@@ -230,3 +230,12 @@ void WorldSimApi::simPlotTransformsWithNames(const std::vector<Pose>& poses, con
         DrawDebugString(simmode_->GetWorld(), simmode_->getGlobalNedTransform().fromGlobalNed(poses[idx]).GetLocation(), FString(names[idx].c_str()), NULL, color.ToFColor(true), duration, false, text_scale);
     }
 }
+
+std::vector<WorldSimApi::MeshResponse> WorldSimApi::getMeshes() const
+{
+	std::vector<WorldSimApi::MeshResponse> responses;
+	UAirBlueprintLib::RunCommandOnGameThread([&responses]() {
+		responses = UAirBlueprintLib::GetStaticMeshComponents();
+	}, true);
+	return responses;
+}

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
@@ -231,9 +231,9 @@ void WorldSimApi::simPlotTransformsWithNames(const std::vector<Pose>& poses, con
     }
 }
 
-std::vector<WorldSimApi::MeshResponse> WorldSimApi::getMeshes() const
+std::vector<WorldSimApi::MeshPositionVertexBuffersResponse> WorldSimApi::getMeshPositionVertexBuffers() const
 {
-	std::vector<WorldSimApi::MeshResponse> responses;
+	std::vector<WorldSimApi::MeshPositionVertexBuffersResponse> responses;
 	UAirBlueprintLib::RunCommandOnGameThread([&responses]() {
 		responses = UAirBlueprintLib::GetStaticMeshComponents();
 	}, true);

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.h
@@ -10,6 +10,7 @@ class WorldSimApi : public msr::airlib::WorldSimApiBase {
 public:
     typedef msr::airlib::Pose Pose;
     typedef msr::airlib::Vector3r Vector3r;
+	typedef msr::airlib::MeshResponse MeshResponse;
 
     WorldSimApi(ASimModeBase* simmode);
     virtual ~WorldSimApi() = default;
@@ -45,6 +46,7 @@ public:
     virtual void simPlotStrings(const std::vector<std::string>& strings, const std::vector<Vector3r>& positions, float scale, const std::vector<float>& color_rgba, float duration) override;
     virtual void simPlotTransforms(const std::vector<Pose>& poses, float scale, float thickness, float duration, bool is_persistent) override;
     virtual void simPlotTransformsWithNames(const std::vector<Pose>& poses, const std::vector<std::string>& names, float tf_scale, float tf_thickness, float text_scale, const std::vector<float>& text_color_rgba, float duration) override;
+	virtual std::vector<MeshResponse> getMeshes() const override;
 
 private:
     ASimModeBase* simmode_;

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.h
@@ -10,7 +10,7 @@ class WorldSimApi : public msr::airlib::WorldSimApiBase {
 public:
     typedef msr::airlib::Pose Pose;
     typedef msr::airlib::Vector3r Vector3r;
-	typedef msr::airlib::MeshResponse MeshResponse;
+	typedef msr::airlib::MeshPositionVertexBuffersResponse MeshPositionVertexBuffersResponse;
 
     WorldSimApi(ASimModeBase* simmode);
     virtual ~WorldSimApi() = default;
@@ -46,7 +46,7 @@ public:
     virtual void simPlotStrings(const std::vector<std::string>& strings, const std::vector<Vector3r>& positions, float scale, const std::vector<float>& color_rgba, float duration) override;
     virtual void simPlotTransforms(const std::vector<Pose>& poses, float scale, float thickness, float duration, bool is_persistent) override;
     virtual void simPlotTransformsWithNames(const std::vector<Pose>& poses, const std::vector<std::string>& names, float tf_scale, float tf_thickness, float text_scale, const std::vector<float>& text_color_rgba, float duration) override;
-	virtual std::vector<MeshResponse> getMeshes() const override;
+	virtual std::vector<MeshPositionVertexBuffersResponse> getMeshPositionVertexBuffers() const override;
 
 private:
     ASimModeBase* simmode_;

--- a/docs/meshes.md
+++ b/docs/meshes.md
@@ -1,0 +1,79 @@
+# How to Access Meshes in AIRSIM
+
+AirSim supports the ability to access the static meshes that make up the scene
+
+
+## Mesh structure
+Each mesh is represented with the below struct.
+```
+struct MeshResponse {
+
+	Vector3r position;
+	Quaternionr orientation;
+
+	std::vector<float> vertices;
+	std::vector<uint32_t> indices;
+	std::string name;
+};
+```
+* The position and orientation are in the Unreal coordinate system.
+* The mesh itself is a triangular mesh represented by the vertices and the indices.
+	* The triangular mesh type is typically called a [Face-Vertex](https://en.wikipedia.org/wiki/Polygon_mesh#Face-vertex_meshes) Mesh. This means every triplet of indices hold the indexes of the vertices that make up the triangle/face.
+	* The x,y,z coordinates of the vertices are all stored in a single vector. This means the vertices vertices is Nx3 where N is number of vertices. 
+    * The position of the vertices are the global positions in the Unreal coordinate system. This means they have already been Transformed by the position and orientation.
+* 
+## How to use
+The API to get the meshes in the scene is quite simple. However, one should note that the function call is very expensive and should
+ very rarely be called. In general this is ok because this function only accesses the static meshes which for most applications are
+ not changing during the duration of your program.
+
+Note that you will have to use a 3rdparty library or your own custom code to actually interact with the recieved meshes. Below I utilize the
+python bindings of [libigl](https://github.com/libigl/libigl) to visualize the recieved meshes.
+
+```
+import airsim
+
+AIRSIM_HOST_IP='127.0.0.1'
+
+client = airsim.VehicleClient(ip=AIRSIM_HOST_IP)
+client.confirmConnection()
+
+# List of returned meshes are received via this function
+meshes=client.simGetMeshes()
+
+
+index=0
+for m in meshes:
+    # Finds one of the cube meshes in the Blocks environment
+    if 'cube' in m.name:
+
+        # Code from here on relies on libigl. Libigl uses pybind11 to wrap C++ code. So here the built pyigl.so
+        # library is in the same directory as this example code.
+        # This is here as code for your own mesh library should require something similar
+        from pyigl import *
+        from iglhelpers import *
+
+        # Convert the lists to numpy arrays
+        vertex_list=np.array(m.vertices,dtype=np.float32)
+        indices=np.array(m.indices,dtype=np.uint32)
+
+        num_vertices=int(len(vertex_list)/3)
+        num_indices=len(indices)
+
+        # Libigl requires the shape to be Nx3 where N is number of vertices or indices
+        # It also requires the actual type to be double(float64) for vertices and int64 for the triangles/indices
+        vertices_reshaped=vertex_list.reshape((num_vertices,3))
+        indices_reshaped=indices.reshape((int(num_indices/3),3))
+        vertices_reshaped=vertices_reshaped.astype(np.float64)
+        indices_reshaped=indices_reshaped.astype(np.int64)
+
+        #Libigl function to convert to internal Eigen format
+        v_eig=p2e(vertices_reshaped)
+        i_eig=p2e(indices_reshaped)
+
+        # View the mesh
+        viewer = igl.glfw.Viewer()
+        viewer.data().set_mesh(v_eig,i_eig)
+        viewer.launch()
+        break
+```

--- a/docs/meshes.md
+++ b/docs/meshes.md
@@ -6,7 +6,7 @@ AirSim supports the ability to access the static meshes that make up the scene
 ## Mesh structure
 Each mesh is represented with the below struct.
 ```
-struct MeshResponse {
+struct MeshPositionVertexBuffersResponse {
 
 	Vector3r position;
 	Quaternionr orientation;
@@ -39,7 +39,7 @@ client = airsim.VehicleClient(ip=AIRSIM_HOST_IP)
 client.confirmConnection()
 
 # List of returned meshes are received via this function
-meshes=client.simGetMeshes()
+meshes=client.simGetMeshPositionVertexBuffers()
 
 
 index=0


### PR DESCRIPTION
Original PR by @nikonodein in #1478. Reposting their description.  

This commit does work for my purposes. However there may be some improvements we want to discuss before merging it in to master.

1) Meshresponse struct:
- Do we want to contain the vertices in seperate X,Y,Z containers?

```
//Right now
struct MeshResponse {
    std::vector<float> vertices; //size is num of vertices *3
}

//Change 

struct MeshResponse {
    std::vector<float> x_vertices;
    std::vector<float> y_vertices;
    std::vector<float> z_vertices;
}
```

2) Coordinate system:
- The meshes coordinate are in the Unreal coordinate system. In this code I just pipe that data directly to the MeshResponse. 
- Converting it to NED is tricky cause then you have to specify a vehicle, which I believe this function should not require.
- For my purposes I just deal with the conversions on the client side, however, I also have the extra functionality in my codebase to get the offset between the NED and the unreal origin.

3) Efficiency of function:
- The function is quite inefficient cause it calls a FlushRenderingCommands() for every single Mesh.
- This to me doesn't actually matter that much, because you should never be calling this function that often. We only call this function once at the start of our main loop, and then never do it again.
- Could be improved by preallocating the buffers, and then call FlushRenderingCommands() once, but in the grand scheme of things doesn't really matter.

4) Meshes to ignore by default:
- By default I ignore the skybox mesh and the camera meshes, but we might not want to do that.


Example of what I receive from this function. Note I ignore the ground plane meshes.
![mesh_responses](https://user-images.githubusercontent.com/32241854/47178712-13baf580-d2ea-11e8-8df5-7047a0b350c7.png)


