### PR TITLE
Adding airsim_node to install list

### DIFF
--- a/ros/src/airsim_ros_pkgs/CMakeLists.txt
+++ b/ros/src/airsim_ros_pkgs/CMakeLists.txt
@@ -102,6 +102,7 @@ target_link_libraries(pd_position_controller_simple_node pd_position_controller_
 
 install(TARGETS
     #list of nodes
+    airsim_node
     pd_position_controller_simple_node
     DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )


### PR DESCRIPTION
Adds the airsim_node to the list of targets to be installed. Without this, commands like ```roslaunch``` are unable to locate the executable in this package and fail.