### PR TITLE
Upgrade setCameraOrientation to setCameraPose

### DIFF
--- a/AirLib/include/api/RpcLibClientBase.hpp
+++ b/AirLib/include/api/RpcLibClientBase.hpp
@@ -98,7 +98,7 @@ public:
     CollisionInfo simGetCollisionInfo(const std::string& vehicle_name = "") const;
 
     CameraInfo simGetCameraInfo(const std::string& camera_name, const std::string& vehicle_name = "") const;
-    void simSetCameraOrientation(const std::string& camera_name, const Quaternionr& orientation, const std::string& vehicle_name = "");
+    void simSetCameraPose(const std::string& camera_name, const Pose& pose, const std::string& vehicle_name = "");
     void simSetCameraFov(const std::string& camera_name, float fov_degrees, const std::string& vehicle_name = "");
 
     msr::airlib::Kinematics::State simGetGroundTruthKinematics(const std::string& vehicle_name = "") const;

--- a/AirLib/include/api/VehicleSimApiBase.hpp
+++ b/AirLib/include/api/VehicleSimApiBase.hpp
@@ -54,7 +54,7 @@ public:
     virtual const msr::airlib::Environment* getGroundTruthEnvironment() const = 0;
 
     virtual CameraInfo getCameraInfo(const std::string& camera_name) const = 0;
-    virtual void setCameraOrientation(const std::string& camera_name, const Quaternionr& orientation) = 0;
+    virtual void setCameraPose(const std::string& camera_name, const Pose& orientation) = 0;
     virtual void setCameraFoV(const std::string& camera_name, float fov_degrees) = 0;
 
     virtual CollisionInfo getCollisionInfo() const = 0;

--- a/AirLib/include/api/VehicleSimApiBase.hpp
+++ b/AirLib/include/api/VehicleSimApiBase.hpp
@@ -54,7 +54,7 @@ public:
     virtual const msr::airlib::Environment* getGroundTruthEnvironment() const = 0;
 
     virtual CameraInfo getCameraInfo(const std::string& camera_name) const = 0;
-    virtual void setCameraPose(const std::string& camera_name, const Pose& orientation) = 0;
+    virtual void setCameraPose(const std::string& camera_name, const Pose& pose) = 0;
     virtual void setCameraFoV(const std::string& camera_name, float fov_degrees) = 0;
 
     virtual CollisionInfo getCollisionInfo() const = 0;

