### PR TITLE
Specify C++17 standard on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_install:
 script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       ./setup.sh;
-      ./build.sh;
+      ./build.sh || travis_terminate 1;
       echo "Starting Unity Build!";
       cd Unity && ./build.sh 2> Unity_error.txt || ((cat Unity_error.txt | grep -i "error:" -B 10 -A 10) && exit 1);
     elif [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
@@ -49,7 +49,7 @@ script:
       cd Unity '&&' build.cmd;
     elif  [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       ./setup.sh;
-      ./build.sh;
+      ./build.sh || travis_terminate 1;
       echo "Starting Unity Build!";
       cd Unity && ./build.sh 2> Unity_error.txt || ((cat Unity_error.txt | grep -i "error:" -B 10 -A 10) && exit 1);
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ jobs:
 
     - name: MacOS
       os: osx
+      osx_image: xcode11.3
 
 
 before_install:

--- a/cmake/cmake-modules/CommonSetup.cmake
+++ b/cmake/cmake-modules/CommonSetup.cmake
@@ -48,10 +48,9 @@ macro(CommonSetup)
     IF(UNIX)
         set(RPC_LIB_DEFINES "-D MSGPACK_PP_VARIADICS_MSVC=0")
         set(BUILD_TYPE "linux")
-
-        if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
+        if (APPLE)
             set(CMAKE_CXX_STANDARD 17)
-            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__CLANG__")
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wstrict-aliasing -D__CLANG__")
         else ()
             set(CMAKE_CXX_FLAGS "\
                 -std=c++17 -stdlib=libc++ -ggdb -Wall -Wextra -Wstrict-aliasing -Wunreachable-code -Wcast-qual -Wctor-dtor-privacy \

--- a/cmake/cmake-modules/CommonSetup.cmake
+++ b/cmake/cmake-modules/CommonSetup.cmake
@@ -50,8 +50,7 @@ macro(CommonSetup)
         set(BUILD_TYPE "linux")
 
         if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
-            #TODO: need to check why below is needed
-            set(CMAKE_CXX_STANDARD 14)
+            set(CMAKE_CXX_STANDARD 17)
             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__CLANG__")
         else ()
             set(CMAKE_CXX_FLAGS "\


### PR DESCRIPTION
master fails to build on my machine (I'm on 10.15.4 with XCode 11.4) with complaints about std::filesystem, although Travis seems fine?

This PR contains the fix I had to use. 