### PR TITLE
Add Vehicle option for Subwindow settings

### DIFF
--- a/AirLib/include/common/AirSimSettings.hpp
+++ b/AirLib/include/common/AirSimSettings.hpp
@@ -40,9 +40,12 @@ public: //types
         ImageType image_type;
         bool visible;
         std::string camera_name;
+        std::string vehicle_name;
 
-        SubwindowSetting(int window_index_val = 0, ImageType image_type_val = ImageType::Scene, bool visible_val = false, const std::string& camera_name_val = "")
-            : window_index(window_index_val), image_type(image_type_val), visible(visible_val), camera_name(camera_name_val)
+        SubwindowSetting(int window_index_val = 0, ImageType image_type_val = ImageType::Scene, 
+                bool visible_val = false, const std::string& camera_name_val = "", const std::string& vehicle_name_val = "")
+            : window_index(window_index_val), image_type(image_type_val), 
+              visible(visible_val), camera_name(camera_name_val), vehicle_name(vehicle_name_val)
         {
         }
     };
@@ -1002,6 +1005,7 @@ private:
                         json_settings_child.getInt("ImageType", 0));
                     subwindow_setting.visible = json_settings_child.getBool("Visible", false);
                     subwindow_setting.camera_name = getCameraName(json_settings_child);
+                    subwindow_setting.vehicle_name = json_settings_child.getString("VehicleName", "");
                 }
             }
         }
@@ -1010,9 +1014,9 @@ private:
     static void initializeSubwindowSettings(std::vector<SubwindowSetting>& subwindow_settings)
     {
         subwindow_settings.clear();
-        subwindow_settings.push_back(SubwindowSetting(0, ImageType::DepthVis, false, "")); //depth
-        subwindow_settings.push_back(SubwindowSetting(0, ImageType::Segmentation, false, "")); //seg
-        subwindow_settings.push_back(SubwindowSetting(0, ImageType::Scene, false, "")); //vis
+        subwindow_settings.push_back(SubwindowSetting(0, ImageType::DepthVis, false, "", "")); //depth
+        subwindow_settings.push_back(SubwindowSetting(1, ImageType::Segmentation, false, "", "")); //seg
+        subwindow_settings.push_back(SubwindowSetting(2, ImageType::Scene, false, "", "")); //vis
     }
 
     void loadOtherSettings(const Settings& settings_json)

--- a/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
@@ -323,20 +323,25 @@ void ASimHUD::initializeSubWindows()
         }
         else
             subwindow_cameras_[0] = subwindow_cameras_[1] = subwindow_cameras_[2] = nullptr;
+    }
 
