### PR TITLE
Build Improvements

### DIFF
--- a/Unity/build.sh
+++ b/Unity/build.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 set -x
-# set -e
+set -e
 
 # check for rpclib
 if [ ! -f ../external/rpclib/rpclib-2.2.1/rpclib.pc.in ]; then

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,6 @@
 #! /bin/bash
 set -x
+set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 pushd "$SCRIPT_DIR" >/dev/null
@@ -78,14 +79,14 @@ else #linux
     sudo apt-get install -y unzip
 fi
 
-# in ubuntu 18 docker CI, avoid building cmake from scratch to save time 
+# in ubuntu 18 docker CI, avoid building cmake from scratch to save time
 # ref: https://apt.kitware.com/
-if [ "$(uname)" == "Linux" ]; then 
+if [ "$(uname)" == "Linux" ]; then
     if [[ $(lsb_release -rs) == "18.04" ]]; then
         sudo apt-get -y install \
             apt-transport-https \
             ca-certificates \
-            gnupg 
+            gnupg
         wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
         sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
         sudo apt-get -y install --no-install-recommends \
@@ -126,7 +127,7 @@ if [ ! -d "external/rpclib/rpclib-2.2.1" ]; then
     rm -rf "external/rpclib"
 
     mkdir -p "external/rpclib"
-    unzip v2.2.1.zip -d external/rpclib
+    unzip -q v2.2.1.zip -d external/rpclib
     rm v2.2.1.zip
 fi
 
@@ -150,7 +151,7 @@ if $downloadHighPolySuv; then
             if [ -d "../Unreal/Plugins/AirSim/Content/VehicleAdv/SUV" ]; then
                 rm -rf "../Unreal/Plugins/AirSim/Content/VehicleAdv/SUV"
             fi
-            unzip car_assets.zip -d ../Unreal/Plugins/AirSim/Content/VehicleAdv
+            unzip -q car_assets.zip -d ../Unreal/Plugins/AirSim/Content/VehicleAdv
             cd ..
             rm -rf "suv_download_tmp"
     fi
@@ -163,7 +164,7 @@ echo "Installing Eigen library..."
 if [ ! -d "AirLib/deps/eigen3" ]; then
     echo "Downloading Eigen..."
     wget -O eigen3.zip https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.zip
-    unzip eigen3.zip -d temp_eigen
+    unzip -q eigen3.zip -d temp_eigen
     mkdir -p AirLib/deps/eigen3
     mv temp_eigen/eigen*/Eigen AirLib/deps/eigen3
     rm -rf temp_eigen


### PR DESCRIPTION
1. setup.sh: Exit script immediately if command exits, unzip quietly (reduces output quite a bit on Travis)
2. Unity: exit script immediately if build fails (Now Linux builds will also fail)

Fixes #2759
