### PR TITLE
Distance sensor Upgrades

### DIFF
--- a/AirLib/include/api/RpcLibAdapatorsBase.hpp
+++ b/AirLib/include/api/RpcLibAdapatorsBase.hpp
@@ -672,7 +672,7 @@ public:
         DistanceSensorData()
         {}
 
-        DistanceSensorData(const msr::airlib::DistanceBase::Output& s)
+        DistanceSensorData(const msr::airlib::DistanceSensorData& s)
         {
             time_stamp = s.time_stamp;
             distance = s.distance;
@@ -681,9 +681,9 @@ public:
             relative_pose = s.relative_pose;
         }
 
-        msr::airlib::DistanceBase::Output to() const
+        msr::airlib::DistanceSensorData to() const
         {
-            msr::airlib::DistanceBase::Output d;
+            msr::airlib::DistanceSensorData d;
 
             d.time_stamp = time_stamp;
             d.distance = distance;

--- a/AirLib/include/api/RpcLibClientBase.hpp
+++ b/AirLib/include/api/RpcLibClientBase.hpp
@@ -84,7 +84,7 @@ public:
     msr::airlib::BarometerBase::Output getBarometerData(const std::string& barometer_name = "", const std::string& vehicle_name = "") const;
     msr::airlib::MagnetometerBase::Output getMagnetometerData(const std::string& magnetometer_name = "", const std::string& vehicle_name = "") const;
     msr::airlib::GpsBase::Output getGpsData(const std::string& gps_name = "", const std::string& vehicle_name = "") const;
-    msr::airlib::DistanceBase::Output getDistanceSensorData(const std::string& distance_sensor_name = "", const std::string& vehicle_name = "") const;
+    msr::airlib::DistanceSensorData getDistanceSensorData(const std::string& distance_sensor_name = "", const std::string& vehicle_name = "") const;
 
     // sensor omniscient APIs
     vector<int> simGetLidarSegmentation(const std::string& lidar_name = "", const std::string& vehicle_name = "") const;

--- a/AirLib/include/api/VehicleApiBase.hpp
+++ b/AirLib/include/api/VehicleApiBase.hpp
@@ -215,7 +215,7 @@ public:
     }
 
     // Distance Sensor API