--- a/AirLib/src/api/RpcLibClientBase.cpp
+++ b/AirLib/src/api/RpcLibClientBase.cpp
@@ -364,9 +364,9 @@ CameraInfo RpcLibClientBase::simGetCameraInfo(const std::string& camera_name, co
 {
     return pimpl_->client.call("simGetCameraInfo", camera_name, vehicle_name).as<RpcLibAdapatorsBase::CameraInfo>().to();
 }
-void RpcLibClientBase::simSetCameraOrientation(const std::string& camera_name, const Quaternionr& orientation, const std::string& vehicle_name)
+void RpcLibClientBase::simSetCameraPose(const std::string& camera_name, const Pose& pose, const std::string& vehicle_name)
 {
-    pimpl_->client.call("simSetCameraOrientation", camera_name, RpcLibAdapatorsBase::Quaternionr(orientation), vehicle_name);
+    pimpl_->client.call("simSetCameraPose", camera_name, RpcLibAdapatorsBase::Pose(pose), vehicle_name);
 }
 void RpcLibClientBase::simSetCameraFov(const std::string& camera_name, float fov_degrees, const std::string& vehicle_name)
 {

--- a/AirLib/src/api/RpcLibServerBase.cpp
+++ b/AirLib/src/api/RpcLibServerBase.cpp
@@ -228,9 +228,9 @@ RpcLibServerBase::RpcLibServerBase(ApiProvider* api_provider, const std::string&
         return RpcLibAdapatorsBase::CameraInfo(camera_info);
     });
 
-    pimpl_->server.bind("simSetCameraOrientation", [&](const std::string& camera_name, const RpcLibAdapatorsBase::Quaternionr& orientation, 
+    pimpl_->server.bind("simSetCameraPose", [&](const std::string& camera_name, const RpcLibAdapatorsBase::Pose& pose, 
         const std::string& vehicle_name) -> void {
-        getVehicleSimApi(vehicle_name)->setCameraOrientation(camera_name, orientation.to());
+        getVehicleSimApi(vehicle_name)->setCameraPose(camera_name, pose.to());
     });
 
     pimpl_->server.bind("simSetCameraFov", [&](const std::string& camera_name, float fov_degrees,

--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -155,17 +155,17 @@ class VehicleClient:
         # TODO: below str() conversion is only needed for legacy reason and should be removed in future
         return CameraInfo.from_msgpack(self.client.call('simGetCameraInfo', str(camera_name), vehicle_name))
 
-    def simSetCameraOrientation(self, camera_name, orientation, vehicle_name = ''):
+    def simSetCameraPose(self, camera_name, pose, vehicle_name = ''):
         """
-        - Control the orientation of a selected camera
+        - Control the pose of a selected camera
 
         Args:
             camera_name (str): Name of the camera to be controlled
-            orientation (airsim.Quaternion()): Quaternion representing the desired orientation of the camera
+            orientation (airsim.Pose()): Pose representing the desired position and orientation of the camera
             vehicle_name (str, optional): Name of vehicle which the camera corresponds to
         """
         # TODO: below str() conversion is only needed for legacy reason and should be removed in future
-        self.client.call('simSetCameraOrientation', str(camera_name), orientation, vehicle_name)
+        self.client.call('simSetCameraPose', str(camera_name), pose, vehicle_name)
         
     def simSetCameraFov(self, camera_name, fov_degrees, vehicle_name = ''):
         """

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/PInvokeWrapper.cpp
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/PInvokeWrapper.cpp
@@ -11,7 +11,7 @@ bool(*SetEnableApi)(bool enableApi, const char* vehicleName);
 bool(*SetCarApiControls)(msr::airlib::CarApiBase::CarControls controls, const char* vehicleName);
 AirSimCarState(*GetCarState)(const char* vehicleName);
 AirSimCameraInfo(*GetCameraInfo)(const char* cameraName, const char* vehicleName);
-bool(*SetCameraOrientation)(const char* cameraName, AirSimQuaternion orientation, const char* vehicleName);
+bool(*SetCameraPose)(const char* cameraName, AirSimPose pose, const char* vehicleName);
 bool(*SetCameraFoV)(const char* cameraName, const float fov_degrees, const char* vehicleName);
 bool(*SetSegmentationObjectId)(const char* meshName, int objectId, bool isNameRegex);
 int(*GetSegmentationObjectId)(const char* meshName);
@@ -33,7 +33,7 @@ void InitVehicleManager(
 	bool(*setCarApiControls)(msr::airlib::CarApiBase::CarControls controls, const char* vehicleName),
 	AirSimCarState(*getCarState)(const char* vehicleName),
 	AirSimCameraInfo(*getCameraInfo)(const char* cameraName, const char* vehicleName),
-	bool(*setCameraOrientation)(const char* cameraName, AirSimQuaternion orientation, const char* vehicleName),
+	bool(*setCameraPose)(const char* cameraName, AirSimPose pose, const char* vehicleName),
 	bool(*setCameraFoV)(const char* cameraName, const float fov_degrees, const char* vehicleName),
 	bool(*setSegmentationObjectId)(const char* meshName, int objectId, bool isNameRegex),
 	int(*getSegmentationObjectId)(const char* meshName),
@@ -55,7 +55,7 @@ void InitVehicleManager(
 	SetCarApiControls = setCarApiControls;
 	GetCarState = getCarState;
 	GetCameraInfo = getCameraInfo;
-	SetCameraOrientation = setCameraOrientation;
+	SetCameraPose = setCameraPose;
 	SetCameraFoV = setCameraFoV;
 	SetSegmentationObjectId = setSegmentationObjectId;
 	GetSegmentationObjectId = getSegmentationObjectId;

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/PInvokeWrapper.h
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/PInvokeWrapper.h
@@ -25,7 +25,7 @@ extern bool(*SetEnableApi)(bool enableApi, const char* vehicleName);
 extern bool(*SetCarApiControls)(msr::airlib::CarApiBase::CarControls controls, const char* vehicleName);
 extern AirSimCarState(*GetCarState)(const char* vehicleName);
 extern AirSimCameraInfo(*GetCameraInfo)(const char* cameraName, const char* vehicleName);
-extern bool(*SetCameraOrientation)(const char* cameraName, AirSimQuaternion orientation, const char* vehicleName);
+extern bool(*SetCameraPose)(const char* cameraName, AirSimPose pose, const char* vehicleName);
 extern bool(*SetCameraFoV)(const char* cameraName, const float fov_degrees, const char* vehicleName);
 extern bool(*SetSegmentationObjectId)(const char* meshName, int objectId, bool isNameRegex);
 extern int(*GetSegmentationObjectId)(const char* meshName);
@@ -49,7 +49,7 @@ extern "C" EXPORT void InitVehicleManager(
 	bool(*setCarApiControls)(msr::airlib::CarApiBase::CarControls controls, const char* vehicleName),
 	AirSimCarState(*getCarState)(const char* vehicleName),
 	AirSimCameraInfo(*getCameraInfo)(const char* cameraName, const char* vehicleName),
-	bool(*setCameraOrientation)(const char* cameraName, AirSimQuaternion orientation, const char* vehicleName),
+	bool(*setCameraPose)(const char* cameraName, AirSimPose pose, const char* vehicleName),
 	bool(*setCameraFoV)(const char* cameraName, const float fov_degrees, const char* vehicleName),
 	bool(*setSegmentationObjectId)(const char* meshName, int objectId, bool isNameRegex),
 	int(*getSegmentationObjectId)(const char* meshName),

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/PawnSimApi.cpp
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/PawnSimApi.cpp
@@ -210,15 +210,9 @@ msr::airlib::CameraInfo PawnSimApi::getCameraInfo(const std::string& camera_name
 	return camera_info;
 }
 
-void PawnSimApi::setCameraOrientation(const std::string& camera_name, const msr::airlib::Quaternionr& orientation)
+void PawnSimApi::setCameraPose(const std::string& camera_name, const msr::airlib::Pose& pose)
 {
-	AirSimQuaternion airSimOrientation;
-	airSimOrientation.x = orientation.x();
-	airSimOrientation.y = orientation.y();
-	airSimOrientation.z = orientation.z();
-	airSimOrientation.w = orientation.w();
-
-	SetCameraOrientation(camera_name.c_str(), airSimOrientation, params_.vehicle_name.c_str());
+	SetCameraPose(camera_name.c_str(), UnityUtilities::Convert_to_AirSimPose(pose), params_.vehicle_name.c_str());
 }
 
 void PawnSimApi::setCameraFoV(const std::string& camera_name, float fov_degrees)

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/PawnSimApi.h
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/PawnSimApi.h
@@ -72,7 +72,7 @@ public:
 	virtual Pose getPose() const override;
 	virtual void setPose(const Pose& pose, bool ignore_collision) override;
 	virtual msr::airlib::CameraInfo getCameraInfo(const std::string& camera_name) const override;
-	virtual void setCameraOrientation(const std::string& camera_name, const Quaternionr& orientation) override;
+	virtual void setCameraPose(const std::string& camera_name, const Pose& pose) override;
 	virtual void setCameraFoV(const std::string& camera_name, float fov_degrees) override;
 	virtual CollisionInfo getCollisionInfo() const override;
 	virtual int getRemoteControlID() const override;

--- a/Unity/UnityDemo/Assets/AirSimAssets/Scripts/Utilities/PInvokeWrapper.cs
+++ b/Unity/UnityDemo/Assets/AirSimAssets/Scripts/Utilities/PInvokeWrapper.cs
@@ -13,7 +13,7 @@ namespace AirSimUnity {
         [DllImport(DLL_NAME)]
         public static extern void InitVehicleManager(IntPtr SetPose, IntPtr GetPose, IntPtr GetCollisionInfo, IntPtr GetRCData,
             IntPtr GetSimImages, IntPtr SetRotorSpeed, IntPtr SetEnableApi, IntPtr SetCarApiControls, IntPtr GetCarState,
-            IntPtr GetCameraInfo, IntPtr SetCameraOrientation, IntPtr SetSegmentationObjectid, IntPtr GetSegmentationObjectId, 
+            IntPtr GetCameraInfo, IntPtr SetCameraPose, IntPtr SetSegmentationObjectid, IntPtr GetSegmentationObjectId, 
             IntPtr PrintLogMessage, IntPtr GetTransformFromUnity, IntPtr Reset, IntPtr GetVelocity, IntPtr GetRayCastHit, IntPtr Pause);
 
         [DllImport(DLL_NAME)]

--- a/Unity/UnityDemo/Assets/AirSimAssets/Scripts/Vehicles/IVehicleInterface.cs
+++ b/Unity/UnityDemo/Assets/AirSimAssets/Scripts/Vehicles/IVehicleInterface.cs
@@ -33,7 +33,7 @@ namespace AirSimUnity {
 
         CameraInfo GetCameraInfo(string cameraName);
 
-        bool SetCameraOrientation(string cameraName, AirSimQuaternion orientation);
+        bool SetCameraPose(string cameraName, AirSimPose pose);
 
         bool PrintLogMessage(string message, string messageParams, string vehicleName, int severity);
 

--- a/Unity/UnityDemo/Assets/AirSimAssets/Scripts/Vehicles/Vehicle.cs
+++ b/Unity/UnityDemo/Assets/AirSimAssets/Scripts/Vehicles/Vehicle.cs
@@ -264,10 +264,10 @@ namespace AirSimUnity {
             return info;
         }
 
-        public bool SetCameraOrientation(string cameraName, AirSimQuaternion orientation) {
+        public bool SetCameraPose(string cameraName, AirSimPose pose) {
             foreach (DataCaptureScript capture in captureCameras) {
                 if (capture.GetCameraName() == cameraName) {
-                    capture.SetOrientation(orientation);
+                    capture.SetPose(pose);
                     return true;
                 }
             }

--- a/Unity/UnityDemo/Assets/AirSimAssets/Scripts/Vehicles/VehicleCompanion.cs
+++ b/Unity/UnityDemo/Assets/AirSimAssets/Scripts/Vehicles/VehicleCompanion.cs
@@ -93,7 +93,7 @@ namespace AirSimUnity {
                 Marshal.GetFunctionPointerForDelegate(new Func<CarControls, string, bool>(SetCarApiControls)),
                 Marshal.GetFunctionPointerForDelegate(new Func<string, CarState>(GetCarState)),
                 Marshal.GetFunctionPointerForDelegate(new Func<string, string, CameraInfo>(GetCameraInfo)),
-                Marshal.GetFunctionPointerForDelegate(new Func<string, AirSimQuaternion, string, bool>(SetCameraOrientation)),
+                Marshal.GetFunctionPointerForDelegate(new Func<string, AirSimPose, string, bool>(SetCameraPose)),
                 Marshal.GetFunctionPointerForDelegate(new Func<string, int, bool, bool>(SetSegmentationObjectId)),
                 Marshal.GetFunctionPointerForDelegate(new Func<string, int>(GetSegmentationObjectId)),
                 Marshal.GetFunctionPointerForDelegate(new Func<string, string, string, int, bool>(PrintLogMessage)),
@@ -183,9 +183,9 @@ namespace AirSimUnity {
             return vehicle.VehicleInterface.GetCameraInfo(cameraName);
         }
 
-        private static bool SetCameraOrientation(string cameraName, AirSimQuaternion orientation, string vehicleName) {
+        private static bool SetCameraPose(string cameraName, AirSimPose pose, string vehicleName) {
             var vehicle = Vehicles.Find(element => element.vehicleName == vehicleName);
-            return vehicle.VehicleInterface.SetCameraOrientation(cameraName, orientation);
+            return vehicle.VehicleInterface.SetCameraPose(cameraName, pose);
         }
 
         private static bool PrintLogMessage(string message, string messageParams, string vehicleName, int severity) {

--- a/Unreal/Plugins/AirSim/Source/NedTransform.cpp
+++ b/Unreal/Plugins/AirSim/Source/NedTransform.cpp
@@ -66,6 +66,14 @@ FVector NedTransform::fromLocalNed(const NedTransform::Vector3r& position) const
 {
     return NedTransform::toFVector(position, world_to_meters_, true) + local_ned_offset_;
 }
+FVector NedTransform::fromRelativeNed(const NedTransform::Vector3r& position) const
+{
+    return NedTransform::toFVector(position, world_to_meters_, true);
+}
+FTransform NedTransform::fromRelativeNed(const Pose& pose) const
+{
+    return FTransform(fromNed(pose.orientation), fromRelativeNed(pose.position));
+}
 FVector NedTransform::fromGlobalNed(const NedTransform::Vector3r& position) const
 {
     return NedTransform::toFVector(position, world_to_meters_, true) + global_transform_.GetLocation();

--- a/Unreal/Plugins/AirSim/Source/NedTransform.h
+++ b/Unreal/Plugins/AirSim/Source/NedTransform.h
@@ -42,6 +42,8 @@ public:
     FVector fromGlobalNed(const Vector3r& position) const;
     FQuat fromNed(const Quaternionr& q) const;
     float fromNed(float length) const;
+    FVector fromRelativeNed(const Vector3r& position) const;
+    FTransform fromRelativeNed(const Pose& pose) const;
     FTransform fromLocalNed(const Pose& pose) const;
     FTransform fromGlobalNed(const Pose& pose) const;
 

--- a/Unreal/Plugins/AirSim/Source/PIPCamera.cpp
+++ b/Unreal/Plugins/AirSim/Source/PIPCamera.cpp
@@ -244,8 +244,12 @@ void APIPCamera::setCameraTypeEnabled(ImageType type, bool enabled)
     enableCaptureComponent(type, enabled);
 }
 
-void APIPCamera::setCameraOrientation(const FRotator& rotator)
+void APIPCamera::setCameraPose(const FTransform& pose)
 {
+    FVector position = pose.GetLocation();
+    this->SetActorRelativeLocation(pose.GetLocation());
+
+    FRotator rotator = pose.GetRotation().Rotator();
     if (gimbal_stabilization_ > 0) {
         gimbald_rotator_.Pitch = rotator.Pitch;
         gimbald_rotator_.Roll = rotator.Roll;

--- a/Unreal/Plugins/AirSim/Source/PIPCamera.h
+++ b/Unreal/Plugins/AirSim/Source/PIPCamera.h
@@ -41,7 +41,7 @@ public:
     void setCameraTypeEnabled(ImageType type, bool enabled);
     bool getCameraTypeEnabled(ImageType type) const;
     void setupCameraFromSettings(const APIPCamera::CameraSetting& camera_setting, const NedTransform& ned_transform);
-    void setCameraOrientation(const FRotator& rotator);
+    void setCameraPose(const FTransform& pose);
     void setCameraFoV(float fov_degrees);
 
     msr::airlib::ProjectionMatrix getProjectionMatrix(const APIPCamera::ImageType image_type) const;

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
@@ -409,12 +409,12 @@ msr::airlib::CameraInfo PawnSimApi::getCameraInfo(const std::string& camera_name
     return camera_info;
 }
 
-void PawnSimApi::setCameraOrientation(const std::string& camera_name, const msr::airlib::Quaternionr& orientation)
+void PawnSimApi::setCameraPose(const std::string& camera_name, const msr::airlib::Pose& pose)
 {
-    UAirBlueprintLib::RunCommandOnGameThread([this, camera_name, orientation]() {
+    UAirBlueprintLib::RunCommandOnGameThread([this, camera_name, pose]() {
         APIPCamera* camera = getCamera(camera_name);
-        FQuat quat = ned_transform_.fromNed(orientation);
-        camera->setCameraOrientation(quat.Rotator());
+        FTransform pose_unreal = ned_transform_.fromRelativeNed(pose);
+        camera->setCameraPose(pose_unreal);
     }, true);
 }
 

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.h
@@ -77,7 +77,7 @@ public: //implementation of VehicleSimApiBase
     virtual Pose getPose() const override;
     virtual void setPose(const Pose& pose, bool ignore_collision) override;
     virtual msr::airlib::CameraInfo getCameraInfo(const std::string& camera_name) const override;
-    virtual void setCameraOrientation(const std::string& camera_name, const Quaternionr& orientation) override;
+    virtual void setCameraPose(const std::string& camera_name, const Pose& pose) override;
     virtual void setCameraFoV(const std::string& camera_name, float fov_degrees) override;
     virtual CollisionInfo getCollisionInfo() const override;
     virtual int getRemoteControlID() const override;

--- a/docs/image_apis.md
+++ b/docs/image_apis.md
@@ -166,9 +166,10 @@ To move around the environment using APIs you can use `simSetVehiclePose` API. T
 ## Camera APIs
 The `simGetCameraInfo` returns the pose (in world frame, NED coordinates, SI units) and FOV (in degrees) for the specified camera. Please see [example usage](https://github.com/Microsoft/AirSim/tree/master/PythonClient//computer_vision/cv_mode.py).
 
-The `simSetCameraOrientation` sets the orientation for the specified camera as quaternion in NED frame. The handy `airsim.to_quaternion()` function allows to convert pitch, roll, yaw to quaternion. For example, to set camera-0 to 15-degree pitch, you can use:
+The `simSetCameraPose` sets the pose for the specified camera while taking an input pose as a combination of relative position and a quaternion in NED frame. The handy `airsim.to_quaternion()` function allows to convert pitch, roll, yaw to quaternion. For example, to set camera-0 to 15-degree pitch while maintaining the same position, you can use:
 ```
-client.simSetCameraOrientation(0, airsim.to_quaternion(0.261799, 0, 0)); #radians
+camera_pose = airsim.Pose(airsim.Vector3(0, 0, 0), airsim.to_quaternion(0.261799, 0, 0))  #RPY in radians
+client.simSetCameraPose(0, camera_pose);
 ```
 
 ### Gimbal


### PR DESCRIPTION
setCameraPose now takes a pose argument instead of just orientation. Commanded pose is expected to contain position in NED, **relative to default camera location**. 

Status:

- [x] Base implementation of setCameraPose for Unreal
- [x] Testing in Unreal
- [x] Unity implementation
- [ ] Testing in Unity
- [ ] Documentation
- [ ] Replacements in examples/ros wrapper