### PR TITLE
Reduced warning level in Unity build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ script:
       ./setup.sh;
       ./build.sh || travis_terminate 1;
       echo "Starting Unity Build!";
-      cd Unity && ./build.sh 2> Unity_error.txt || ((cat Unity_error.txt | grep -i "error:" -B 10 -A 10) && exit 1);
+      cd Unity && ./build.sh || travis_terminate 1;
     elif [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
       export PATH=$MSBUILD_PATH:$PATH_FIX:$PATH;
       cmd.exe //C 'C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvarsall.bat' amd64 '&&'
@@ -54,5 +54,5 @@ script:
       ./setup.sh;
       ./build.sh || travis_terminate 1;
       echo "Starting Unity Build!";
-      cd Unity && ./build.sh 2> Unity_error.txt || ((cat Unity_error.txt | grep -i "error:" -B 10 -A 10) && exit 1);
+      cd Unity && ./build.sh || travis_terminate 1;
     fi

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/Vehicles/Multirotor/SimModeWorldMultiRotor.h
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/Vehicles/Multirotor/SimModeWorldMultiRotor.h
@@ -19,7 +19,7 @@ public:
 	virtual void BeginPlay() override;
 	virtual void EndPlay() override;
 	void Tick(float DeltaSeconds) override;
-	UnityPawn* GetVehiclePawn();
+	UnityPawn* GetVehiclePawn() override;
 
 private:
 	typedef FlyingPawn TVehiclePawn;

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.h
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.h
@@ -18,7 +18,7 @@ public:
 	virtual void pause(bool is_paused) override;
 	virtual void continueForTime(double seconds) override;
     virtual void setTimeOfDay(bool is_enabled, const std::string& start_datetime, bool is_start_datetime_dst,
-            float celestial_clock_speed, float update_interval_secs, bool move_sun);
+            float celestial_clock_speed, float update_interval_secs, bool move_sun) override;
 
     virtual void enableWeather(bool enable) override;
     virtual void setWeatherParameter(WeatherParameter param, float val) override;

--- a/Unity/AirLibWrapper/AirsimWrapper/cmake/rpc-setup.cmake
+++ b/Unity/AirLibWrapper/AirsimWrapper/cmake/rpc-setup.cmake
@@ -268,7 +268,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
   # clang is the compiler used for developing mainly, so
   # this is where I set the highest warning level
   list(APPEND RPCLIB_BUILD_FLAGS
-    -Wall -pedantic -Weverything -Wno-c++98-compat
+    -Wall -Wextra -Wno-c++98-compat
     -Wno-c++98-compat-pedantic -Wno-padded -Wno-missing-prototypes
     -Wno-undef -pthread)
 

--- a/Unity/AirLibWrapper/AirsimWrapper/cmake/rpc-setup.cmake
+++ b/Unity/AirLibWrapper/AirsimWrapper/cmake/rpc-setup.cmake
@@ -125,7 +125,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
   # clang is the compiler used for developing mainly, so
   # this is where I set the highest warning level
   list(APPEND RPCLIB_BUILD_FLAGS
-    -Wall -pedantic -Weverything -Wno-c++98-compat
+    -Wall -Wextra -Wno-c++98-compat
     -Wno-c++98-compat-pedantic -Wno-padded -Wno-missing-prototypes
     -Wno-undef -pthread)
 


### PR DESCRIPTION
Attempts to address https://github.com/microsoft/AirSim/issues/2478 by removing `-Weverything` and using `-Wall -Wextra` to drive the Unity build process.

CC @rajat2004 