### PR TITLE
[px4] bug-fix: MavLinkMultirotorApi::sendHILSensor()

### DIFF
--- a/AirLib/include/vehicles/multirotor/firmwares/mavlink/MavLinkMultirotorApi.hpp
+++ b/AirLib/include/vehicles/multirotor/firmwares/mavlink/MavLinkMultirotorApi.hpp
@@ -1315,6 +1315,7 @@ private: //methods
             }
 
             if (!received_actuator_controls_) {
+                last_hil_sensor_time_ = now;
                 // drop this one since we are in LOCKSTEP mode and we have not yet received the HilActuatorControlsMessage.
                 return;
             }


### PR DESCRIPTION
See these comments for reported error https://github.com/microsoft/AirSim/issues/2477#issuecomment-611277899, https://github.com/microsoft/AirSim/issues/2477#issuecomment-611410314, https://github.com/microsoft/AirSim/pull/2549#issuecomment-611387300

See this comment https://github.com/microsoft/AirSim/issues/2477#issuecomment-611537909 for details on bug

PR updates  update `last_hil_sensor_time_` in the case no actuator control is received, so future messages are not affected