### PR TITLE
Linux build improvements - clang8, no custom libcxx 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,6 @@ jobs:
 
     - name: MacOS
       os: osx
-      env:
-        - TOOL="cmake"
-        - DESCRIPTION="OS X build/test via CMake"
-        - LLVM_PACKAGE="clang+llvm-5.0.2-x86_64-apple-darwin"
-        - CIINSTALL=yes
 
 
 before_install:
@@ -34,9 +29,7 @@ before_install:
       sudo apt-get -y install git wget unzip;
       sudo apt-get -y install build-essential software-properties-common cmake rsync libboost-all-dev;
     elif [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ "$TOOL" == "cmake" ]]; then
-      wget http://releases.llvm.org/5.0.2/${LLVM_PACKAGE}.tar.xz;
-      tar -xf ${LLVM_PACKAGE}.tar.xz;
-      export LLVM_DIR=${TRAVIS_BUILD_DIR}/${LLVM_PACKAGE};
+      echo "No before_install actions for OSX";
     fi
 
 script:

--- a/build.sh
+++ b/build.sh
@@ -65,15 +65,8 @@ else
     # variable for build output
     build_dir=build_debug
     if [ "$(uname)" == "Darwin" ]; then
-
-        if [[ -n $CIINSTALL ]]; then # use downloaded binaries on Travis
-            export CC=${LLVM_DIR}/bin/clang
-            export CXX=${LLVM_DIR}/bin/clang++
-        else
-            export CC=/usr/local/opt/llvm-5.0/bin/clang-5.0
-            export CXX=/usr/local/opt/llvm-5.0/bin/clang++-5.0
-        fi
-
+        export CC=/usr/local/opt/llvm@8/bin/clang
+        export CXX=/usr/local/opt/llvm@8/bin/clang++
     else
         export CC="clang-8"
         export CXX="clang++-8"

--- a/build.sh
+++ b/build.sh
@@ -62,25 +62,6 @@ if $gccBuild; then
         export CXX="g++"
     fi
 else
-    #check for correct verion of llvm
-    if [[ ! -d "llvm-source-50" ]]; then
-        if [[ -d "llvm-source-39" ]]; then
-            echo "Hello there! We just upgraded AirSim to Unreal Engine 4.24."
-            echo "Here are few easy steps for upgrade so everything is new and shiny :)"
-            echo "https://github.com/Microsoft/AirSim/blob/master/docs/unreal_upgrade.md"
-            exit 1
-        else
-            echo "The llvm-souce-50 folder was not found! Mystery indeed."
-        fi
-    fi
-
-    # check for libc++
-    if [[ !(-d "./llvm-build/output/lib") ]]; then
-        echo "ERROR: clang++ and libc++ is necessary to compile AirSim and run it in Unreal engine"
-        echo "Please run setup.sh first."
-        exit 1
-    fi
-
     # variable for build output
     build_dir=build_debug
     if [ "$(uname)" == "Darwin" ]; then
@@ -94,8 +75,8 @@ else
         fi
 
     else
-        export CC="clang-5.0"
-        export CXX="clang++-5.0"
+        export CC="clang-8"
+        export CXX="clang++-8"
     fi
 fi
 
@@ -131,7 +112,6 @@ pushd $build_dir  >/dev/null
 make -j`nproc`
 popd >/dev/null
 
-
 mkdir -p AirLib/lib/x64/Debug
 mkdir -p AirLib/deps/rpclib/lib
 mkdir -p AirLib/deps/MavLinkCom/lib
@@ -164,6 +144,5 @@ echo ""
 echo "For help see:"
 echo "https://github.com/Microsoft/AirSim/blob/master/docs/build_linux.md"
 echo "=================================================================="
-
 
 popd >/dev/null

