### PR TITLE
[compiler_warning_fix] format not a string literal

### DIFF
--- a/AirLib/include/common/common_utils/Utils.hpp
+++ b/AirLib/include/common/common_utils/Utils.hpp
@@ -56,6 +56,7 @@
 */
 
 #ifndef _MSC_VER
+__attribute__((__format__ (__printf__, 1, 0)))
 static int _vscprintf(const char * format, va_list pargs)
 {
     int retval;
@@ -235,20 +236,9 @@ public:
         return str.substr(i, len - i);
     }
 
-    static string formatNumber(double number, int digits_after_decimal = -1, int digits_before_decimal = -1, bool sign_always = false)
-    {
-        std::string format_string = "%";
-        if (sign_always)
-            format_string += "+";
-        if (digits_before_decimal >= 0)
-            format_string += "0" + std::to_string(digits_before_decimal + std::max(digits_after_decimal, 0) + 1);
-        if (digits_after_decimal >= 0)
-            format_string += "." + std::to_string(digits_after_decimal);
-        format_string += "f";
-
-        return stringf(format_string.c_str(), number);
-    }
-
+    #ifndef _MSC_VER
+    __attribute__((__format__ (__printf__, 1, 0)))
+    #endif
     static string stringf(const char* format, ...)
     {
         va_list args;

--- a/MavLinkCom/MavLinkTest/UnitTests.cpp
+++ b/MavLinkCom/MavLinkTest/UnitTests.cpp
@@ -287,7 +287,7 @@ void UnitTests::FtpTest() {
         const char* TestPattern = "This is line %d\n";
 
         for (int i = 0; i < 100; i++) {
-            std::string line = Utils::stringf(TestPattern, i);
+            std::string line = Utils::stringf("%s %i", TestPattern, i);
             stream << line;
         }
 
@@ -331,7 +331,7 @@ void UnitTests::FtpTest() {
         std::getline(istream, line);
         while (line.size() > 0) {
             line += '\n';
-            std::string expected = Utils::stringf(TestPattern, count);
+            std::string expected = Utils::stringf("%s %i", TestPattern, count);
             if (line != expected)
             {
                 throw std::runtime_error(Utils::stringf("ftp local file contains unexpected contents '%s' on line %d\n", line.c_str(), count));

--- a/MavLinkCom/MavLinkTest/main.cpp
+++ b/MavLinkCom/MavLinkTest/main.cpp
@@ -75,6 +75,7 @@ void DebugOutput(const char* message, ...) {
 }
 #else 
 // how do you write to the debug output windows on Unix ?
+ __attribute__((__format__ (__printf__, 1, 0))) 
 void DebugOutput(const char* message, ...) {
     va_list args;
     va_start(args, message);

--- a/MavLinkCom/common_utils/Utils.hpp
+++ b/MavLinkCom/common_utils/Utils.hpp
@@ -65,6 +65,7 @@ using std::experimental::optional;
 */
 
 #ifndef _MSC_VER
+__attribute__((__format__ (__printf__, 1, 0)))
 static int _vscprintf(const char * format, va_list pargs)
 {
     int retval;
@@ -214,20 +215,9 @@ public:
         return str.substr(i, len - i);
     }
 
-    static string formatNumber(double number, int digits_after_decimal = -1, int digits_before_decimal = -1, bool sign_always = false)
-    {
-        std::string format_string = "%";
-        if (sign_always)
-            format_string += "+";
-        if (digits_before_decimal >= 0)
-            format_string += "0" + std::to_string(digits_before_decimal + std::max(digits_after_decimal, 0) + 1);
-        if (digits_after_decimal >= 0)
-            format_string += "." + std::to_string(digits_after_decimal);
-        format_string += "f";
-
-        return stringf(format_string.c_str(), number);
-    }
-
+    #ifndef _MSC_VER
+    __attribute__((__format__ (__printf__, 1, 0)))
+    #endif
     static string stringf(const char* format, ...)
     {
         va_list args;


### PR DESCRIPTION
hopefully doesn't break windows build
fix is based on https://stackoverflow.com/a/36120843, and me realizing `formatNumber` is not called in the code anywhere
ubuntu 18, clang8, ue 4.24