### PR TITLE
UE 4.24 automatically change the config

### DIFF
--- a/Unreal/Environments/Blocks/Config/DefaultEngine.ini
+++ b/Unreal/Environments/Blocks/Config/DefaultEngine.ini
@@ -12,7 +12,7 @@ GlobalDefaultGameMode=/Script/Blocks.BlocksGameMode
 GlobalDefaultServerGameMode=None
 
 [/Script/IOSRuntimeSettings.IOSRuntimeSettings]
-MinimumiOSVersion=IOS_8
+MinimumiOSVersion=IOS_11
 
 
 [/Script/Engine.Engine]


### PR DESCRIPTION
The `MinimumiOSVersion` is IOS_11 for UE 4.24 (see [UE doc](https://docs.unrealengine.com/en-US/Platforms/Mobile/iOS/DeviceCompatibility/index.html) and [UE release note](https://docs.unrealengine.com/en-US/Support/Builds/ReleaseNotes/4_23/index.html)). This config was changed when building the unreal project.
