### PR TITLE
ros fix: runtime_error "Duration is out of dual 32-bit range"

### DIFF
--- a/ros/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
+++ b/ros/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
@@ -1087,6 +1087,10 @@ void AirsimROSWrapper::process_and_publish_img_response(const std::vector<ImageR
 
     for (const auto& curr_img_response : img_response_vec)
     {
+        // if a render request failed for whatever reason, this img will be empty.
+        // Attempting to use a make_ts(0) results in ros::Duration runtime error.
+        if (curr_img_response.time_stamp == 0) continue;
+
         // todo publishing a tf for each capture type seems stupid. but it foolproofs us against render thread's async stuff, I hope. 
         // Ideally, we should loop over cameras and then captures, and publish only one tf.  
         publish_camera_tf(curr_img_response, curr_ros_time, vehicle_name, curr_img_response.camera_name);


### PR DESCRIPTION
Fixes #2489.

**tl;dr**
Occasionally `gameViewport == nullptr`, so `UnrealImageCapture::getSceneCaptureImage` returns early. `ImageResponse`s are therefore empty, leading to a negative time in ROS.

Not sure why `gameViewport` is sometimes `null`. My computer doesn't seem taxed. Maybe its related to resizing / moving the UE4 editor window? Unclear.

With the following code changes:

```c++
void AirsimROSWrapper::process_and_publish_img_response(const std::vector<ImageResponse>& img_response_vec, const int img_response_idx, const std::string& vehicle_name)
{    

    // ...

            std::cout << "curr_img_response time_stamp: " << curr_img_response.time_stamp 
                        << "\twidth: " << curr_img_response.width 
                        << "\tvec: " << img_response_vec.size() << std::endl;
            std::cout << "curr_img_response message: " << curr_img_response.message << std::endl;
            image_pub_vec_[img_response_idx_internal].publish(get_img_msg_from_response(curr_img_response, 
                                                    curr_ros_time, 
                                                    curr_img_response.camera_name + "_optical"));
    // ...

}

// ...

ros::Time AirsimROSWrapper::make_ts(uint64_t unreal_ts) {
    if (first_imu_unreal_ts < 0) {
        first_imu_unreal_ts = unreal_ts;
        first_imu_ros_ts = ros::Time::now();
    }
    std::cout << "make_ts(" << unreal_ts << ")..." << std::flush;
    auto r = first_imu_ros_ts + ros::Duration( (unreal_ts- first_imu_unreal_ts)/1e9); 
    std::cout << "done. " << r << std::endl;
    return r;
}
```

```c++
void UnrealImageCapture::getSceneCaptureImage(const std::vector<msr::airlib::ImageCaptureBase::ImageRequest>& requests, 
    std::vector<msr::airlib::ImageCaptureBase::ImageResponse>& responses, bool use_safe_method) const
{
    // ...

    if (nullptr == gameViewport) {
        for (unsigned int i = 0; i < requests.size(); ++i) {
            ImageResponse& response = responses.at(i);
            response.message = "early return";
        } 
        return;
    } 

    // ...

}
```

I get the following print out
```bash
get_img_msg_from_response make_ts(1585499892451160576)...done. 1585499892.809536487
get_depth_img_msg_from_response make_ts(1585499892493161472)...done. 1585499892.851537383
curr_img_response time_stamp: 1585499892634164480	width: 640	vec: 1
curr_img_response message: everything is fine
get_img_msg_from_response make_ts(1585499892634164480)...done. 1585499892.992540391
curr_img_response time_stamp: 0	width: 0	vec: 1
curr_img_response message: early return
get_img_msg_from_response make_ts(0)...terminate called after throwing an instance of 'std::runtime_error'
  what():  Duration is out of dual 32-bit range
```