### PR TITLE
Fixes #2854: [UE4] simGetSegmentationObjectID will always return -1

### DIFF
--- a/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
+++ b/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
@@ -324,14 +324,33 @@ bool UAirBlueprintLib::SetMeshStencilID(const std::string& mesh_name, int object
 
 int UAirBlueprintLib::GetMeshStencilID(const std::string& mesh_name)
 {
-    FString fmesh_name(mesh_name.c_str());
-    for (TObjectIterator<UMeshComponent> comp; comp; ++comp)
-    {
-        // Access the subclass instance with the * or -> operators.
-        UMeshComponent *mesh = *comp;
-        if (mesh->GetName() == fmesh_name) {
+    // Takes a UStaticMeshComponent, USkinnedMeshComponent or ALandscapeProxy and returns their custom stencil ID if 
+    // their meshes's name or their owner's name (depending on the naming method in mesh_naming_method_) equals mesh_name
+    auto getCustomStencilForMesh = [&mesh_name](auto mesh) -> int {
+        const std::string component_mesh_name = common_utils::Utils::toLower(GetMeshName(mesh));
+        if (component_mesh_name.compare(mesh_name) == 0) {
             return mesh->CustomDepthStencilValue;
         }
+        return -1;
+    };
+
+    for (TObjectIterator<UStaticMeshComponent> comp; comp; ++comp)
+    {
+        int id = getCustomStencilForMesh(*comp);
+        if(id != -1)
+            return id;
+    }
+    for (TObjectIterator<USkinnedMeshComponent> comp; comp; ++comp)
+    {
+        int id = getCustomStencilForMesh(*comp);
+        if (id != -1)
+            return id;
+    }
+    for (TObjectIterator<ALandscapeProxy> comp; comp; ++comp)
+    {
+        int id = getCustomStencilForMesh(*comp);
+        if (id != -1)
+            return id;
     }
 
     return -1;


### PR DESCRIPTION
This PR fixes #2854 .

Calling simGetSegmentationObjectID from Python and AirSim running in Unreal Engine 4 always fails with -1 because the underlying function `UAirBlueprintLib::GetMeshStencilID` is comparing the passed parameter not against the actual mesh's or owner's name but the name of the mesh component instead (e.g. StaticMeshComponent0). 

This PR fixes that by miming the same calls as the actual initialization of IDs in `UAirBlueprintLib::InitializeMeshStencilIDs`.
