### PR TITLE
MavLinkMultirotorApi: correctly set the HIL_SENSOR fields_updated field

### DIFF
--- a/AirLib/include/vehicles/multirotor/firmwares/mavlink/MavLinkMultirotorApi.hpp
+++ b/AirLib/include/vehicles/multirotor/firmwares/mavlink/MavLinkMultirotorApi.hpp
@@ -1333,14 +1333,21 @@ private: //methods
         hil_sensor.ygyro = gyro.y();
         hil_sensor.zgyro = gyro.z();
 
+        hil_sensor.fields_updated = 0b111 | 0b111000; // Set accel and gyro bit fields respectively
+
         hil_sensor.xmag = mag.x();
         hil_sensor.ymag = mag.y();
         hil_sensor.zmag = mag.z();
 
+        hil_sensor.fields_updated = hil_sensor.fields_updated | 0b111000000; // Set mag bit field
+
         hil_sensor.abs_pressure = abs_pressure;
         hil_sensor.pressure_alt = pressure_alt;
+
+        hil_sensor.fields_updated = hil_sensor.fields_updated | 0b1101000000000; // Set baro bit field
+
         //TODO: enable temperature? diff_pressure
-        hil_sensor.fields_updated = was_reset_ ? (1 << 31) : 0;
+        hil_sensor.fields_updated = was_reset_ ? (1 << 31) : hil_sensor.fields_updated;
 
         if (hil_node_ != nullptr) {
             hil_node_->sendMessage(hil_sensor);


### PR DESCRIPTION
Fixes the reported in https://github.com/microsoft/AirSim/issues/2477#issuecomment-610800925.

The interface with the PX4 [*simulator* module](https://github.com/PX4/Firmware/blob/master/src/modules/simulator/simulator_mavlink.cpp#L196-L229) was changed to allow that different sensor sources get processed at different rates, which what you expect from a real system. In this case, since the sensor sources are not being sent at different rates, I basically just set the `fields_updated` bitmask correctly so it can be interpreted in the simulator module and the sensor data can be parsed.

FYI @bys1123, @Jaeyoung-Lim, @LorenzMeier.