-    virtual DistanceBase::Output getDistanceSensorData(const std::string& distance_sensor_name) const
+    virtual DistanceSensorData getDistanceSensorData(const std::string& distance_sensor_name) const
     {
         const DistanceBase* distance_sensor = nullptr;
 

--- a/AirLib/include/common/AirSimSettings.hpp
+++ b/AirLib/include/common/AirSimSettings.hpp
@@ -196,6 +196,12 @@ public: //types
     };
 
     struct DistanceSetting : SensorSetting {
+        // shared defaults
+        real_T min_distance = 20.0f / 100; //m
+        real_T max_distance = 4000.0f / 100; //m
+        Vector3r position = VectorMath::nanVector();
+        Rotation rotation = Rotation::nanRotation();
+        bool draw_debug_points = false;
     };
 
     struct LidarSetting : SensorSetting {
@@ -1161,10 +1167,12 @@ private:
 
     static void initializeDistanceSetting(DistanceSetting& distance_setting, const Settings& settings_json)
     {
-        unused(distance_setting);
-        unused(settings_json);
+        distance_setting.min_distance = settings_json.getFloat("MinDistance", distance_setting.min_distance);
+        distance_setting.max_distance = settings_json.getFloat("MaxDistance", distance_setting.max_distance);
+        distance_setting.draw_debug_points = settings_json.getBool("DrawDebugPoints", distance_setting.draw_debug_points);
 
-        //TODO: set from json as needed
+        distance_setting.position = createVectorSetting(settings_json, distance_setting.position);
+        distance_setting.rotation = createRotationSetting(settings_json, distance_setting.rotation);
     }
 
     static void initializeLidarSetting(LidarSetting& lidar_setting, const Settings& settings_json)

--- a/AirLib/include/common/CommonStructs.hpp
+++ b/AirLib/include/common/CommonStructs.hpp
@@ -304,6 +304,17 @@ struct LidarData {
     {}
 };
 
+struct DistanceSensorData {
+    TTimePoint time_stamp;
+    real_T distance;        //meters
+    real_T min_distance;    //m
+    real_T max_distance;    //m
+    Pose relative_pose;
+
+    DistanceSensorData()
+    {}
+};
+
 struct MeshPositionVertexBuffersResponse {
     Vector3r position;
     Quaternionr orientation;

--- a/AirLib/include/sensors/distance/DistanceBase.hpp
+++ b/AirLib/include/sensors/distance/DistanceBase.hpp
@@ -16,16 +16,6 @@ public:
         : SensorBase(sensor_name)
     {}
 
-public: //types
-    struct Output { //same fields as ROS message
-        TTimePoint time_stamp;
-        real_T distance;    //meters
-        real_T min_distance;//m
-        real_T max_distance;//m
-        Pose relative_pose;
-    };
-
-
 public:
     virtual void reportState(StateReporter& reporter) override
     {
@@ -35,20 +25,20 @@ public:
         reporter.writeValue("Dist-Curr", output_.distance);
     }
 
-    const Output& getOutput() const
+    const DistanceSensorData& getOutput() const
     {
         return output_;
     }
 
 protected:
-    void setOutput(const Output& output)
+    void setOutput(const DistanceSensorData& output)
     {
         output_ = output;
     }
 
 
 private:
-    Output output_;
+    DistanceSensorData output_;
 };
 
 

--- a/AirLib/include/sensors/distance/DistanceSimple.hpp
+++ b/AirLib/include/sensors/distance/DistanceSimple.hpp
@@ -14,7 +14,7 @@
 
 namespace msr { namespace airlib {
 
-class DistanceSimple  : public DistanceBase {
+class DistanceSimple : public DistanceBase {
 public:
     DistanceSimple(const AirSimSettings::DistanceSetting& setting = AirSimSettings::DistanceSetting())
         : DistanceBase(setting.sensor_name)
@@ -62,17 +62,18 @@ public:
 
     virtual ~DistanceSimple() = default;
 
-protected:
-    virtual real_T getRayLength(const Pose& pose) = 0;
-    const DistanceSimpleParams& getParams()
+    const DistanceSimpleParams& getParams() const
     {
         return params_;
     }
 
+protected:
+    virtual real_T getRayLength(const Pose& pose) = 0;
+
 private: //methods
-    Output getOutputInternal()
+    DistanceSensorData getOutputInternal()
     {
-        Output output;
+        DistanceSensorData output;
         const GroundTruth& ground_truth = getGroundTruth();
 
         //order of Pose addition is important here because it also adds quaternions which is not commutative!
@@ -97,7 +98,7 @@ private:
     RandomGeneratorGausianR uncorrelated_noise_;
 
     FrequencyLimiter freq_limiter_;
-    DelayLine<Output> delay_line_;
+    DelayLine<DistanceSensorData> delay_line_;
 
     //start time
 };

--- a/AirLib/include/sensors/distance/DistanceSimpleParams.hpp
+++ b/AirLib/include/sensors/distance/DistanceSimpleParams.hpp
@@ -14,9 +14,13 @@ namespace msr { namespace airlib {
 struct DistanceSimpleParams {
     real_T min_distance = 20.0f / 100; //m
     real_T max_distance = 4000.0f / 100; //m
-    Pose relative_pose;
 
-    bool draw_debug_points = true;
+    Pose relative_pose {
+        Vector3r(0,0,-1),           // position - a little above vehicle (especially for cars) or Vector3r::Zero()
+        Quaternionr::Identity()     // orientation - by default Quaternionr(1, 0, 0, 0)
+    };
+
+    bool draw_debug_points = false;
 
 /*
     Ref: A Stochastic Approach to Noise Modeling for Barometric Altimeters
@@ -42,7 +46,33 @@ struct DistanceSimpleParams {
 
     void initializeFromSettings(const AirSimSettings::DistanceSetting& settings)
     {
-        unused(settings);
+        std::string simmode_name = AirSimSettings::singleton().simmode_name;
+
+        min_distance = settings.min_distance;
+        max_distance = settings.max_distance;
+
+        draw_debug_points = settings.draw_debug_points;
+
+        relative_pose.position = settings.position;
+        if (std::isnan(relative_pose.position.x()))
+            relative_pose.position.x() = 0;
+        if (std::isnan(relative_pose.position.y()))
+            relative_pose.position.y() = 0;
+        if (std::isnan(relative_pose.position.z())) {
+            if (simmode_name == "Multirotor")
+                relative_pose.position.z() = 0;
+            else
+                relative_pose.position.z() = -1;  // a little bit above for cars
+        }
+
+        float pitch, roll, yaw;
+        pitch = !std::isnan(settings.rotation.pitch) ? settings.rotation.pitch : 0;
+        roll = !std::isnan(settings.rotation.roll) ? settings.rotation.roll : 0;
+        yaw = !std::isnan(settings.rotation.yaw) ? settings.rotation.yaw : 0;
+        relative_pose.orientation = VectorMath::toQuaternion(
+            Utils::degreesToRadians(pitch),   //pitch - rotation around Y axis
+            Utils::degreesToRadians(roll),    //roll  - rotation around X axis
+            Utils::degreesToRadians(yaw));    //yaw   - rotation around Z axis
     }
 };
 

--- a/AirLib/include/sensors/distance/DistanceSimpleParams.hpp
+++ b/AirLib/include/sensors/distance/DistanceSimpleParams.hpp
@@ -16,6 +16,8 @@ struct DistanceSimpleParams {
     real_T max_distance = 4000.0f / 100; //m
     Pose relative_pose;
 
+    bool draw_debug_points = true;
+
 /*
     Ref: A Stochastic Approach to Noise Modeling for Barometric Altimeters
      Angelo Maria Sabatini* and Vincenzo Genovese

--- a/AirLib/src/api/RpcLibClientBase.cpp
+++ b/AirLib/src/api/RpcLibClientBase.cpp
@@ -184,7 +184,7 @@ msr::airlib::GpsBase::Output RpcLibClientBase::getGpsData(const std::string& gps
     return pimpl_->client.call("getGpsData", gps_name, vehicle_name).as<RpcLibAdapatorsBase::GpsData>().to();
 }
 
-msr::airlib::DistanceBase::Output RpcLibClientBase::getDistanceSensorData(const std::string& distance_sensor_name, const std::string& vehicle_name) const
+msr::airlib::DistanceSensorData RpcLibClientBase::getDistanceSensorData(const std::string& distance_sensor_name, const std::string& vehicle_name) const
 {
     return pimpl_->client.call("getDistanceSensorData", distance_sensor_name, vehicle_name).as<RpcLibAdapatorsBase::DistanceSensorData>().to();
 }

--- a/PythonClient/airsim/types.py
+++ b/PythonClient/airsim/types.py
@@ -400,9 +400,9 @@ class GpsData(MsgpackMixin):
 
 class DistanceSensorData(MsgpackMixin):
     time_stamp = np.uint64(0)
-    distance = Quaternionr()
-    min_distance = Quaternionr()
-    max_distance = Quaternionr()
+    distance = 0.0
+    min_distance = 0.0
+    max_distance = 0.0
     relative_pose = Pose()
 
 class PIDGains():

--- a/PythonClient/car/distance_sensor_multi.py
+++ b/PythonClient/car/distance_sensor_multi.py
@@ -1,0 +1,49 @@
+import airsim
+import time
+
+'''
+An example script showing usage of Distance sensor to measure distance between 2 Car vehicles
+Settings -
+
+{
+  "SettingsVersion": 1.2,
+  "SimMode": "Car",
+  "Vehicles": {
+    "Car1": {
+      "VehicleType": "PhysXCar",
+      "AutoCreate": true,
+      "Sensors": {
+        "Distance": {
+            "SensorType": 5,
+            "Enabled" : true,
+            "DrawDebugPoints": true
+        }
+      }
+    },
+    "Car2": {
+        "VehicleType": "PhysXCar",
+        "AutoCreate": true,
+        "X": 10, "Y": 0, "Z": 0,
+        "Sensors": {
+            "Distance": {
+                "SensorType": 5,
+                "Enabled" : true,
+                "DrawDebugPoints": true
+            }
+        }
+    }
+  }
+}
+
+Car2 is placed in front of Car 1
+
+'''
+
+client = airsim.CarClient()
+client.confirmConnection()
+
+while True:
+    data_car1 = client.getDistanceSensorData(vehicle_name="Car1")
+    data_car2 = client.getDistanceSensorData(vehicle_name="Car2")
+    print(f"Distance sensor data: Car1: {data_car1.distance}, Car2: {data_car2.distance}")
+    time.sleep(1.0)

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.h
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.h
@@ -128,6 +128,10 @@ private:
     typedef msr::airlib::ClockFactory ClockFactory;
     typedef msr::airlib::TTimePoint TTimePoint;
     typedef msr::airlib::TTimeDelta TTimeDelta;
+    typedef msr::airlib::SensorBase::SensorType SensorType;
+    typedef msr::airlib::Vector3r Vector3r;
+    typedef msr::airlib::Pose Pose;
+    typedef msr::airlib::VectorMath VectorMath;
 
 private:
     //assets loaded in constructor
@@ -170,4 +174,5 @@ private:
     void setupPhysicsLoopPeriod();
     void showClockStats();
     void drawLidarDebugPoints();
+    void drawDistanceSensorDebugPoints();
 };

--- a/docs/sensors.md
+++ b/docs/sensors.md
@@ -35,7 +35,7 @@ Behind the scenes, `createDefaultSensorSettings` method in [AirSimSettings.hpp](
 
 The default sensor list can be configured in settings json:
 
-```JSON
+```json
 "DefaultSensors": {
     "Barometer": {
          "SensorType": 1,
@@ -72,7 +72,7 @@ If a vehicle provides its sensor list, it **must** provide the whole list. Selec
 A vehicle specific sensor list can be specified in the vehicle settings part of the json.
 e.g.,
 
-```
+```json
     "Vehicles": {
 
         "Drone1": {
@@ -105,6 +105,44 @@ e.g.,
 Each sensor-type has its own set of settings as well.
 Please see [lidar](lidar.md) for example of Lidar specific settings.
 
+#### Distance Sensor
+
+By default, Distance Sensor points to the front of the vehicle. It can be pointed in any direction by modifying the settings
+
+Configurable Parameters -
+
+Parameter        | Description
+-----------------|------------
+X Y Z            | Position of the sensor relative to the vehicle (in NED, in meters) (Default (0,0,0)-Multirotor, (0,0,-1)-Car)
+Yaw Pitch Roll   | Orientation of the sensor relative to the vehicle (degrees) (Default (0,0,0))
+MinDistance      | Minimum distance measured by distance sensor (metres, only used to fill Mavlink message for PX4) (Default 0.2m)
+MaxDistance      | Maximum distance measured by distance sensor (metres) (Default 40.0m)
+
+For example, to make the sensor point towards the ground (for altitude measurement similar to barometer), the orientation can be modified as follows -
+
+```json
+"Distance": {
+    "SensorType": 5,
+    "Enabled" : true,
+    "Yaw": 0, "Pitch": -90, "Roll": 0
+}
+```
+
+**Note:** For Cars, the sensor is placed 1 meter above the vehicle center by default. This is required since otherwise the sensor gives strange data due it being inside the vehicle. This doesn't affect the sensor values say when measuring the distance between 2 cars. See [`PythonClient/car/distance_sensor_multi.py`](https://github.com/Microsoft/AirSim/blob/master/PythonClient/car/distance_sensor_multi.py) for an example usage.
+
+##### Server side visualization for debugging
+
+Be default, the points hit by distance sensor are not drawn on the viewport. To enable the drawing of hit points on the viewport, please enable setting `DrawDebugPoints` via settings json. E.g. -
+
+```json
+"Distance": {
+    "SensorType": 5,
+    "Enabled" : true,
+    ...
+    "DrawDebugPoints": true
+}
+```
+
 ## Sensor APIs
 Jump straight to [`hello_drone.py`](https://github.com/Microsoft/AirSim/blob/master/PythonClient/multirotor/hello_drone.py) or [`hello_drone.cpp`](https://github.com/Microsoft/AirSim/blob/master/HelloDrone/main.cpp) for example usage, or see follow below for the full API.
 
@@ -117,7 +155,7 @@ Jump straight to [`hello_drone.py`](https://github.com/Microsoft/AirSim/blob/mas
 
     Python
     ```python
-    barometer_data = getBarometerData(barometer_name = "", vehicle_name = "")
+    barometer_data = client.getBarometerData(barometer_name = "", vehicle_name = "")
     ```
 
 - IMU
@@ -129,7 +167,7 @@ Jump straight to [`hello_drone.py`](https://github.com/Microsoft/AirSim/blob/mas
 
     Python
     ```python
-    imu_data = getImuData(imu_name = "", vehicle_name = "")
+    imu_data = client.getImuData(imu_name = "", vehicle_name = "")
     ```
 
 - GPS
@@ -140,7 +178,7 @@ Jump straight to [`hello_drone.py`](https://github.com/Microsoft/AirSim/blob/mas
     ```
     Python
     ```python
-    gps_data = getGpsData(gps_name = "", vehicle_name = "")
+    gps_data = client.getGpsData(gps_name = "", vehicle_name = "")
     ```
 
 - Magnetometer
@@ -151,18 +189,18 @@ Jump straight to [`hello_drone.py`](https://github.com/Microsoft/AirSim/blob/mas
     ```
     Python
     ```python
-    magnetometer_data = getMagnetometerData(magnetometer_name = "", vehicle_name = "")
+    magnetometer_data = client.getMagnetometerData(magnetometer_name = "", vehicle_name = "")
     ```
 
 - Distance sensor
 
     C++
     ```cpp
-    msr::airlib::DistanceBase::Output getDistanceSensorData(const std::string& distance_sensor_name = "", const std::string& vehicle_name = "");
+    msr::airlib::DistanceSensorData getDistanceSensorData(const std::string& distance_sensor_name = "", const std::string& vehicle_name = "");
     ```
     Python
     ```python
-    distance_sensor_name = getDistanceSensorData(distance_sensor_name = "", vehicle_name = "")
+    distance_sensor_data = client.getDistanceSensorData(distance_sensor_name = "", vehicle_name = "")
     ```
 
 - Lidar

--- a/ros/src/airsim_ros_pkgs/include/airsim_ros_wrapper.h
+++ b/ros/src/airsim_ros_pkgs/include/airsim_ros_wrapper.h
@@ -11,7 +11,6 @@ STRICT_MODE_ON
 #include "common/common_utils/FileSystem.hpp"
 #include "ros/ros.h"
 #include "sensors/imu/ImuBase.hpp"
-#include "sensors/distance/DistanceBase.hpp"
 #include "vehicles/multirotor/api/MultirotorRpcLibClient.hpp"
 #include "vehicles/car/api/CarRpcLibClient.hpp"
 #include "yaml-cpp/yaml.h"
@@ -286,7 +285,7 @@ private:
     sensor_msgs::NavSatFix get_gps_sensor_msg_from_airsim_geo_point(const msr::airlib::GeoPoint& geo_point) const;
     sensor_msgs::Imu get_imu_msg_from_airsim(const msr::airlib::ImuBase::Output& imu_data) const;
     airsim_ros_pkgs::Altimeter get_altimeter_msg_from_airsim(const msr::airlib::BarometerBase::Output& alt_data) const;
-    sensor_msgs::Range get_range_from_airsim(const msr::airlib::DistanceBase::Output& dist_data) const;
+    sensor_msgs::Range get_range_from_airsim(const msr::airlib::DistanceSensorData& dist_data) const;
     sensor_msgs::PointCloud2 get_lidar_msg_from_airsim(const msr::airlib::LidarData& lidar_data, const std::string& vehicle_name) const;
     sensor_msgs::NavSatFix get_gps_msg_from_airsim(const msr::airlib::GpsBase::Output& gps_data) const;
     sensor_msgs::MagneticField get_mag_msg_from_airsim(const msr::airlib::MagnetometerBase::Output& mag_data) const;

--- a/ros/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
+++ b/ros/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
@@ -851,7 +851,7 @@ sensor_msgs::NavSatFix AirsimROSWrapper::get_gps_msg_from_airsim(const msr::airl
     return gps_msg;
 }
 
-sensor_msgs::Range AirsimROSWrapper::get_range_from_airsim(const msr::airlib::DistanceBase::Output& dist_data) const
+sensor_msgs::Range AirsimROSWrapper::get_range_from_airsim(const msr::airlib::DistanceSensorData& dist_data) const
 {
     sensor_msgs::Range dist_msg;
     dist_msg.header.stamp = airsim_timestamp_to_ros(dist_data.time_stamp);


### PR DESCRIPTION
1. Add setting for drawing debug point with Distance Sensor
2. Expose Distance sensor settings, also move sensor above Car vehicle by 1 meter by default 
3. Fix `DistanceSensorData` struct in `types.py` (Should be float, not Quaternion)
4. Update docs
5. Use Custom sensor orientation in Mavlink Distance Sensor message (Needs testing with PX4)
6. ROS wrapper change
7. Example script for Distance sensor with 2 cars

Default sensor-
![Screenshot from 2020-06-28 08-42-07](https://user-images.githubusercontent.com/37938604/85936816-bdee7b80-b91b-11ea-8cf3-c9b27af22f01.png)

Downward-facing (altitude measurement)-
![Screenshot from 2020-06-28 11-35-03](https://user-images.githubusercontent.com/37938604/85939648-e767d100-b934-11ea-8b2a-302c26dad9db.png)

2 Cars with distance sensor
![Screenshot from 2020-07-24 10-30-09](https://user-images.githubusercontent.com/37938604/88362107-efcaf480-cd98-11ea-9316-e1fe109ea4fc.png)

Closes #2723, closes #2806
Related issues - #2444, #1029

Question: Should there be fields in settings for other params such as `update_frequency`, noise, etc? Currently haven't added those