### PR TITLE
XBox Controller fix

### DIFF
--- a/Unreal/Plugins/AirSim/Source/SimJoyStick/SimJoyStick.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimJoyStick/SimJoyStick.cpp
@@ -316,7 +316,7 @@ public:
                     else { //XBox
                         switch(event_.number) {
                         case 0: state.left_x = normalizeAxisVal(event_.value, true, false, false); break;
-                        case 1: state.left_y = normalizeAxisVal(event_.value, false, true, true); break;
+                        case 1: state.left_y = normalizeAxisVal(event_.value, true, false, true); break;
                         case 2: state.left_z = normalizeAxisVal(event_.value, true, false, false); break;
                         case 3: state.right_x = normalizeAxisVal(event_.value, true, false, false); break;
                         case 4: state.right_y = normalizeAxisVal(event_.value, true, false, false); break;


### PR DESCRIPTION
Fixes #2768 
Pending testing from @agentfeux

Zero2One conversion is being done here - https://github.com/microsoft/AirSim/blob/master/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp#L227
Before this PR, it was changing an already 0-1 value to 0-1, so it introduced a positive offset

This change won't affect Win since it's kept behind #ifdefs