### PR TITLE
Upgrade Windows Unity project to VS 2019

### DIFF
--- a/Unity/AirLibWrapper/AirsimWrapper/AirsimWrapper.vcxproj
+++ b/Unity/AirLibWrapper/AirsimWrapper/AirsimWrapper.vcxproj
@@ -28,31 +28,32 @@
     <ProjectGuid>{B3142B89-A825-4A07-84D3-45C65CF0D7B0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>AirsimWrapper</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -94,6 +95,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;AIRSIMWRAPPER_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\..\AirLib\include\vehicles\car;$(ProjectDir)..\..\..\AirLib\include;$(ProjectDir)..\..\..\AirLib\deps\eigen3;$(ProjectDir)..\..\..\external\rpclib\rpclib-2.2.1\include;$(ProjectDir)..\..\..\MavLinkCom\include;$(ProjectDir)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -116,6 +118,7 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\..\AirLib\include\vehicles\car;$(ProjectDir)..\..\..\AirLib\include;$(ProjectDir)..\..\..\AirLib\deps\eigen3;$(ProjectDir)..\..\..\external\rpclib\rpclib-2.2.1\include;$(ProjectDir)..\..\..\MavLinkCom\include;$(ProjectDir)include;%(AdditionalIncludeDirectories);</AdditionalIncludeDirectories>
       <SuppressStartupBanner>false</SuppressStartupBanner>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -143,6 +146,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;AIRSIMWRAPPER_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\..\AirLib\include\vehicles\car;$(ProjectDir)..\..\..\AirLib\include;$(ProjectDir)..\..\..\AirLib\deps\eigen3;$(ProjectDir)..\..\..\external\rpclib\rpclib-2.2.1\include;$(ProjectDir)..\..\..\MavLinkCom\include;$(ProjectDir)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -169,6 +173,7 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\..\AirLib\include\vehicles\car;$(ProjectDir)..\..\..\AirLib\include;$(ProjectDir)..\..\..\AirLib\deps\eigen3;$(ProjectDir)..\..\..\external\rpclib\rpclib-2.2.1\include;$(ProjectDir)..\..\..\MavLinkCom\include;$(ProjectDir)include;%(AdditionalIncludeDirectories);</AdditionalIncludeDirectories>
       <SuppressStartupBanner>false</SuppressStartupBanner>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/Unity/AirLibWrapper/AirsimWrapper/AirsimWrapper.vcxproj
+++ b/Unity/AirLibWrapper/AirsimWrapper/AirsimWrapper.vcxproj
@@ -28,7 +28,6 @@
     <ProjectGuid>{B3142B89-A825-4A07-84D3-45C65CF0D7B0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>AirsimWrapper</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
Retarget Unity's AirsimWrapper.vcxproj to VS 2019 and C++17