### PR TITLE
Fix ROS build 

### DIFF
--- a/cmake/cmake-modules/CommonSetup.cmake
+++ b/cmake/cmake-modules/CommonSetup.cmake
@@ -53,14 +53,15 @@ macro(CommonSetup)
             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wstrict-aliasing -D__CLANG__")
         else ()
             set(CMAKE_CXX_FLAGS "\
-                -std=c++17 -stdlib=libc++ -ggdb -Wall -Wextra -Wstrict-aliasing -Wunreachable-code -Wcast-qual -Wctor-dtor-privacy \
+                -std=c++17 -ggdb -Wall -Wextra -Wstrict-aliasing -Wunreachable-code -Wcast-qual -Wctor-dtor-privacy \
                 -Wdisabled-optimization -Wformat=2 -Winit-self -Wmissing-include-dirs -Wswitch-default \
                 -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wstrict-overflow=5 -Wswitch-default -Wundef \
-                -Wno-variadic-macros -Wno-parentheses -Wno-unused-function -Wno-unused -Wno-documentation -fdiagnostics-show-option \
+                -Wno-variadic-macros -Wno-parentheses -Wno-unused-function -Wno-unused -fdiagnostics-show-option \
                 -pthread \
                 ${RPC_LIB_DEFINES} ${CMAKE_CXX_FLAGS}")
 
             if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+                set(CMAKE_CXX_FLAGS "-stdlib=libc++ -Wno-documentation ${CMAKE_CXX_FLAGS}")
                 set(CXX_EXP_LIB "-lc++fs -ferror-limit=10")
             else()
                 set(CXX_EXP_LIB "-lstdc++fs -fmax-errors=10 -Wnoexcept -Wstrict-null-sentinel")

--- a/docs/airsim_ros_pkgs.md
+++ b/docs/airsim_ros_pkgs.md
@@ -3,6 +3,10 @@
 A ROS wrapper over the AirSim C++ client library. 
 
 ##  Setup 
+- Install gcc >= 8.0.0
+`sudo apt-get install gcc-8 g++-8`
+Verify version by `gcc --version`
+
 - Ubuntu 16.04
   * Install [ROS kinetic](https://wiki.ros.org/kinetic/Installation/Ubuntu)
 

--- a/ros/src/airsim_ros_pkgs/CMakeLists.txt
+++ b/ros/src/airsim_ros_pkgs/CMakeLists.txt
@@ -8,7 +8,12 @@ add_subdirectory("${AIRSIM_ROOT}/cmake/rpclib_wrapper" rpclib_wrapper)
 add_subdirectory("${AIRSIM_ROOT}/cmake/AirLib" AirLib)
 add_subdirectory("${AIRSIM_ROOT}/cmake/MavLinkCom" MavLinkCom)
 
-set(CMAKE_CXX_STANDARD 11) 
+set(CMAKE_CXX_STANDARD 11)
+set(CXX_EXP_LIB "-nostdinc++ -I/usr/include/c++/8 -I/usr/include/x86_64-linux-gnu/c++/8 -nodefaultlibs 
+-l/usr/lib/x86_64-linux-gnu/libc++.so -l/usr/lib/x86_64-linux-gnu/libc++abi.so
+-lm -lc -lgcc_s -lgcc  
+-lstdc++fs -fmax-errors=10 -Wnoexcept -Wstrict-null-sentinel") 
+
 set(RPC_LIB_INCLUDES " ${AIRSIM_ROOT}/external/rpclib/rpclib-2.2.1/include")
 set(RPC_LIB rpc) # name of .a file with lib prefix
 message(STATUS "found RPC_LIB_INCLUDES=${RPC_LIB_INCLUDES}")

--- a/ros/src/airsim_ros_pkgs/launch/airsim_node.launch
+++ b/ros/src/airsim_ros_pkgs/launch/airsim_node.launch
@@ -1,15 +1,12 @@
 <launch>
 	<arg name="host" default="localhost" />
 	<node name="airsim_node" pkg="airsim_ros_pkgs" type="airsim_node" output="screen">
-	<!-- <node pkg="nodelet" type="nodelet" name="airsim_nodelet_manager" args="manager" output="screen" /> -->
-	<!-- <node pkg="nodelet" type="nodelet" name="airsim_nodelet" args="standalone airsim_ros_pkgs/airsim_ros_nodelet airsim_nodelet_manager" output="screen"> -->
-
 		<!-- ROS timer rates. Note that timer callback will be processed at maximum possible rate, upperbounded by the following ROS params -->
 		<param name="is_vulkan" type="bool" value="false" /> 
 		<param name="update_airsim_img_response_every_n_sec" type="double" value="0.05" /> 
 		<param name="update_airsim_control_every_n_sec" type="double" value="0.001" />
 		<param name="update_lidar_every_n_sec" type="double" value="0.01" />
-		<param name="host_ip" type="string" value="$(arg host)"
+		<param name="host_ip" type="string" value="$(arg host)" />
 	</node>
 
 	<!-- Static transforms -->

--- a/ros/src/airsim_tutorial_pkgs/CMakeLists.txt
+++ b/ros/src/airsim_tutorial_pkgs/CMakeLists.txt
@@ -18,7 +18,6 @@ find_package(catkin REQUIRED COMPONENTS
   tf2_ros
 )
 
-
 catkin_package(
   INCLUDE_DIRS
   CATKIN_DEPENDS message_runtime roscpp std_msgs airsim_ros_pkgs  


### PR DESCRIPTION
 add libc++ with gcc in ros/cmakelists, move clang only flags in if-else clause in commonsetup.cmake

As highlighted in #2551, #2569, the ROS build is breaking. 
This happened coz of https://github.com/microsoft/AirSim/pull/2500
The fix is to use libc++ with gcc, as explained here - https://libcxx.llvm.org/docs/UsingLibcxx.html#using-libc-with-gcc. 