+    for (size_t window_index = 0; window_index < AirSimSettings::kSubwindowCount; ++window_index) {
 
-        for (size_t window_index = 0; window_index < AirSimSettings::kSubwindowCount; ++window_index) {
+        const auto& subwindow_setting = AirSimSettings::singleton().subwindow_settings.at(window_index);
+        auto vehicle_sim_api = simmode_->getVehicleSimApi(subwindow_setting.vehicle_name);
 
-            const auto& subwindow_setting = AirSimSettings::singleton().subwindow_settings.at(window_index);
-
+        if (vehicle_sim_api) {
             if (vehicle_sim_api->getCamera(subwindow_setting.camera_name) != nullptr)
                 subwindow_cameras_[subwindow_setting.window_index] = vehicle_sim_api->getCamera(subwindow_setting.camera_name);
             else
                 UAirBlueprintLib::LogMessageString("CameraID in <SubWindows> element in settings.json is invalid",
                     std::to_string(window_index), LogDebugLevel::Failure);
         }
-    }
+        else
+            UAirBlueprintLib::LogMessageString("Vehicle in <SubWindows> element in settings.json is invalid",
+                std::to_string(window_index), LogDebugLevel::Failure);
 
+    }
 
 }
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -104,9 +104,9 @@ Below are complete list of settings available along with their default values. I
     "UpdateIntervalSecs": 60
   },
   "SubWindows": [
-    {"WindowID": 0, "CameraName": "0", "ImageType": 3, "Visible": false},
-    {"WindowID": 1, "CameraName": "0", "ImageType": 5, "Visible": false},
-    {"WindowID": 2, "CameraName": "0", "ImageType": 0, "Visible": false}
+    {"WindowID": 0, "CameraName": "0", "ImageType": 3, "VehicleName": "", "Visible": false},
+    {"WindowID": 1, "CameraName": "0", "ImageType": 5, "VehicleName": "", "Visible": false},
+    {"WindowID": 2, "CameraName": "0", "ImageType": 0, "VehicleName": "", "Visible": false}
   ],
   "SegmentationSettings": {
     "InitMethod": "",
@@ -189,14 +189,27 @@ Also see [Time of Day API](apis.md#time-of-day-api).
 This setting specifies the latitude, longitude and altitude of the Player Start component placed in the Unreal environment. The vehicle's home point is computed using this transformation. Note that all coordinates exposed via APIs are using NED system in SI units which means each vehicle starts at (0, 0, 0) in NED system. Time of Day settings are computed for geographical coordinates specified in `OriginGeopoint`.
 
 ## SubWindows
-This setting determines what is shown in each of 3 subwindows which are visible when you press 0 key. The WindowsID can be 0 to 2, CameraName is any [available camera](image_apis.md#available_cameras) on the vehicle. ImageType integer value determines what kind of image gets shown according to [ImageType enum](image_apis.md#available-imagetype). For example, for car vehicles below shows driver view, front bumper view and rear view as scene, depth and surface normals respectively.
-```
+This setting determines what is shown in each of 3 subwindows which are visible when you press 0,1,2 keys. The `WindowID` can be 0 to 2, `CameraName` is any [available camera](image_apis.md#available_cameras) on the vehicle. `ImageType` integer value determines what kind of image gets shown according to [ImageType enum](image_apis.md#available-imagetype). `VehicleName` string allows you to specify the vehicle to use the camera from, used when multiple vehicles are specified in the settings. First vehicle's camera will be used if there are any mistakes such as incorrect vehicle name, or only a single vehicle.
+
+For example, for a single car vehicle, below shows driver view, front bumper view and rear view as scene, depth and surface normals respectively.
+```json
   "SubWindows": [
     {"WindowID": 0, "ImageType": 0, "CameraName": "3", "Visible": true},
     {"WindowID": 1, "ImageType": 3, "CameraName": "0", "Visible": true},
     {"WindowID": 2, "ImageType": 6, "CameraName": "4", "Visible": true}
   ]
 ```
+
+In case of multiple vehicles, different vehicles can be specified as follows-
+
+```json
+    "SubWindows": [
+        {"WindowID": 0, "CameraName": "0", "ImageType": 3, "VehicleName": "Car1", "Visible": false},
+        {"WindowID": 1, "CameraName": "0", "ImageType": 5, "VehicleName": "Car2", "Visible": false},
+        {"WindowID": 2, "CameraName": "0", "ImageType": 0, "VehicleName": "Car1", "Visible": false}
+    ]
+```
+
 ## Recording
 The recording feature allows you to record data such as position, orientation, velocity along with the captured image at specified intervals. You can start recording by pressing red Record button on lower right or the R key. The data is stored in the `Documents\AirSim` folder, in a time stamped subfolder for each recording session, as tab separated file.
 


### PR DESCRIPTION
Example Settings - 
```
{
    "SeeDocsAt": "https://github.com/Microsoft/AirSim/blob/master/docs/settings_json.md",
    "SettingsVersion": 1.2,
    "SimMode": "Car",

    "Vehicles": {
        "Car1": {
          "VehicleType": "PhysXCar",
          "AutoCreate": true
        },
        "Car2": {
          "VehicleType": "PhysXCar",
          "AutoCreate": true,
          "X": 0, "Y": 10, "Z": 0
        }
    },
    "SubWindows": [
        {"WindowID": 0, "CameraName": "0", "ImageType": 3, "VehicleName": "Car1", "Visible": false},
        {"WindowID": 1, "CameraName": "0", "ImageType": 5, "VehicleName": "Car2", "Visible": false},
        {"WindowID": 2, "CameraName": "0", "ImageType": 0, "VehicleName": "Car1", "Visible": false}
    ],
}
```
![Screenshot from 2020-07-08 23-11-31](https://user-images.githubusercontent.com/37938604/86958241-7a94d800-c179-11ea-8e2b-0aad01b5014c.png)

I've tested this to make sure that earlier behaviour is unchanged, i.e. if `Vehicle` is not specified, first vehicle is used. And if no `SubWindows` settings are specified, then the default windows appear. Any testing would be great!

Closes #2838, closes #1172

