### PR TITLE
[Travis] Add ROS compilation test, dependencies script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ script:
       ./setup.sh;
       ./build.sh || travis_terminate 1;
       echo "Starting Unity Build!";
-      cd Unity && ./build.sh || travis_terminate 1;
+      (cd Unity && ./build.sh || travis_terminate 1);
     elif [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
       export PATH=$MSBUILD_PATH:$PATH_FIX:$PATH;
       cmd.exe //C 'C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvarsall.bat' amd64 '&&'
@@ -48,5 +48,11 @@ script:
       ./setup.sh;
       ./build.sh || travis_terminate 1;
       echo "Starting Unity Build!";
-      cd Unity && ./build.sh || travis_terminate 1;
+      (cd Unity && ./build.sh || travis_terminate 1);
+    fi
+
+  # Test ROS wrapper compilation
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      ./tools/install_ros_deps.sh;
+      (cd ros && source ~/.bashrc && catkin build -DCMAKE_C_COMPILER=gcc-8 -DCMAKE_CXX_COMPILER=g++-8);
     fi

--- a/tools/install_ros_deps.sh
+++ b/tools/install_ros_deps.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -x
+
+DISTRO="$(lsb_release -sc)"
+if [[ "$DISTRO" == "bionic" ]]; then
+    ROS_DISTRO="melodic"
+elif [[ "$DISTRO" == "xenial" ]]; then
+    ROS_DISTRO="kinetic"
+fi
+
+sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
+sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+
+sudo apt update
+sudo apt install ros-$ROS_DISTRO-desktop-full
+
+echo "source /opt/ros/$ROS_DISTRO/setup.bash" >> ~/.bashrc
+
+sudo apt install python-rosdep python-rosinstall python-rosinstall-generator python-wstool build-essential
+sudo rosdep init
+rosdep update
+
+# AirSim ROS Wrapper dependencies
+
+if [[ "$DISTRO" == "xenial" ]]; then
+    sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+    sudo apt-get update
+fi
+
+sudo apt-get install gcc-8 g++-8
+sudo apt-get install ros-$ROS_DISTRO-mavros*
+sudo apt-get install python-catkin-tools


### PR DESCRIPTION
Came to mind when working on #2710

Should the AirSim dependencies be separated into a different script? Don't think there's much of a need for this, but let me know if that's better