### PR TITLE
[ros] Add mavros_msgs to build dependencies

### DIFF
--- a/ros/src/airsim_ros_pkgs/package.xml
+++ b/ros/src/airsim_ros_pkgs/package.xml
@@ -15,6 +15,7 @@
   <build_depend>image_transport</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>message_runtime</build_depend>
+  <build_depend>mavros_msgs</build_depend>
   <build_depend>nav_msgs</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>


### PR DESCRIPTION
If mavros is being built in the same catkin workspace then airsim_ros_pkgs needs to depend upon mavros_msgs for the packages to be built in the correct order.