### PR TITLE
Bug fixes in drag face coordinates; computation of rotor torque from pwm

### DIFF
--- a/AirLib/include/vehicles/multirotor/MultiRotorPhysicsBody.hpp
+++ b/AirLib/include/vehicles/multirotor/MultiRotorPhysicsBody.hpp
@@ -192,12 +192,12 @@ private: //methods
 
         //add six drag vertices representing 6 sides
         drag_faces_.clear();
-        drag_faces_.emplace_back(Vector3r(0, 0, -params.body_box.z()), Vector3r(0, 0, -1), drag_factor_unit.z());
-        drag_faces_.emplace_back(Vector3r(0, 0,  params.body_box.z()), Vector3r(0, 0,  1), drag_factor_unit.z());
-        drag_faces_.emplace_back(Vector3r(0, -params.body_box.y(), 0), Vector3r(0, -1, 0), drag_factor_unit.y());
-        drag_faces_.emplace_back(Vector3r(0,  params.body_box.y(), 0), Vector3r(0,  1, 0), drag_factor_unit.y());
-        drag_faces_.emplace_back(Vector3r(-params.body_box.x(), 0, 0), Vector3r(-1, 0, 0), drag_factor_unit.x());
-        drag_faces_.emplace_back(Vector3r( params.body_box.x(), 0, 0), Vector3r( 1, 0, 0), drag_factor_unit.x());
+        drag_faces_.emplace_back(Vector3r(0, 0, -params.body_box.z() / 2.0f), Vector3r(0, 0, -1), drag_factor_unit.z());
+        drag_faces_.emplace_back(Vector3r(0, 0,  params.body_box.z() / 2.0f), Vector3r(0, 0,  1), drag_factor_unit.z());
+        drag_faces_.emplace_back(Vector3r(0, -params.body_box.y() / 2.0f, 0), Vector3r(0, -1, 0), drag_factor_unit.y());
+        drag_faces_.emplace_back(Vector3r(0,  params.body_box.y() / 2.0f, 0), Vector3r(0,  1, 0), drag_factor_unit.y());
+        drag_faces_.emplace_back(Vector3r(-params.body_box.x() / 2.0f, 0, 0), Vector3r(-1, 0, 0), drag_factor_unit.x());
+        drag_faces_.emplace_back(Vector3r( params.body_box.x() / 2.0f, 0, 0), Vector3r( 1, 0, 0), drag_factor_unit.x());
 
     }
 

--- a/AirLib/include/vehicles/multirotor/RotorActuator.hpp
+++ b/AirLib/include/vehicles/multirotor/RotorActuator.hpp
@@ -122,7 +122,7 @@ private: //methods
         //see relationship of rotation speed with thrust: http://physics.stackexchange.com/a/32013/14061
         output.speed = sqrt(output.control_signal_filtered * params.max_speed_square);
         output.thrust = output.control_signal_filtered * params.max_thrust;
-        output.torque_scaler = output.control_signal_input * params.max_torque * static_cast<int>(turning_direction);
+        output.torque_scaler = output.control_signal_filtered * params.max_torque * static_cast<int>(turning_direction);
         output.turning_direction = turning_direction;
     }
 


### PR DESCRIPTION
- AirSim models the quadrotor physics body as a center cuboid surrounded by four cylinders at the end of each arm, representing a propeller. 
At the centroid of each face of the cuboid, a "drag face" (misleading called "drag vertices" in the code (IMO)) is initialized. In the code, the cuboid is defined by its dimensions as `Vector3r MultirotorParams::Params::body_box`. 
The first commit changes the "position" corresponding to each drag face (aka drag vertex) to be at the center of each rectangular face. If the centroid of the cuboid is defined as the origin of quadrotor's body frame, and the dimensions of the cuboid are given as `body_box.x, body_box.y, body_box.z`, then, the coordinates of the centroid of each face should be - `+/-body_box.x / 2, 0, 0`, `0,body_box.y / 2, 0`, `0,0, +/- body_box.z / 2` ( and **not** `+/-body_box.x, 0, 0`, `0,body_box.y, 0`, `0,0, +/- body_box.z `) 

- The second commit is concerned with the function [`Rotor::setOutput`](https://github.com/microsoft/AirSim/blob/master/AirLib/include/vehicles/multirotor/Rotor.hpp#L118):

The current master's impl is:
```cpp
    static void setOutput(Output& output, const RotorParams& params, const FirstOrderFilter<real_T>& control_signal_filter, RotorTurningDirection turning_direction)
    {
        output.control_signal_input = control_signal_filter.getInput();
        output.control_signal_filtered = control_signal_filter.getOutput();
        //see relationship of rotation speed with thrust: http://physics.stackexchange.com/a/32013/14061
        output.speed = sqrt(output.control_signal_filtered * params.max_speed_square);
        output.thrust = output.control_signal_filtered * params.max_thrust;
        output.torque_scaler = output.control_signal_input * params.max_torque * static_cast<int>(turning_direction);
        output.turning_direction = turning_direction;
    }
```

While `output.thrust` is proportional to `output.control_signal_filtered`, I don't understand why is `output.torque_scaler` proportional to `output.control_signal_input`. 
The second commit changes it to control_signal_filtered. 
