### PR TITLE
Update docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -380,6 +380,7 @@ ros/src/CMakeLists.txt
 
 # docs
 docs/README.md
+docs/api_docs
 build_docs/
 
 # api docs

--- a/.gitignore
+++ b/.gitignore
@@ -380,7 +380,6 @@ ros/src/CMakeLists.txt
 
 # docs
 docs/README.md
-docs/api_docs
 build_docs/
 
 # api docs

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Welcome to AirSim
 
-AirSim is a simulator for drones, cars and more, built on [Unreal Engine](https://www.unrealengine.com/) (we now also have an experimental [Unity](https://unity3d.com/) release). It is open-source, cross platform, and supports hardware-in-loop with popular flight controllers such as PX4 for physically and visually realistic simulations. It is developed as an Unreal plugin that can simply be dropped into any Unreal environment. Similarly, we have an experimental release for a Unity plugin.
+AirSim is a simulator for drones, cars and more, built on [Unreal Engine](https://www.unrealengine.com/) (we now also have an experimental [Unity](https://unity3d.com/) release). It is open-source, cross platform, and supports software-in-the-loop simulation with popular flight controllers such as PX4 & ArduPilot and hardware-in-loop with PX4 for physically and visually realistic simulations. It is developed as an Unreal plugin that can simply be dropped into any Unreal environment. Similarly, we have an experimental release for a Unity plugin.
 
 Our goal is to develop AirSim as a platform for AI research to experiment with deep learning, computer vision and reinforcement learning algorithms for autonomous vehicles. For this purpose, AirSim also exposes APIs to retrieve data and control vehicles in a platform independent way.
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Press F10 to see various options available for weather effects. You can also con
 - [Video - Setting up AirSim with Pixhawk Tutorial](https://youtu.be/1oY8Qu5maQQ) by Chris Lovett
 - [Video - Using AirSim with Pixhawk Tutorial](https://youtu.be/HNWdYrtw3f0) by Chris Lovett
 - [Video - Using off-the-self environments with AirSim](https://www.youtube.com/watch?v=y09VbdQWvQY) by Jim Piavis
-- [Reinforcement Learning with AirSim](https://microsoft.github.io/AirSim/docs/reinforcement_learning) by Ashish Kapoor
+- [Reinforcement Learning with AirSim](https://microsoft.github.io/AirSim/reinforcement_learning) by Ashish Kapoor
 - [The Autonomous Driving Cookbook](https://aka.ms/AutonomousDrivingCookbook) by Microsoft Deep Learning and Robotics Garage Chapter
 - [Using TensorFlow for simple collision avoidance](https://github.com/simondlevy/AirSimTensorFlow) by Simon Levy and WLU team
 

--- a/build_docs.sh
+++ b/build_docs.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# get path of current script: https://stackoverflow.com/a/39340259/207661
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+pushd "$SCRIPT_DIR"  >/dev/null
+
 cp README.md docs/
 sed -i 's/](docs\//](/g' docs/README.md
+
+# Build API docs
+pushd PythonClient/docs >/dev/null
+make html
+
+popd >/dev/null
+
+cp -r PythonClient/docs/_build docs/api_docs/
+
 mkdocs build
+
+popd >/dev/null

--- a/build_docs.sh
+++ b/build_docs.sh
@@ -1,19 +1,10 @@
 #!/bin/bash
 
-# get path of current script: https://stackoverflow.com/a/39340259/207661
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 pushd "$SCRIPT_DIR"  >/dev/null
 
 cp README.md docs/
 sed -i 's/](docs\//](/g' docs/README.md
-
-# Build API docs
-pushd PythonClient/docs >/dev/null
-make html
-
-popd >/dev/null
-
-cp -r PythonClient/docs/_build docs/api_docs/
 
 mkdocs build
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 Below is summarized list of important changes. This does not include minor/less important changes or bug fixes or documentation update. This list updated every few months. For complete detailed changes, please review [commit history](https://github.com/Microsoft/AirSim/commits/master).
 
+### July 2020
+
+* [Allow passing the settings.json file location via `--settings` argument](https://github.com/microsoft/AirSim/pull/2668)
+* [Distance Sensor Upgrades and fixes](https://github.com/microsoft/AirSim/pull/2807)
+* [Update to min CMake version required for VS 2019](https://github.com/microsoft/AirSim/pull/2766)
+* [Fix: Non-linear bias corrupts SurfaceNormals, Segmentation image](https://github.com/microsoft/AirSim/pull/2845)
+* [Fix: `simGetSegmentationObjectID` will always return -1](https://github.com/microsoft/AirSim/pull/2855)
+* [Initial implementation of simLoadLevel, simGet/SetObjectScale, simSpawn|DestroyObject APIs](https://github.com/microsoft/AirSim/pull/2651)
+* [Upgrade `setCameraOrientation` API to `setCameraPose`](https://github.com/microsoft/AirSim/pull/2710)
+* [ROS: All sensors and car support](https://github.com/microsoft/AirSim/pull/2743)
+* [Get rid of potential div-0 errors so we can set dt = 0 for pausing](https://github.com/microsoft/AirSim/pull/2705)
+* [ROS: Add mavros_msgs to build dependencies](https://github.com/microsoft/AirSim/pull/2642)
+* [Move Wiki pages to docs](https://github.com/microsoft/AirSim/pull/2803)
+* [Add Recording APIs](https://github.com/microsoft/AirSim/pull/2834)
+* [Update Dockerfiles and documentation to Ubuntu 18.04](https://github.com/microsoft/AirSim/pull/2865)
+* [Azure development environment and documentation](https://github.com/microsoft/AirSim/pull/2816)
+* [ROS: Add airsim_node to install list](https://github.com/microsoft/AirSim/pull/2706)
+
+### May 2020
+
+* [Fix more issues with PX4 master](https://github.com/microsoft/AirSim/pull/2649)
+* [Reduce warnings level in Unity build](https://github.com/microsoft/AirSim/pull/2672)
+* [Support for Unreal Engine 4.25](https://github.com/microsoft/AirSim/pull/2669)
+* [Unity crash fix, upgrade to 2019.3.12, Linux build improvements](https://github.com/microsoft/AirSim/pull/2328)
+
 ### April 2020
 
 * [Fix issues with PX4 latest master branch](https://github.com/microsoft/AirSim/pull/2634)

--- a/docs/airsim_ros_pkgs.md
+++ b/docs/airsim_ros_pkgs.md
@@ -14,7 +14,7 @@ Verify installation by `gcc-8 --version`
     * Install [ROS melodic](https://wiki.ros.org/melodic/Installation/Ubuntu)
     * Install tf2 sensor and mavros packages: `sudo apt-get install ros-melodic-tf2-sensor-msgs ros-melodic-mavros*`
 
-- Install [catkin_tools](https://catkin-tools.readthedocs.io/en/latest/installing.html)  
+- Install [catkin_tools](https://catkin-tools.readthedocs.io/en/latest/installing.html)
     `sudo apt-get install python-catkin-tools` or
     `pip install catkin_tools`
 

--- a/docs/airsim_ros_pkgs.md
+++ b/docs/airsim_ros_pkgs.md
@@ -3,19 +3,18 @@
 A ROS wrapper over the AirSim C++ client library. 
 
 ##  Setup 
-- Install gcc >= 8.0.0
-`sudo apt-get install gcc-8 g++-8`
-Verify version by `gcc --version`
+- Install gcc >= 8.0.0: `sudo apt-get install gcc-8 g++-8`  
+Verify installation by `gcc-8 --version`
 
 - Ubuntu 16.04
-  * Install [ROS kinetic](https://wiki.ros.org/kinetic/Installation/Ubuntu)
-  * Install tf2 sensor and mavros packages: `sudo apt-get install ros-kinetic-tf2-sensor-msgs ros-kinetic-mavros*`
+    * Install [ROS kinetic](https://wiki.ros.org/kinetic/Installation/Ubuntu)
+    * Install tf2 sensor and mavros packages: `sudo apt-get install ros-kinetic-tf2-sensor-msgs ros-kinetic-mavros*`
 
 - Ubuntu 18.04
-  * Install [ROS melodic](https://wiki.ros.org/melodic/Installation/Ubuntu)
-  * Install tf2 sensor and mavros packages: `sudo apt-get install ros-melodic-tf2-sensor-msgs ros-melodic-mavros*`
+    * Install [ROS melodic](https://wiki.ros.org/melodic/Installation/Ubuntu)
+    * Install tf2 sensor and mavros packages: `sudo apt-get install ros-melodic-tf2-sensor-msgs ros-melodic-mavros*`
 
-- Install [catkin_tools](https://catkin-tools.readthedocs.io/en/latest/installing.html)
+- Install [catkin_tools](https://catkin-tools.readthedocs.io/en/latest/installing.html)  
     `sudo apt-get install python-catkin-tools` or
     `pip install catkin_tools`
 
@@ -69,18 +68,19 @@ Odometry in NED frame (default name: odom_local_ned, launch name and frame type 
 
 - `/tf` [tf2_msgs/TFMessage](https://docs.ros.org/api/tf2_msgs/html/msg/TFMessage.html)
 
-- `/airsim_node/VEHICLE_NAME/altimeter/SENSOR_NAME` [airsim_ros_pkgs::Altimeter] This the current altimeter reading for altitude, pressure, and QNH (https://en.wikipedia.org/wiki/QNH)
+- `/airsim_node/VEHICLE_NAME/altimeter/SENSOR_NAME` [airsim_ros_pkgs/Altimeter](https://github.com/microsoft/AirSim/blob/master/ros/src/airsim_ros_pkgs/msg/Altimeter.msg)  
+This the current altimeter reading for altitude, pressure, and [QNH](https://en.wikipedia.org/wiki/QNH)
   
-- `/airsim_node/VEHICLE_NAME/imu/SENSOR_NAME` [sensor_msgs::Imu] (http://docs.ros.org/api/sensor_msgs/html/msg/Imu.html)
-  IMU sensor data
+- `/airsim_node/VEHICLE_NAME/imu/SENSOR_NAME` [sensor_msgs::Imu](http://docs.ros.org/api/sensor_msgs/html/msg/Imu.html)  
+IMU sensor data
 
-- `/airsim_node/VEHICLE_NAME/magnetometer/SENSOR_NAME` [sensor_msgs::MagneticField] (http://docs.ros.org/api/sensor_msgs/html/msg/MagneticField.html)
+- `/airsim_node/VEHICLE_NAME/magnetometer/SENSOR_NAME` [sensor_msgs::MagneticField](http://docs.ros.org/api/sensor_msgs/html/msg/MagneticField.html)  
   Meausrement of magnetic field vector/compass
 
-- `/airsim_node/VEHICLE_NAME/distance/SENSOR_NAME` [sensor_msgs::Range] (http://docs.ros.org/api/sensor_msgs/html/msg/Range.html)
+- `/airsim_node/VEHICLE_NAME/distance/SENSOR_NAME` [sensor_msgs::Range](http://docs.ros.org/api/sensor_msgs/html/msg/Range.html)  
   Meausrement of distance from an active ranger, such as infrared or IR
 
-- `/airsim_node/VEHICLE_NAME/lidar/SENSOR_NAME` [sensor_msgs::PointCloud2] (http://docs.ros.org/api/sensor_msgs/html/msg/PointCloud2.html)
+- `/airsim_node/VEHICLE_NAME/lidar/SENSOR_NAME` [sensor_msgs::PointCloud2](http://docs.ros.org/api/sensor_msgs/html/msg/PointCloud2.html)  
   LIDAR pointcloud
 
 #### Subscribers: 
@@ -96,8 +96,8 @@ Odometry in NED frame (default name: odom_local_ned, launch name and frame type 
 - `/gimbal_angle_quat_cmd` [airsim_ros_pkgs/GimbalAngleQuatCmd](https://github.com/microsoft/AirSim/tree/master/ros/src/airsim_ros_pkgs/msg/GimbalAngleQuatCmd.msg)   
   Gimbal set point in quaternion.    
 
-- `/airsim_node/VEHICLE_NAME/car_cmd` [airsim_ros_pkgs/CarControls]
-  Throttle, brake, steering and gear selections for control. Both automatic and manual transmission control possible, see the car_joy.py script for use.
+- `/airsim_node/VEHICLE_NAME/car_cmd` [airsim_ros_pkgs/CarControls](https://github.com/microsoft/AirSim/blob/master/ros/src/airsim_ros_pkgs/msg/CarControls.msg)  
+Throttle, brake, steering and gear selections for control. Both automatic and manual transmission control possible, see the [`car_joy.py`](https://github.com/microsoft/AirSim/blob/master/ros/src/airsim_ros_pkgs/scripts/car_joy) script for use.
 
 #### Services:
 - `/airsim_node/VEHICLE_NAME/land` [airsim_ros_pkgs/Takeoff](https://docs.ros.org/api/std_srvs/html/srv/Empty.html)
@@ -172,7 +172,7 @@ Odometry in NED frame (default name: odom_local_ned, launch name and frame type 
   Target gps position + yaw.   
   In **absolute** altitude. 
 
-- `/airsim_node/VEHICLE_NAME/local_position_goal` [Request: [srv/SetLocalPosition](https://github.com/microsoft/AirSim/blob/master/ros/src/airsim_ros_pkgs/srv/SetLocalPosition.srv)   
+- `/airsim_node/VEHICLE_NAME/local_position_goal` [Request: [srv/SetLocalPosition](https://github.com/microsoft/AirSim/blob/master/ros/src/airsim_ros_pkgs/srv/SetLocalPosition.srv)]   
   Target local position + yaw in global NED frame.   
 
 #### Subscribers:
@@ -200,15 +200,15 @@ Odometry in NED frame (default name: odom_local_ned, launch name and frame type 
 ### Misc
 #### Windows Subsytem for Linux on Windows 10
 - WSL setup:
-  * Get [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10)
-  * Get [Ubuntu 16.04](https://www.microsoft.com/en-us/p/ubuntu-1604-lts/9pjn388hp8c9?activetab=pivot:overviewtab) or [Ubuntu 18.04](https://www.microsoft.com/en-us/p/ubuntu-1804-lts/9n9tngvndl3q?activetab=pivot%3Aoverviewtab)  
-  * Go to Ubuntu 16 / 18 instructions!
+    * Get [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10)
+    * Get [Ubuntu 16.04](https://www.microsoft.com/en-us/p/ubuntu-1604-lts/9pjn388hp8c9?activetab=pivot:overviewtab) or [Ubuntu 18.04](https://www.microsoft.com/en-us/p/ubuntu-1804-lts/9n9tngvndl3q?activetab=pivot%3Aoverviewtab)  
+    * Go to Ubuntu 16 / 18 instructions!
 
 
 - Setup for X apps (like RViz, rqt_image_view, terminator) in Windows + WSL
-  * Install [Xming X Server](https://sourceforge.net/projects/xming/). 
-  * Find and run `XLaunch` from the Windows start menu.   
-  Select `Multiple Windows` in first popup, `Start no client` in second popup, **only** `Clipboard` in third popup. Do **not** select `Native Opengl`.  
-  * Open Ubuntu 16.04 / 18.04 session by typing `Ubuntu 16.04`  / `Ubuntu 18.04` in Windows start menu.  
-  * Recommended: Install [terminator](http://www.ubuntugeek.com/terminator-multiple-gnome-terminals-in-one-window.html) : `$ sudo apt-get install terminator.` 
+    * Install [Xming X Server](https://sourceforge.net/projects/xming/). 
+    * Find and run `XLaunch` from the Windows start menu.   
+    Select `Multiple Windows` in first popup, `Start no client` in second popup, **only** `Clipboard` in third popup. Do **not** select `Native Opengl`.  
+    * Open Ubuntu 16.04 / 18.04 session by typing `Ubuntu 16.04`  / `Ubuntu 18.04` in Windows start menu.  
+    * Recommended: Install [terminator](http://www.ubuntugeek.com/terminator-multiple-gnome-terminals-in-one-window.html) : `$ sudo apt-get install terminator.` 
     - You can open terminator in a new window by entering `$ DISPLAY=:0 terminator -u`. 

--- a/docs/build_linux.md
+++ b/docs/build_linux.md
@@ -7,6 +7,7 @@ Only macOS **Catalina (10.15)** is supported.
 We've two options - you can either build inside docker containers or your host machine.
 
 ## Docker
+
 Please see instructions [here](https://github.com/Microsoft/AirSim/blob/master/docs/docker_ubuntu.md)
 
 ## Host machine
@@ -19,14 +20,14 @@ Please see instructions [here](https://github.com/Microsoft/AirSim/blob/master/d
 
 - Clone Unreal in your favorite folder and build it (this may take a while!). **Note**: We only support Unreal >= 4.22 at present. We recommend using 4.24.
 
-   ```bash
-   # go to the folder where you clone GitHub projects
-   git clone -b 4.24 https://github.com/EpicGames/UnrealEngine.git
-   cd UnrealEngine
-   ./Setup.sh
-   ./GenerateProjectFiles.sh
-   make
-   ```
+```bash
+# go to the folder where you clone GitHub projects
+git clone -b 4.24 https://github.com/EpicGames/UnrealEngine.git
+cd UnrealEngine
+./Setup.sh
+./GenerateProjectFiles.sh
+make
+```
 
 #### macOS - Download Unreal Engine
 
@@ -41,18 +42,18 @@ Click on the `Add Versions` which should show the option to download **Unreal 4.
 
 - Clone AirSim and build it:
 
-   ```bash
-   # go to the folder where you clone GitHub projects
-   git clone https://github.com/Microsoft/AirSim.git
-   cd AirSim
-   ```
+```bash
+# go to the folder where you clone GitHub projects
+git clone https://github.com/Microsoft/AirSim.git
+cd AirSim
+```
 
   By default AirSim recommends using clang 8 to build the binaries as those will be compatible with UE 4.24.  The setup script will install the right version of cmake, llvm, and eigen.
 
-  ```bash
-   ./setup.sh
-   ./build.sh
-   ```
+```bash
+./setup.sh
+./build.sh
+```
 
 ### Build Unreal Environment
 
@@ -68,17 +69,17 @@ Once AirSim is setup:
 - When Unreal Engine prompts for opening or creating project, select Browse and choose `AirSim/Unreal/Environments/Blocks` (or your [custom](unreal_custenv.md) Unreal project).
 - Alternatively, the project file can be passed as a commandline argument. For Blocks: `./Engine/Binaries/Linux/UE4Editor <AirSim_path>/Unreal/Environments/Blocks/Blocks.uproject`
 - If you get prompts to convert project, look for More Options or Convert-In-Place option. If you get prompted to build, choose Yes. If you get prompted to disable AirSim plugin, choose No.
-- After Unreal Editor loads, press Play button. 
+- After Unreal Editor loads, press Play button.
 
 ### Mac
 
 - Browse to `AirSim/Unreal/Environments/Blocks`.
 - Run `./GenerateProjectFiles.sh <UE_PATH>` from the terminal, where `UE_PATH` is the path to the Unreal installation folder. (By default, this is `/Users/Shared/Epic\ Games/UE_4.24/`) The script creates an XCode workspace by the name Blocks.xcworkspace.
-- Open the XCode workspace, and press the Build and run button in the top left. 
-- After Unreal Editor loads, press Play button. 
+- Open the XCode workspace, and press the Build and run button in the top left.
+- After Unreal Editor loads, press Play button.
 
 See [Using APIs](apis.md) and [settings.json](settings.md) for various options available for AirSim usage.
-Tip: go to 'Edit->Editor Preferences', in the 'Search' box type 'CPU' and ensure that the 'Use Less CPU when in Background' is unchecked. 
+Tip: go to 'Edit->Editor Preferences', in the 'Search' box type 'CPU' and ensure that the 'Use Less CPU when in Background' is unchecked.
 
 ### [Optional] Setup Remote Control (Multirotor Only)
 
@@ -88,38 +89,39 @@ Alternatively, you can use [APIs](apis.md) for programmatic control or use the s
 
 ## FAQs
 
-- I'm getting error "<MyProject> could not be compiled. Try rebuilding from source manually".
-  * This could either happen because of compile error or the fact that your gch files are outdated. Look in to your console window. Do you see something like below?
-   ```
-   fatal error: file  '/usr/include/linux/version.h''/usr/include/linux/version.h'  has  been  modified  since  the  precompiled  header
-   ```
-  * If this is the case then look for *.gch file(s) that follows after that message, delete them and try again. Here's [relevant thread](https://answers.unrealengine.com/questions/412349/linux-ue4-build-precompiled-header-fatal-error.html) on Unreal Engine forums.
-  * If you see other compile errors in console then open up those source files and see if it is due to changes you made. If not, then report it as issue on GitHub.
+- I'm getting error `<MyProject> could not be compiled. Try rebuilding from source manually`.
+    * This could either happen because of compile error or the fact that your gch files are outdated. Look in to your console window. Do you see something like below?
+
+`fatal error: file '/usr/include/linux/version.h''/usr/include/linux/version.h' has been modified since the precompiled header`
+
+* If this is the case then look for *.gch file(s) that follows after that message, delete them and try again. Here's [relevant thread](https://answers.unrealengine.com/questions/412349/linux-ue4-build-precompiled-header-fatal-error.html) on Unreal Engine forums.
+
+* If you see other compile errors in console then open up those source files and see if it is due to changes you made. If not, then report it as issue on GitHub.
 
 - Unreal crashed! How do I know what went wrong?
-  * Go to the `MyUnrealProject/Saved/Crashes` folder and search for the file `MyProject.log` within its subdirectories. At the end of this file you will see the stack trace and messages.
-   You can also take a look at the `Diagnostics.txt` file.
+    * Go to the `MyUnrealProject/Saved/Crashes` folder and search for the file `MyProject.log` within its subdirectories. At the end of this file you will see the stack trace and messages.
+    You can also take a look at the `Diagnostics.txt` file.
 
 - How do I use an IDE on Linux?
-  * You can use Qt Creator or CodeLite. Instructions for Qt Creator are available [here](https://docs.unrealengine.com/latest/INT/Platforms/Linux/BeginnerLinuxDeveloper/SettingUpAnIDE/index.html).
+    * You can use Qt Creator or CodeLite. Instructions for Qt Creator are available [here](https://docs.unrealengine.com/latest/INT/Platforms/Linux/BeginnerLinuxDeveloper/SettingUpAnIDE/index.html).
 
 - Can I cross compile for Linux from a Windows machine?
-  * Yes, you can, but we haven't tested it. You can find the instructions [here](https://docs.unrealengine.com/latest/INT/Platforms/Linux/GettingStarted/index.html).
+    * Yes, you can, but we haven't tested it. You can find the instructions [here](https://docs.unrealengine.com/latest/INT/Platforms/Linux/GettingStarted/index.html).
 
 - What compiler and stdlib does AirSim use?
-  * We use the same compiler that Unreal Engine uses, **Clang 8**, and stdlib, **libc++**. AirSim's `setup.sh` will automatically download them.
+    * We use the same compiler that Unreal Engine uses, **Clang 8**, and stdlib, **libc++**. AirSim's `setup.sh` will automatically download them.
 
 - What version of CMake does the AirSim build use?
-  * 3.10.0 or higher. This is *not* the default in Ubuntu 16.04 so setup.sh installs it for you. You can check your CMake version using `cmake --version`. If you have an older version, follow [these instructions](cmake_linux.md) or see the [CMake website](https://cmake.org/install/).
+    * 3.10.0 or higher. This is *not* the default in Ubuntu 16.04 so setup.sh installs it for you. You can check your CMake version using `cmake --version`. If you have an older version, follow [these instructions](cmake_linux.md) or see the [CMake website](https://cmake.org/install/).
 
 - Can I compile AirSim in BashOnWindows?
-  * Yes, however, you can't run Unreal from BashOnWindows. So this is kind of useful to check a Linux compile, but not for an end-to-end run.
-   See the [BashOnWindows install guide](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide).
-   Make sure to have the latest version (Windows 10 Creators Edition) as previous versions had various issues.
-   Also, don't invoke `bash` from `Visual Studio Command Prompt`, otherwise CMake might find VC++ and try and use that!
+    * Yes, however, you can't run Unreal from BashOnWindows. So this is kind of useful to check a Linux compile, but not for an end-to-end run.
+    See the [BashOnWindows install guide](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide).
+    Make sure to have the latest version (Windows 10 Creators Edition) as previous versions had various issues.
+    Also, don't invoke `bash` from `Visual Studio Command Prompt`, otherwise CMake might find VC++ and try and use that!
 
 - Where can I find more info on running Unreal on Linux?
-   * Start here: [Unreal on Linux](https://docs.unrealengine.com/latest/INT/Platforms/Linux/index.html)
-   * [Building Unreal on Linux](https://wiki.unrealengine.com/Building_On_Linux#Clang)
-   * [Unreal Linux Support](https://wiki.unrealengine.com/Linux_Support)
-   * [Unreal Cross Compilation](https://wiki.unrealengine.com/Compiling_For_Linux)
+    * Start here: [Unreal on Linux](https://docs.unrealengine.com/latest/INT/Platforms/Linux/index.html)
+    * [Building Unreal on Linux](https://wiki.unrealengine.com/Building_On_Linux#Clang)
+    * [Unreal Linux Support](https://wiki.unrealengine.com/Linux_Support)
+    * [Unreal Cross Compilation](https://wiki.unrealengine.com/Compiling_For_Linux)

--- a/docs/build_windows.md
+++ b/docs/build_windows.md
@@ -72,6 +72,13 @@ And add this Compiler version setting:
 </Configuration>
 ```
 
+### I'm getting error `<MyProject> could not be compiled. Try rebuilding from source manually`
+
+This will occur when there are compilation errors. Logs are stored in `<My-Project>\Saved\Logs` which can be used to figure out the problem.
+
+A common problem could be Visual Studio version conflict, AirSim uses VS 2019 while UE is using VS 2017, this can be found by searching for `2017` in the Log file. In that case, see the answer above.
+
+If you have modified the AirSim plugin files, then you can right-click the `.uproject` file, select `Generate Visual Studio solution file` and then open the `.sln` file in VS to fix the errors and build again.
 
 ### I get `error C100 : An internal error has occurred in the compiler` when running build.cmd
 We have noticed this happening with VS version `15.9.0` and have checked-in a workaround in AirSim code. If you have this VS version, please make sure to pull the latest AirSim code.
@@ -88,12 +95,14 @@ Sometimes the Unreal + VS build system doesn't recompile if you make changes to 
 
 ### Unreal still uses VS2015 or I'm getting some link error
 Running several versions of VS can lead to issues when compiling UE projects. One problem that may arise is that UE will try to compile with an older version of VS which may or may not work. There are two settings in Unreal, one for for the engine and one for the project, to adjust the version of VS to be used.
-1. Edit -> Editor preferences -> General -> Source code
+
+1. Edit -> Editor preferences -> General -> Source code -> Source Code Editor
 2. Edit -> Project Settings -> Platforms -> Windows -> Toolchain ->CompilerVersion
 
 In some cases, these settings will still not lead to the desired result and errors such as the following might be produced: LINK : fatal error LNK1181: cannot open input file 'ws2_32.lib'
 
 To resolve such issues the following procedure can be applied:
+
 1. Uninstall all old versions of VS using the [VisualStudioUninstaller](https://github.com/Microsoft/VisualStudioUninstaller/releases)
 2. Repair/Install VS 2019
 3. Restart machine and install Epic launcher and desired version of the engine

--- a/docs/build_windows.md
+++ b/docs/build_windows.md
@@ -14,6 +14,9 @@ Click on the `Add Versions` which should show the option to download **Unreal 4.
 **Make sure** to select **Desktop Development with C++** and **Windows 10 SDK 10.0.18362** (should be selected by default) while installing VS 2019.
 * Start `Developer Command Prompt for VS 2019`.
 * Clone the repo: `git clone https://github.com/Microsoft/AirSim.git`, and go the AirSim directory by `cd AirSim`.
+
+    **Note:** It's generally not a good idea to install AirSim in C drive. This can cause scripts to fail, and requires running VS in Admin mode. Instead clone in a different drive such as D or E.
+
 * Run `build.cmd` from the command line. This will create ready to use plugin bits in the `Unreal\Plugins` folder that can be dropped into any Unreal project.
 
 ## Build Unreal Project

--- a/docs/flight_controller.md
+++ b/docs/flight_controller.md
@@ -14,7 +14,7 @@ In "software-in-loop" simulation (SITL or SIL) mode the firmware runs in your co
 
 ## What Flight Controllers are Supported?
 
-AirSim has built-in flight controller called [simple_flight](simple_flight.md) and it is used by default. You don't need to do anything to use or configure it. AirSim also supports [PX4](px4_setup.md) as another flight controller for advanced users. In the future, we also plan to support [ROSFlight](https://rosflight.org/) and [Hackflight](https://github.com/simondlevy/hackflight).
+AirSim has built-in flight controller called [simple_flight](simple_flight.md) and it is used by default. You don't need to do anything to use or configure it. AirSim also supports [PX4](px4_setup.md) & [ArduPilot](https://ardupilot.org/dev/docs/sitl-with-airsim.html) as external flight controllers for advanced users.
 
 ## Using AirSim Without Flight Controller
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -274,13 +274,14 @@ The `Gimbal` element allows to freeze camera orientation for pitch, roll and/or 
 Each simulation mode will go through the list of vehicles specified in this setting and create the ones that has `"AutoCreate": true`. Each vehicle specified in this setting has key which becomes the name of the vehicle. If `"Vehicles"` element is missing then this list is populated with default car named "PhysXCar" and default multirotor named "SimpleFlight".
 
 ### Common Vehicle Setting
-- `VehicleType`: This could be either `PhysXCar`, `SimpleFlight`, `PX4Multirotor` or `ComputerVision`. There is no default value therefore this element must be specified.
+- `VehicleType`: This could be any one of the following - `PhysXCar`, `SimpleFlight`, `PX4Multirotor`, `ComputerVision`, `ArduCopter` & `ArduRover`. There is no default value therefore this element must be specified.
 - `PawnPath`: This allows to override the pawn blueprint to use for the vehicle. For example, you may create new pawn blueprint derived from ACarPawn for a warehouse robot in your own project outside the AirSim code and then specify its path here. See also [PawnPaths](#PawnPaths).
 - `DefaultVehicleState`: Possible value for multirotors is `Armed` or `Disarmed`.
 - `AutoCreate`: If true then this vehicle would be spawned (if supported by selected sim mode).
 - `RC`: This sub-element allows to specify which remote controller to use for vehicle using `RemoteControlID`. The value of -1 means use keyboard (not supported yet for multirotors). The value >= 0 specifies one of many remote controllers connected to the system. The list of available RCs can be seen in Game Controllers panel in Windows, for example.
 - `X, Y, Z, Yaw, Roll, Pitch`: These elements allows you to specify the initial position and orientation of the vehicle. Position is in NED coordinates in SI units with origin set to Player Start location in Unreal environment. The orientation is specified in degrees.
 - `IsFpvVehicle`: This setting allows to specify which vehicle camera will follow and the view that will be shown when ViewMode is set to Fpv. By default, AirSim selects the first vehicle in settings as FPV vehicle.
+- `Sensors`: This element specifies the sensors associated with the vehicle, see [Sensors page](sensors.md) for details.
 - `Cameras`: This element specifies camera settings for vehicle. The key in this element is name of the [available camera](image_apis.md#available_cameras) and the value is same as `CameraDefaults` as described above. For example, to change FOV for the front center camera to 120 degrees, you can use this for `Vehicles` setting:
 
 ```json
@@ -361,6 +362,10 @@ When communicating over UDP or TCP PX4 requires two separate channels.  If UseTc
 otherwise the TcpPort is used.  TCP support in PX4 was added in 1.9.2 with the `lockstep` feature because the guarantee of message delivery that
 TCP provides is required for the proper functioning of lockstep.  AirSim becomes a TCP server in that case, and waits for a connection
 from the PX4 app.  The second channel for controlling the vehicle is defined by (ControlIp, ControlPort) and is always a UDP channel.
+
+### Using ArduPilot
+
+[ArduPilot](https://ardupilot.org/) Copter & Rover vehicles are supported in latest AirSim master & releases `v1.3.0` and later. For settings and how to use, please see [ArduPilot SITL with AirSim](https://ardupilot.org/dev/docs/sitl-with-airsim.html)
 
 ## Other Settings
 

--- a/docs/unreal_custenv.md
+++ b/docs/unreal_custenv.md
@@ -4,18 +4,18 @@ This page contains the complete instructions start to finish for setting up Unre
 Below we will use a freely downloadable environment from Unreal Marketplace called Landscape Mountain but the steps are same for any other environments. You can also view these steps performed in [Unreal AirSim Setup Video](https://youtu.be/1oY8Qu5maQQ).
 
 ## Note for Linux Users
-There is no `Epic Games Launcher` for Linux which means that if you need to create custom environment, you will need Windows machine to do that. Once you have Unreal project folder, just copy it over to your Linux machine. 
+There is no `Epic Games Launcher` for Linux which means that if you need to create custom environment, you will need Windows machine to do that. Once you have Unreal project folder, just copy it over to your Linux machine.
 
 ## Step by Step Instructions
 
 1. Make sure AirSim is built and Unreal 4.24 is installed as described in [build instructions](build_windows.md).
 2. In `Epic Games Launcher` click the Learn tab then scroll down and find `Landscape Mountains`. Click the `Create Project` and download this content (~2GB download).
 
-![current version](images/landscape_mountains.png)
+    ![current version](images/landscape_mountains.png)
 
 3. Open `LandscapeMountains.uproject`, it should launch the Unreal Editor.
 
-![unreal editor](images/unreal_editor.png)
+    ![unreal editor](images/unreal_editor.png)
 
 4. From the `File menu` select `New C++ class`, leave default `None` on the type of class, click `Next`, leave default name `MyClass`, and click `Create Class`. We need to do this because Unreal requires at least one source file in project. It should trigger compile and open up Visual Studio solution `LandscapeMountains.sln`.
 
@@ -23,52 +23,52 @@ There is no `Epic Games Launcher` for Linux which means that if you need to crea
 
 6. Edit the `LandscapeMountains.uproject` so that it looks like this
 
-```
-{
-	"FileVersion": 3,
-	"EngineAssociation": "4.24",
-	"Category": "Samples",
-	"Description": "",
-	"Modules": [
-		{
-			"Name": "LandscapeMountains",
-			"Type": "Runtime",
-			"LoadingPhase": "Default",
-			"AdditionalDependencies": [
-				"AirSim"
-			]
-		}
-	],
-	"TargetPlatforms": [
-		"MacNoEditor",
-		"WindowsNoEditor"
-	],
-	"Plugins": [
-		{
-			"Name": "AirSim",
-			"Enabled": true
-		}
-	]
-}
-```
+    ```
+    {
+    	"FileVersion": 3,
+    	"EngineAssociation": "4.24",
+    	"Category": "Samples",
+    	"Description": "",
+    	"Modules": [
+    		{
+    			"Name": "LandscapeMountains",
+    			"Type": "Runtime",
+    			"LoadingPhase": "Default",
+    			"AdditionalDependencies": [
+    				"AirSim"
+    			]
+    		}
+    	],
+    	"TargetPlatforms": [
+    		"MacNoEditor",
+    		"WindowsNoEditor"
+    	],
+    	"Plugins": [
+    		{
+    			"Name": "AirSim",
+    			"Enabled": true
+    		}
+    	]
+    }
+    ```
 
 7. Close Visual Studio and the  `Unreal Editor` and right click the LandscapeMountains.uproject in Windows Explorer and select `Generate Visual Studio Project Files`.  This step detects all plugins and source files in your Unreal project and generates `.sln` file for Visual Studio.
 
-![regen](images/regen_sln.png)
+    ![regen](images/regen_sln.png)
 
-Tip: If the `Generate Visual Studio Project Files` option is missing you may need to reboot your machine for the Unreal Shell extensions to take effect.  If it is still missing then open the LandscapeMountains.uproject in the Unreal Editor and select `Refresh Visual Studio Project` from the `File` menu.
+    Tip: If the `Generate Visual Studio Project Files` option is missing you may need to reboot your machine for the Unreal Shell extensions to take effect.  If it is still missing then open the LandscapeMountains.uproject in the Unreal Editor and select `Refresh Visual Studio Project` from the `File` menu.
 
 8. Reopen `LandscapeMountains.sln` in Visual Studio, and make sure "DebugGame Editor" and "Win64" build configuration is the active build configuration.
 
-![build config](images/vsbuild_config.png)
+    ![build config](images/vsbuild_config.png)
 
 9. Press `F5` to `run`. This will start the Unreal Editor. The Unreal Editor allows you to edit the environment, assets and other game related settings. First thing you want to do in your environment is set up `PlayerStart` object. In Landscape Mountains environment, `PlayerStart` object already exist and you can find it in the `World Outliner`. Make sure its location is setup as shown. This is where AirSim plugin will create and place the vehicle. If its too high up then vehicle will fall down as soon as you press play giving potentially random behavior
 
-![lm_player_start_pos.png](images/lm_player_start_pos.png)
+    ![lm_player_start_pos.png](images/lm_player_start_pos.png)
 
 10. In `Window/World Settings` as shown below, set the `GameMode Override` to `AirSimGameMode`:
 
-![sim_game_mode.png](images/sim_game_mode.png)
+    ![sim_game_mode.png](images/sim_game_mode.png)
 
 11. Go to 'Edit->Editor Preferences' in Unreal Editor, in the 'Search' box type 'CPU' and ensure that the 'Use Less CPU when in Background' is unchecked. If you don't do this then UE will be slowed down dramatically when UE window loses focus.
 
@@ -90,7 +90,7 @@ Once you have your environment using above instructions, you should frequently u
 ## FAQ
 
 #### What are other cool environments?
-[Unreal Marketplace](https://www.unrealengine.com/marketplace) has dozens of prebuilt extra-ordinarily detailed [environments](https://www.unrealengine.com/marketplace/content-cat/assets/environments) ranging from Moon to Mars and everything in between. The one we have used for testing is called [Modular Neighborhood Pack](https://www.unrealengine.com/marketplace/modular-neighborhood-pack) 
+[Unreal Marketplace](https://www.unrealengine.com/marketplace) has dozens of prebuilt extra-ordinarily detailed [environments](https://www.unrealengine.com/marketplace/content-cat/assets/environments) ranging from Moon to Mars and everything in between. The one we have used for testing is called [Modular Neighborhood Pack](https://www.unrealengine.com/marketplace/modular-neighborhood-pack)
 but you can use any environment. Another free environment is [Infinity Blade series](https://www.unrealengine.com/marketplace/infinity-blade-plain-lands). Alternatively, if you look under the Learn tab in Epic Game Launcher, you will find many free samples that you can use. One of our favorites is "A Boy and His Kite" which is a 100 square miles of highly detailed environment (caution: you will need *very* beefy PC to run it!).
 
 #### When I press Play button some kind of video starts instead of my vehicle.
@@ -108,19 +108,18 @@ In this case, create a new blank C++ project with no Starter Content and add you
 #### I already have my own Unreal project. How do I use AirSim with it?
 Copy the `Unreal\Plugins` folder from the build you did in the above section into the root of your Unreal project's folder. In your Unreal project's .uproject file, add the key `AdditionalDependencies` to the "Modules" object
 as we showed in the `LandscapeMountains.uproject` above.
-   ```
+```
 "AdditionalDependencies": [
     "AirSim"
 ]
-   ```                
+```
+
 and the `Plugins` section to the top level object:
-   ```
-        "Plugins": [
-            {
-                "Name": "AirSim",
-                "Enabled": true
-            }
-        ]      
-  ```
-
-
+```
+"Plugins": [
+    {
+        "Name": "AirSim",
+        "Enabled": true
+    }
+]
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,7 +16,7 @@ theme:
 
 extra:
   highlightjs: true
-  version: 1.2.1
+  version: 1.3.1
   feature:
       tabs: true
   palette:
@@ -46,6 +46,7 @@ nav:
     - "Core APIs": 'apis.md'
     - "Image APIs": 'image_apis.md'
     - "C++ APIs": 'apis_cpp.md'
+    - "API Reference Docs": 'api_docs/html/index.html'
     - "Development Workflow": 'dev_workflow.md'
     - "Settings": 'settings.md'
     - "Camera Views": 'camera_views.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,19 +70,23 @@ nav:
     - "Flight Controller": 'flight_controller.md'
     - "Simple Flight": 'simple_flight.md'
     - "Hello Drone": 'hello_drone.md'
-  - "MavLink and PX4":
-    - "PX4 Setup for AirSim": 'px4_setup.md'
-    - "PX4 in SITL": 'px4_sitl.md'
-    - "AirSim with Pixhawk": 'https://youtu.be/1oY8Qu5maQQ'
-    - "PX4 Setup with AirSim": 'https://youtu.be/HNWdYrtw3f0'
-    - "Debugging Attitude Estimation": 'https://www.youtube.com/watch?v=d_FyjKDWQfc&feature=youtu.be'
-    - "Intercepting MavLink Messages": 'https://github.com/Microsoft/AirSim/wiki/Intercepting-MavLink-messages'
-    - "Rapid Descent on PX4 Drones": 'https://github.com/Microsoft/AirSim/wiki/Rapid-Descent-on-PX4-drones'
-    - "Building PX4": "px4_build.md"
-    - "PX4/MavLink Logging": 'px4_logging.md'
-    - "MavLink LogViewer": "log_viewer.md"
-    - "MavLinkCom": 'mavlinkcom.md'
-    - "MavLink MoCap": 'mavlinkcom_mocap.md'
+  - "External Flight Controllers":
+    - "MavLink and PX4":
+      - "PX4 Setup for AirSim": 'px4_setup.md'
+      - "PX4 in SITL": 'px4_sitl.md'
+      - "AirSim with Pixhawk": 'https://youtu.be/1oY8Qu5maQQ'
+      - "PX4 Setup with AirSim": 'https://youtu.be/HNWdYrtw3f0'
+      - "Debugging Attitude Estimation": 'https://www.youtube.com/watch?v=d_FyjKDWQfc&feature=youtu.be'
+      - "Intercepting MavLink Messages": 'https://github.com/Microsoft/AirSim/wiki/Intercepting-MavLink-messages'
+      - "Rapid Descent on PX4 Drones": 'https://github.com/Microsoft/AirSim/wiki/Rapid-Descent-on-PX4-drones'
+      - "Building PX4": "px4_build.md"
+      - "PX4/MavLink Logging": 'px4_logging.md'
+      - "MavLink LogViewer": "log_viewer.md"
+      - "MavLinkCom": 'mavlinkcom.md'
+      - "MavLink MoCap": 'mavlinkcom_mocap.md'
+    - "ArduPilot":
+      - "ArduPilot SITL Setup": "https://ardupilot.org/dev/docs/building-the-code.html"
+      - "AirSim & ArduPilot": "https://ardupilot.org/dev/docs/sitl-with-airsim.html"
   - "Upgrading":
     - "Upgrading Unreal": 'unreal_upgrade.md'
     - "Upgrading APIs": 'upgrade_apis.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ site_description: 'Open source simulator based on Unreal Engine for autonomous v
 markdown_extensions:
     - toc:
         permalink: "#"
+    - pymdownx.extra:
 
 remote_branch: gh-pages
 


### PR DESCRIPTION
1. Add Python API docs
2. Add links for ArduPilot usage (Closes #2686)
3. Update CHANGELOG.md
4. Add more info about Logs in FAQs 
5. Fix indentation
6. Note about installation in C drive (#2697)
7. Fix RL page link (closes #2745)
8. Add  [PyMarkdown extras extension](https://facelessuser.github.io/pymdown-extensions/extensions/extra/) - requires `pip install pymdown-extensions`

I'm not quite sure as to how to link to the html page from the markdown files other than just having it in the nav bar and mentioning in the markdown to go to them through the github.io page nav bar. Better ways to add it to the docs are very much welcome

The 5th commit fixes the code-blocks and FAQs ordering in https://microsoft.github.io/AirSim/build_linux/, and numbering of steps in https://microsoft.github.io/AirSim/unreal_custenv/
It, however, causes the content of .uproject in the custom env page to be like the ones in the Linux build page. I thought it's okay considering it fixes the step numbering which I think is more imp
Let me know if I should change it back

Edit: The above is no longer a problem, the `extras` extension contains `superfences` which handles fenced codeblocks, and gives a nice-looking border around them, do test it out!

Just using `build_docs.sh` and opening the `index.html` file will lead to links opening to the file server and not the html files directly. Run `mkdocs serve` to see how it will actually work