### PR TITLE
Fix Lidar DrawDebugPoints causing crash

### DIFF
--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
@@ -671,10 +671,10 @@ void ASimModeBase::drawLidarDebugPoints()
                         DrawDebugPoint(
                             this->GetWorld(),
                             uu_point,
-                            5,              //size
+                            5,              // size
                             FColor::Green,
-                            true,           //persistent (never goes away)
-                            0.1             //point leaves a trail on moving object
+                            false,          // persistent (never goes away)
+                            0.03            // LifeTime: point leaves a trail on moving object
                         );
                     }
                 }


### PR DESCRIPTION
Make the points non-persistent and reduce Lifetime

Issue: #2608
FYI @IamPete1 @nightduck

Also see https://www.ue4community.wiki/Legacy/Draw_3D_Debug_Points,_Lines,_and_Spheres:_Visualize_Your_Algorithm_in_Action

For someone trying to reproduce-
```
{
    "SeeDocsAt": "https://github.com/Microsoft/AirSim/blob/master/docs/settings_json.md",
    "SettingsVersion": 1.2,
    "SimMode": "Multirotor",
     "Vehicles": {
        "Drone1": {
            "VehicleType": "simpleflight",
            "AutoCreate": true,
            "Sensors": {
                "LidarSensor1": { 
                    "SensorType": 6,
                    "Enabled" : true,
                    "NumberOfChannels": 16,
                    "RotationsPerSecond": 10,
                    "PointsPerSecond": 100000,
                    "X": 0, "Y": 0, "Z": -1,
                    "Roll": 0, "Pitch": 0, "Yaw" : 0,
                    "VerticalFOVUpper": -15,
                    "VerticalFOVLower": -25,
                    "HorizontalFOVStart": -20,
                    "HorizontalFOVEnd": 20,
                    "DrawDebugPoints": true,
                    "DataFrame": "SensorLocalFrame"
                }
            }
        }
    }
}
```
FPS will drop to below 10, and the RAM usage will keep increasing, by about a GB in some 10-15 seconds

As to how it worked earlier, maybe the Persistency parameter was not working?

https://forums.unrealengine.com/development-discussion/c-gameplay-programming/1539369-drawdebughelpers-h-outdated-persistent-lines-not-working