### PR TITLE
Update RotorParams.hpp

### DIFF
--- a/AirLib/include/vehicles/multirotor/RotorParams.hpp
+++ b/AirLib/include/vehicles/multirotor/RotorParams.hpp
@@ -23,7 +23,7 @@ namespace msr {
             torque in N.m = C_P * \rho * n^2 * D^5 / (2*pi)
             where,
             \rho = air density (1.225 kg/m^3)
-            n = radians per sec
+            n = revolutions per sec
             D = propeller diameter in meters
             C_T, C_P = dimensionless constants available at
             propeller performance database http://m-selig.ae.illinois.edu/props/propDB.html


### PR DESCRIPTION
The unit of n should be rev/s, but it is written  as rad/s in the comment.
The  code is correct using rpm/60 to get  n.
So update the comment.