### PR TITLE
Auto-build docs from master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ before_install:
       sudo apt-get update;
       sudo apt-get -y install git wget unzip;
       sudo apt-get -y install build-essential software-properties-common cmake rsync libboost-all-dev;
+      sudo apt-get -y install python3 python3-pip python3-setuptools python3-wheel;
+      pip3 install mkdocs Sphinx sphinx_rtd_theme pymdown-extensions numpy msgpack-rpc-python;
     elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       echo "No before_install actions for OSX";
     elif [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
@@ -56,3 +58,14 @@ script:
       ./tools/install_ros_deps.sh;
       (cd ros && source ~/.bashrc && catkin build -DCMAKE_C_COMPILER=gcc-8 -DCMAKE_CXX_COMPILER=g++-8);
     fi
+
+after_success:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      ./build_docs.sh;
+    fi
+
+deploy:
+  - provider: script
+    script: bash deploy_docs.sh
+    on:
+      branch: master

--- a/PythonClient/docs/conf.py
+++ b/PythonClient/docs/conf.py
@@ -15,6 +15,7 @@
 import os
 import sys
 sys.path.insert(0, os.path.abspath('..'))
+sys.path.append(os.path.abspath('../airsim'))
 
 import sphinx_rtd_theme
 


### PR DESCRIPTION
Commits picked from #2658

Needs work by the maintainers to add script with tokens, etc

From the linked PR comments - 

Added a commit which runs a currently non-existent `deploy_docs.sh` script on Travis master
I'm not sure of how the docs are updated, but probably `mkdocs gh-deploy` isn't used since it erases all history on the branch.

Maybe something like https://github.com/mkdocs/mkdocs/pull/1082? I went for Travis instead of a Github Action since we also Sphinx in the mix to build the Python API docs
There are several other ways to write the script, just need to find one which works best

Useful blog post - https://tech.michaelaltfield.net/2020/07/18/sphinx-rtd-github-pages-1/

Travis setup needs to be looked at