### PR TITLE
Remove workaround for empty struct in RPC

### DIFF
--- a/AirLib/include/api/RpcLibAdapatorsBase.hpp
+++ b/AirLib/include/api/RpcLibAdapatorsBase.hpp
@@ -405,12 +405,6 @@ public:
             image_data_uint8 = s.image_data_uint8;
             image_data_float = s.image_data_float;
 
-            //TODO: remove bug workaround for https://github.com/rpclib/rpclib/issues/152
-            if (image_data_uint8.size() == 0)
-                image_data_uint8.push_back(0);
-            if (image_data_float.size() == 0)
-                image_data_float.push_back(0);
-
             camera_name = s.camera_name;
             camera_position = Vector3r(s.camera_position);
             camera_orientation = Quaternionr(s.camera_orientation);
@@ -481,11 +475,6 @@ public:
         {
             time_stamp = s.time_stamp;
             point_cloud = s.point_cloud;
-
-            //TODO: remove bug workaround for https://github.com/rpclib/rpclib/issues/152
-            if (point_cloud.size() == 0)
-                point_cloud.push_back(0);
-
             pose = s.pose;
         }
 

--- a/AirLib/src/api/RpcLibServerBase.cpp
+++ b/AirLib/src/api/RpcLibServerBase.cpp
@@ -128,12 +128,7 @@ RpcLibServerBase::RpcLibServerBase(ApiProvider* api_provider, const std::string&
             return RpcLibAdapatorsBase::ImageResponse::from(response);
     });
     pimpl_->server.bind("simGetImage", [&](const std::string& camera_name, ImageCaptureBase::ImageType type, const std::string& vehicle_name) -> vector<uint8_t> {
-        auto result = getVehicleSimApi(vehicle_name)->getImage(camera_name, type);
-        if (result.size() == 0) {
-            // rpclib has a bug with serializing empty vectors, so we return a 1 byte vector instead.
-            result.push_back(0);
-        }
-        return result;
+        return getVehicleSimApi(vehicle_name)->getImage(camera_name, type);
     });
 
     pimpl_->server.bind("simGetMeshPositionVertexBuffers", [&]() ->vector<RpcLibAdapatorsBase::MeshPositionVertexBuffersResponse> {


### PR DESCRIPTION
https://github.com/rpclib/rpclib/issues/152 has been fixed
Testing was with #2810 where empty Lidar data was produced sometimes, no crash, and can be checked easily in Python e.g.
`if not lidar_data.point_cloud:`