--- a/cmake/cmake-modules/CommonSetup.cmake
+++ b/cmake/cmake-modules/CommonSetup.cmake
@@ -36,10 +36,6 @@ macro(CommonSetup)
     SET(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/output/bin)
     SET(LIBRARY_OUTPUT_PATH ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 
-    #libcxx which we will use with specific version of clang
-    SET(LIBCXX_INC_PATH ${AIRSIM_ROOT}/llvm-build/output/include/c++/v1)
-    SET(LIBCXX_LIB_PATH ${AIRSIM_ROOT}/llvm-build/output/lib)
-
     #setup include and lib for rpclib which will be referenced by other projects
     set(RPCLIB_VERSION_FOLDER rpclib-2.2.1)
     set(RPC_LIB_INCLUDES " ${AIRSIM_ROOT}/external/rpclib/${RPCLIB_VERSION_FOLDER}/include")
@@ -58,10 +54,8 @@ macro(CommonSetup)
             set(CMAKE_CXX_STANDARD 14)
             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__CLANG__")
         else ()
-            # other flags used in Unreal: -funwind-tables  -fdiagnostics-format=msvc -fno-inline  -Werror -fno-omit-frame-pointer  -fstack-protector -O2
-            # TODO: add back -Wunused-parameter -Wno-documentation after rpclib can be compiled
             set(CMAKE_CXX_FLAGS "\
-                -std=c++14 -ggdb -Wall -Wextra -Wstrict-aliasing -Wunreachable-code -Wcast-qual -Wctor-dtor-privacy \
+                -std=c++14 -stdlib=libc++ -ggdb -Wall -Wextra -Wstrict-aliasing -Wunreachable-code -Wcast-qual -Wctor-dtor-privacy \
                 -Wdisabled-optimization -Wformat=2 -Winit-self -Wmissing-include-dirs -Wswitch-default \
                 -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wstrict-overflow=5 -Wswitch-default -Wundef \
                 -Wno-variadic-macros -Wno-parentheses -Wno-unused-function -Wno-unused -Wno-documentation -fdiagnostics-show-option \
@@ -69,25 +63,6 @@ macro(CommonSetup)
                 ${RPC_LIB_DEFINES} ${CMAKE_CXX_FLAGS}")
 
             if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
-                # make sure to match the compiler flags with which the Unreal
-                # Engine is built with
-                set(CMAKE_CXX_FLAGS "\
-                    -nostdinc++ -ferror-limit=10 -isystem ${LIBCXX_INC_PATH} \
-                    -D__CLANG__ ${CMAKE_CXX_FLAGS}")
-
-                # removed -lsupc++ from below (Git issue # 678)
-                set(CMAKE_EXE_LINKER_FLAGS "\
-                    ${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -lc++ -lc++abi -lm -lc \
-                    -L ${LIBCXX_LIB_PATH} -rpath ${LIBCXX_LIB_PATH}")
-
-                #do not use experimental as it might potentially cause ABI issues
-                #set(CXX_EXP_LIB "-lc++experimental")
-
-                if("${BUILD_TYPE}" STREQUAL "debug")
-                    # set same options that Unreal sets in debug builds
-                    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -funwind-tables -fdiagnostics-format=msvc -fno-inline -fno-omit-frame-pointer -fstack-protector")
-                endif()
-
             else()
                 set(CXX_EXP_LIB "-lstdc++fs -fmax-errors=10 -Wnoexcept -Wstrict-null-sentinel")
             endif ()

--- a/setup.sh
+++ b/setup.sh
@@ -51,17 +51,9 @@ if $gccBuild; then
 else
     # llvm tools
     if [ "$(uname)" == "Darwin" ]; then # osx
-        if [[ -n $CIINSTALL ]]; then # use downloaded binaries on Travis
-            export C_COMPILER=${LLVM_DIR}/bin/clang
-            export COMPILER=${LLVM_DIR}/bin/clang++
-        else
-            brew update
-
-            # brew install llvm@3.9
-            brew tap llvm-hs/homebrew-llvm
-            brew install llvm-8.0
-        fi
-
+        brew update
+        brew tap llvm-hs/homebrew-llvm
+        brew install llvm@8
     else #linux
         #install clang and build tools
         VERSION=$(lsb_release -rs | cut -d. -f1)
@@ -71,7 +63,7 @@ else
             wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
             sudo apt-get update
         fi
-        sudo apt-get install -y clang-8 clang++-8 libc++-8-dev libc++abi-8-dev 
+        sudo apt-get install -y clang-8 clang++-8 libc++-8-dev libc++abi-8-dev
     fi
 fi
 
@@ -119,15 +111,8 @@ if version_less_than_equal_to $cmake_ver $MIN_CMAKE_VERSION; then
         make
         popd
     fi
-
-    if [ "$(uname)" == "Darwin" ]; then
-        CMAKE="$(greadlink -f cmake_build/bin/cmake)"
-    else
-        CMAKE="$(readlink -f cmake_build/bin/cmake)"
-    fi
 else
     echo "Already have good version of cmake: $cmake_ver"
-    CMAKE=$(which cmake)
 fi
 
 # Download rpclib


### PR DESCRIPTION
- Tested with UE4.24, Ubuntu 18 (might have to enforce 4.24, right now we support >=4.22)
  - or add option for clang-7 for UE 4.22
- install `clang-, libc++-8-dev, libc++abi-8-dev` in `setup.sh`
- remove all the clang5.0 and custom libcxx download and building
- in commonsetup.cmake, throwing in a `-stdlib=libc++` and removing all the unreal specific flags seems to the job

