### PR TITLE
Allows to pass the settings.json file location via the --settings argument

### DIFF
--- a/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
@@ -357,9 +357,10 @@ bool ASimHUD::getSettingsText(std::string& settingsText)
         readSettingsTextFromFile(FString(msr::airlib::Settings::Settings::getUserDirectoryFullPath("settings.json").c_str()), settingsText));
 }
 
-// Attempts to parse the settings text from the command line
+// Attempts to parse the settings file path or the settings text from the command line
 // Looks for the flag "--settings". If it exists, settingsText will be set to the value.
-// Example: AirSim.exe -s '{"foo" : "bar"}' -> settingsText will be set to {"foo": "bar"}
+// Example (Path): AirSim.exe --settings "C:\path\to\settings.json"
+// Example (Text): AirSim.exe -s '{"foo" : "bar"}' -> settingsText will be set to {"foo": "bar"}
 // Returns true if the argument is present, false otherwise.
 bool ASimHUD::getSettingsTextFromCommandLine(std::string& settingsText) 
 {
@@ -372,6 +373,11 @@ bool ASimHUD::getSettingsTextFromCommandLine(std::string& settingsText)
         FString commandLineArgsFString = FString(commandLineArgs);
         int idx = commandLineArgsFString.Find(TEXT("-settings"));
         FString settingsJsonFString = commandLineArgsFString.RightChop(idx + 10);
+
+        if (readSettingsTextFromFile(settingsJsonFString.TrimQuotes(), settingsText)) {
+            return true;
+        }
+
         if (FParse::QuotedString(*settingsJsonFString, settingsTextFString)) {
             settingsText = std::string(TCHAR_TO_UTF8(*settingsTextFString));
             found = true;

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -4,11 +4,13 @@
 AirSim is searching for the settings definition in 4 different ways in the following order. The first match will be used:
 
 1. Looking at the (absolute) path specified by the `--settings` command line argument.  
-Example: `AirSim.exe --settings 'C:\path\to\settings.json'`
-2. Looking for a json document passed as a command line argument by the `--settings` argument.  
-Example: `AirSim.exe --settings '{"foo" : "bar"}'`
-3. Looking in the folder of the executable for a file called `settings.json`.
-3. Looking in the users home folder for a file called `settings.json`. The AirSim subfolder is located at `Documents\AirSim` on Windows and `~/Documents/AirSim` on Linux systems.
+For example, in Windows: `AirSim.exe --settings 'C:\path\to\settings.json'`   
+In Linux `./Blocks.sh --settings '/home/$USER/path/to/settings.json'`
+1. Looking for a json document passed as a command line argument by the `--settings` argument.  
+For example, in Windows: `AirSim.exe --settings '{"foo" : "bar"}'`   
+In Linux `./Blocks.sh --settings '{"foo" : "bar"}'`
+1. Looking in the folder of the executable for a file called `settings.json`.
+2. Looking in the users home folder for a file called `settings.json`. The AirSim subfolder is located at `Documents\AirSim` on Windows and `~/Documents/AirSim` on Linux systems.
 
 The file is in usual [json format](https://en.wikipedia.org/wiki/JSON). On first startup AirSim would create `settings.json` file with no settings at the users home folder. To avoid problems, always use ASCII format to save json file.
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,10 +1,16 @@
 # AirSim Settings
 
 ## Where are Settings Stored?
-Windows: `Documents\AirSim`
-Linux: `~/Documents/AirSim`
+AirSim is searching for the settings definition in 4 different ways in the following order. The first match will be used:
 
-The file is in usual [json format](https://en.wikipedia.org/wiki/JSON). On first startup AirSim would create `settings.json` file with no settings. To avoid problems, always use ASCII format to save json file.
+1. Looking at the (absolute) path specified by the `--settings` command line argument.  
+Example: `AirSim.exe --settings 'C:\path\to\settings.json'`
+2. Looking for a json document passed as a command line argument by the `--settings` argument.  
+Example: `AirSim.exe --settings '{"foo" : "bar"}'`
+3. Looking in the folder of the executable for a file called `settings.json`.
+3. Looking in the users home folder for a file called `settings.json`. The AirSim subfolder is located at `Documents\AirSim` on Windows and `~/Documents/AirSim` on Linux systems.
+
+The file is in usual [json format](https://en.wikipedia.org/wiki/JSON). On first startup AirSim would create `settings.json` file with no settings at the users home folder. To avoid problems, always use ASCII format to save json file.
 
 ## How to Chose Between Car and Multirotor?
 The default is to use multirotor. To use car simple set `"SimMode": "Car"` like this:


### PR DESCRIPTION
Allows to pass the settings.json file location via the --settings argument as a path in addition to passing its content.

Also updated documentation, which did not list the other loading possibilities added with #715.
