### PR TITLE
Fix bug: rotateToYaw not working

### DIFF
--- a/AirLib/include/vehicles/multirotor/api/MultirotorApiBase.hpp
+++ b/AirLib/include/vehicles/multirotor/api/MultirotorApiBase.hpp
@@ -339,6 +339,7 @@ private: //variables
     //TODO: make this configurable?
     float landing_vel_ = 0.2f; //velocity to use for landing
     float approx_zero_vel_ = 0.05f;
+    float approx_zero_angular_vel_ = 0.01f;
 };
 
 }} //namespace

--- a/AirLib/src/vehicles/multirotor/api/MultirotorApiBase.cpp
+++ b/AirLib/src/vehicles/multirotor/api/MultirotorApiBase.cpp
@@ -476,12 +476,11 @@ bool MultirotorApiBase::rotateByYawRate(float yaw_rate, float duration)
 
     auto start_pos = getPosition();
     YawMode yaw_mode(true, yaw_rate);
-    Waiter waiter(getCommandPeriod(), duration, getCancelToken());
-    do {
+    
+    return waitForFunction([&]() {
         moveToPositionInternal(start_pos, yaw_mode);
-    } while (waiter.sleep());
-
-    return waiter.isTimeout();
+        return false; //keep moving until timeout
+    }, duration).isTimeout();
 }
 
 void MultirotorApiBase::setAngleLevelControllerGains(const vector<float>& kp, const vector<float>& ki, const vector<float>& kd) 


### PR DESCRIPTION
Fix #1682, #856

Changes to fix `rotateToYaw`:
- `isYawWithinMargin` should receive the target yaw degree as the first argument
- The original stop criterion does not stop rotation due to inertia, so the resulted yaw is not guaranteed.

By the way, the `rotateByYawRate` implementation were made consistent with other API.