### PR TITLE
ROS tf2 - Stop rebroadcasting static frames

### DIFF
--- a/ros/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
+++ b/ros/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
@@ -795,6 +795,9 @@ void AirsimROSWrapper::drone_state_timer_cb(const ros::TimerEvent& event)
                 static_tf_msg.header.stamp = ros::Time::now();
                 static_tf_pub_.sendTransform(static_tf_msg);
             }
+
+            // we've sent these static transforms, so no need to keep sending them
+            static_tf_msg_vec_.clear();
         }
 
         // todo add and expose a gimbal angular velocity to airlib


### PR DESCRIPTION
The `tf2` API in ROS creates two topics for transforms: `/tf` and `/tf_static`. The `/tf_static` topic is for transforms that do not change. Having two topics lets `/tf_static` leverage topic latching to minimize bandwidth usage.

In the AirSim ROS wrapper, the two static tfs that are created are for camera/lidar w.r.t body frame and for the odom frame (named using the vehicle name). These are all loaded from the settings. This changes stops rebroadcasting these static transforms on every state update.