### PR TITLE
[Travis] Allow OSX build to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,10 @@ language: cpp
 
 jobs:
   allow_failures:
-    - env: ALLOW_FAILURES=true
+    # TODO: Remove this when OSX 10.15 is available in Travis
+    - name: MacOS
+      os: osx
+      osx_image: xcode11.3
 
   include:
     - name: Ubuntu 18.04


### PR DESCRIPTION
AirSim requires OSX 10.15, which is not present on Travis

Needed after https://github.com/microsoft/AirSim/pull/2520