### PR TITLE
Extend Recording to multiple vehicles

### DIFF
--- a/AirLib/include/common/AirSimSettings.hpp
+++ b/AirLib/include/common/AirSimSettings.hpp
@@ -53,6 +53,7 @@ public: //types
     struct RecordingSetting {
         bool record_on_move = false;
         float record_interval = 0.05f;
+        std::string folder = "";
 
         std::map<std::string, std::vector<ImageCaptureBase::ImageRequest> > requests;
 
@@ -60,8 +61,8 @@ public: //types
         {
         }
 
-        RecordingSetting(bool record_on_move_val, float record_interval_val)
-            : record_on_move(record_on_move_val), record_interval(record_interval_val)
+        RecordingSetting(bool record_on_move_val, float record_interval_val, std::string folder_val)
+            : record_on_move(record_on_move_val), record_interval(record_interval_val), folder(folder_val)
         {
         }
     };
@@ -594,6 +595,7 @@ private:
         if (settings_json.getChild("Recording", recording_json)) {
             recording_setting.record_on_move = recording_json.getBool("RecordOnMove", recording_setting.record_on_move);
             recording_setting.record_interval = recording_json.getFloat("RecordInterval", recording_setting.record_interval);
+            recording_setting.folder = recording_json.getString("Folder", recording_setting.folder);
 
             Settings req_cameras_settings;
             if (recording_json.getChild("Cameras", req_cameras_settings)) {

--- a/AirLib/include/common/AirSimSettings.hpp
+++ b/AirLib/include/common/AirSimSettings.hpp
@@ -66,7 +66,7 @@ public: //types
         {
         }
 
-        RecordingSetting(bool record_on_move_val, float record_interval_val, std::string folder_val, bool enabled_val)
+        RecordingSetting(bool record_on_move_val, float record_interval_val, const std::string& folder_val, bool enabled_val)
             : record_on_move(record_on_move_val), record_interval(record_interval_val), folder(folder_val),
               enabled(enabled_val)
         {
@@ -124,7 +124,6 @@ public: //types
         // ShowFlag.VisualizeHDR 1.
         //to replicate camera settings_json to SceneCapture2D
         //TODO: should we use UAirBlueprintLib::GetDisplayGamma()?
-        typedef msr::airlib::Utils Utils;
         static constexpr float kSceneTargetGamma = 1.4f;
 
         int image_type = 0;
@@ -620,7 +619,6 @@ private:
                 // Get name of the default vehicle to be used if "VehicleName" isn't specified
                 // Map contains a default vehicle if vehicles haven't been specified
                 std::string default_vehicle_name = vehicles.begin()->first;
-
 
                 for (size_t child_index = 0; child_index < req_cameras_settings.size(); ++child_index) {
                     Settings req_camera_settings;

--- a/AirLib/include/common/AirSimSettings.hpp
+++ b/AirLib/include/common/AirSimSettings.hpp
@@ -58,6 +58,7 @@ public: //types
         bool record_on_move = false;
         float record_interval = 0.05f;
         std::string folder = "";
+        bool enabled = false;
 
         std::map<std::string, std::vector<ImageCaptureBase::ImageRequest> > requests;
 
@@ -65,8 +66,9 @@ public: //types
         {
         }
 
-        RecordingSetting(bool record_on_move_val, float record_interval_val, std::string folder_val)
-            : record_on_move(record_on_move_val), record_interval(record_interval_val), folder(folder_val)
+        RecordingSetting(bool record_on_move_val, float record_interval_val, std::string folder_val, bool enabled_val)
+            : record_on_move(record_on_move_val), record_interval(record_interval_val), folder(folder_val),
+              enabled(enabled_val)
         {
         }
     };
@@ -636,6 +638,7 @@ private:
             recording_setting.record_on_move = recording_json.getBool("RecordOnMove", recording_setting.record_on_move);
             recording_setting.record_interval = recording_json.getFloat("RecordInterval", recording_setting.record_interval);
             recording_setting.folder = recording_json.getString("Folder", recording_setting.folder);
+            recording_setting.enabled = recording_json.getBool("Enabled", recording_setting.enabled);
 
             Settings req_cameras_settings;
             if (recording_json.getChild("Cameras", req_cameras_settings)) {

--- a/AirLib/include/common/common_utils/FileSystem.hpp
+++ b/AirLib/include/common/common_utils/FileSystem.hpp
@@ -108,10 +108,11 @@ public:
         return str.substr(ui, len - ui);
     }
 
-    static std::string getLogFolderPath(bool folder_timestamp)
+    static std::string getLogFolderPath(bool folder_timestamp, const std::string& parent = "")
     {
         std::string logfolder = folder_timestamp ? Utils::to_string(Utils::now()) : "";
-        std::string fullPath = combine(getAppDataFolder(), logfolder);
+        std::string parent_folder = (parent == "") ? getAppDataFolder() : parent;
+        std::string fullPath = combine(parent_folder, logfolder);
         ensureFolder(fullPath);
 
         return fullPath;

--- a/AirLib/include/common/common_utils/Utils.hpp
+++ b/AirLib/include/common/common_utils/Utils.hpp
@@ -704,6 +704,35 @@ public:
                 }
             }
         }
+
+        file.close();
+    }
+
+    static void writePPMfile(const uint8_t* const image_data, int width, int height, const std::string& path)
+    {
+        std::ofstream file(path.c_str(), std::ios::binary);
+
+        // Header information
+        file << "P6\n";                             // Magic type for PPM files
+        file << width << " " << height << "\n";
+        file << "255\n";                            // Max color value
+
+        auto write_binary = [&file](const uint8_t &data) {
+            file.write(reinterpret_cast<const char*>(&data), sizeof(data));
+        };
+
+        for (int i=0; i<height; i++) {
+            for (int j=0; j<width; j++) {
+                int id = (i*width + j)*3;           // Pixel index
+
+                // Image is in BGR, write as RGB
+                write_binary(image_data[id+2]);     // R
+                write_binary(image_data[id+1]);     // G
+                write_binary(image_data[id]);       // B
+            }
+        }
+
+        file.close();
     }
 
     template<typename T>

--- a/AirLib/include/common/common_utils/Utils.hpp
+++ b/AirLib/include/common/common_utils/Utils.hpp
@@ -678,9 +678,9 @@ public:
         return uval[0] == 1;
     }
 
-    static void writePfmFile(const float * const image_data, int width, int height, std::string path, float scalef=1)
+    static void writePFMfile(const float * const image_data, int width, int height, const std::string& path, float scalef=1)
     {
-        std::fstream file(path.c_str(), std::ios::out | std::ios::binary);
+        std::ofstream file(path.c_str(), std::ios::binary);
 
         std::string bands;
         float fvalue;       // scale factor and temp value to hold pixel value

--- a/AirLib/include/sensors/distance/DistanceSimpleParams.hpp
+++ b/AirLib/include/sensors/distance/DistanceSimpleParams.hpp
@@ -59,7 +59,7 @@ struct DistanceSimpleParams {
         if (std::isnan(relative_pose.position.y()))
             relative_pose.position.y() = 0;
         if (std::isnan(relative_pose.position.z())) {
-            if (simmode_name == "Multirotor")
+            if (simmode_name == AirSimSettings::kSimModeTypeMultirotor)
                 relative_pose.position.z() = 0;
             else
                 relative_pose.position.z() = -1;  // a little bit above for cars

--- a/AirLib/include/sensors/lidar/LidarSimpleParams.hpp
+++ b/AirLib/include/sensors/lidar/LidarSimpleParams.hpp
@@ -53,7 +53,7 @@ struct LidarSimpleParams {
         // for cars, the lidars FOV is more forward facing.
         vertical_FOV_upper = settings.vertical_FOV_upper;
         if (std::isnan(vertical_FOV_upper)) {
-            if (simmode_name == "Multirotor")
+            if (simmode_name == AirSimSettings::kSimModeTypeMultirotor)
                 vertical_FOV_upper = -15;
             else
                 vertical_FOV_upper = +10;
@@ -61,7 +61,7 @@ struct LidarSimpleParams {
 
         vertical_FOV_lower = settings.vertical_FOV_lower;
         if (std::isnan(vertical_FOV_lower)) {
-            if (simmode_name == "Multirotor")
+            if (simmode_name == AirSimSettings::kSimModeTypeMultirotor)
                 vertical_FOV_lower = -45;
             else
                 vertical_FOV_lower = -10;
@@ -73,7 +73,7 @@ struct LidarSimpleParams {
         if (std::isnan(relative_pose.position.y()))
             relative_pose.position.y() = 0;
         if (std::isnan(relative_pose.position.z())) {
-            if (simmode_name == "Multirotor")
+            if (simmode_name == AirSimSettings::kSimModeTypeMultirotor)
                 relative_pose.position.z() = 0;
             else
                 relative_pose.position.z() = -1;  // a little bit above for cars

--- a/Examples/DataCollection/DataCollectorSGM.h
+++ b/Examples/DataCollection/DataCollectorSGM.h
@@ -234,13 +234,13 @@ private:
             fclose(img_r);
 
             //GT disparity and depth
-            Utils::writePfmFile(gt_depth_data.data(), w, h, FileSystem::combine(result->storage_dir_, depth_gt_file_name));
+            Utils::writePFMfile(gt_depth_data.data(), w, h, FileSystem::combine(result->storage_dir_, depth_gt_file_name));
             denormalizeDisparity(gt_disparity_data, w);
-            Utils::writePfmFile(gt_disparity_data.data(), w, h, FileSystem::combine(result->storage_dir_, disparity_gt_file_name));
+            Utils::writePFMfile(gt_disparity_data.data(), w, h, FileSystem::combine(result->storage_dir_, disparity_gt_file_name));
             
             //SGM depth disparity and confidence
-            Utils::writePfmFile(sgm_depth_data.data(), w, h, FileSystem::combine(result->storage_dir_, depth_sgm_file_name));
-            Utils::writePfmFile(sgm_disparity_data.data(), w, h, FileSystem::combine(result->storage_dir_, disparity_sgm_file_name));
+            Utils::writePFMfile(sgm_depth_data.data(), w, h, FileSystem::combine(result->storage_dir_, depth_sgm_file_name));
+            Utils::writePFMfile(sgm_disparity_data.data(), w, h, FileSystem::combine(result->storage_dir_, disparity_sgm_file_name));
             FILE *sgm_c = fopen(FileSystem::combine(result->storage_dir_, confidence_sgm_file_name).c_str(), "wb");
             svpng(sgm_c,w,h,reinterpret_cast<const unsigned char*>(sgm_confidence_data.data()),0,1);
             fclose(sgm_c);

--- a/Examples/DataCollection/StereoImageGenerator.hpp
+++ b/Examples/DataCollection/StereoImageGenerator.hpp
@@ -174,7 +174,7 @@ private:
 
             denormalizeDisparity(disparity_data, result.response.at(2).width);
 
-            Utils::writePfmFile(disparity_data.data(), result.response.at(2).width, result.response.at(2).height,
+            Utils::writePFMfile(disparity_data.data(), result.response.at(2).width, result.response.at(2).height,
                 FileSystem::combine(result.storage_dir_, disparity_file_name));
 
             (* result.file_list) << left_file_name << "," << right_file_name << "," << disparity_file_name << std::endl;

--- a/HelloCar/main.cpp
+++ b/HelloCar/main.cpp
@@ -50,7 +50,7 @@ int main()
                 if (path != "") {
                     std::string file_path = FileSystem::combine(path, std::to_string(image_info.time_stamp));
                     if (image_info.pixels_as_float) {
-                        Utils::writePfmFile(image_info.image_data_float.data(), image_info.width, image_info.height,
+                        Utils::writePFMfile(image_info.image_data_float.data(), image_info.width, image_info.height,
                             file_path + ".pfm");
                     }
                     else {

--- a/HelloDrone/main.cpp
+++ b/HelloDrone/main.cpp
@@ -44,7 +44,7 @@ int main()
                 if (path != "") {
                     std::string file_path = FileSystem::combine(path, std::to_string(image_info.time_stamp));
                     if (image_info.pixels_as_float) {
-                        Utils::writePfmFile(image_info.image_data_float.data(), image_info.width, image_info.height,
+                        Utils::writePFMfile(image_info.image_data_float.data(), image_info.width, image_info.height,
                             file_path + ".pfm");
                     }
                     else {

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
@@ -581,32 +581,17 @@ std::string PawnSimApi::getRecordFileLine(bool is_header_line) const
         return "VehicleName\tTimeStamp\tPOS_X\tPOS_Y\tPOS_Z\tQ_W\tQ_X\tQ_Y\tQ_Z\t";
     }
 
-    const Kinematics::State* kinematics = getGroundTruthKinematics();
-    uint64_t timestamp_millis = static_cast<uint64_t>(msr::airlib::ClockFactory::get()->nowNanos() / 1.0E6);
+    const auto* kinematics = getGroundTruthKinematics();
+    const uint64_t timestamp_millis = static_cast<uint64_t>(clock()->nowNanos() / 1.0E6);
 
-    //TODO: because this bug we are using alternative code with stringstream
-    //https://answers.unrealengine.com/questions/664905/unreal-crashes-on-two-lines-of-extremely-simple-st.html
+    std::ostringstream ss;
+    ss << getVehicleName() << "\t";
+    ss << timestamp_millis << "\t";
+    ss << kinematics->pose.position.x() << "\t" << kinematics->pose.position.y() << "\t" << kinematics->pose.position.z() << "\t";
+    ss << kinematics->pose.orientation.w() << "\t" << kinematics->pose.orientation.x() << "\t"
+        << kinematics->pose.orientation.y() << "\t" << kinematics->pose.orientation.z() << "\t";
 
-    std::string line;
-    line.append(getVehicleName()).append("\t")
-        .append(std::to_string(timestamp_millis)).append("\t")
-        .append(std::to_string(kinematics->pose.position.x())).append("\t")
-        .append(std::to_string(kinematics->pose.position.y())).append("\t")
-        .append(std::to_string(kinematics->pose.position.z())).append("\t")
-        .append(std::to_string(kinematics->pose.orientation.w())).append("\t")
-        .append(std::to_string(kinematics->pose.orientation.x())).append("\t")
-        .append(std::to_string(kinematics->pose.orientation.y())).append("\t")
-        .append(std::to_string(kinematics->pose.orientation.z())).append("\t")
-        ;
-
-    return line;
-
-    //std::stringstream ss;
-    //ss << timestamp_millis << "\t";
-    //ss << kinematics.pose.position.x() << "\t" << kinematics.pose.position.y() << "\t" << kinematics.pose.position.z() << "\t";
-    //ss << kinematics.pose.orientation.w() << "\t" << kinematics.pose.orientation.x() << "\t" << kinematics.pose.orientation.y() << "\t" << kinematics.pose.orientation.z() << "\t";
-    //ss << "\n";
-    //return ss.str();
+    return ss.str();
 }
 
 msr::airlib::VehicleApiBase* PawnSimApi::getVehicleApiBase() const

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
@@ -578,7 +578,7 @@ msr::airlib::Environment* PawnSimApi::getEnvironment()
 std::string PawnSimApi::getRecordFileLine(bool is_header_line) const
 {
     if (is_header_line) {
-        return "TimeStamp\tPOS_X\tPOS_Y\tPOS_Z\tQ_W\tQ_X\tQ_Y\tQ_Z\t";
+        return "VehicleName\tTimeStamp\tPOS_X\tPOS_Y\tPOS_Z\tQ_W\tQ_X\tQ_Y\tQ_Z\t";
     }
 
     const Kinematics::State* kinematics = getGroundTruthKinematics();
@@ -588,7 +588,8 @@ std::string PawnSimApi::getRecordFileLine(bool is_header_line) const
     //https://answers.unrealengine.com/questions/664905/unreal-crashes-on-two-lines-of-extremely-simple-st.html
 
     std::string line;
-    line.append(std::to_string(timestamp_millis)).append("\t")
+    line.append(getVehicleName()).append("\t")
+        .append(std::to_string(timestamp_millis)).append("\t")
         .append(std::to_string(kinematics->pose.position.x())).append("\t")
         .append(std::to_string(kinematics->pose.position.y())).append("\t")
         .append(std::to_string(kinematics->pose.position.z())).append("\t")

--- a/Unreal/Plugins/AirSim/Source/Recording/RecordingFile.cpp
+++ b/Unreal/Plugins/AirSim/Source/Recording/RecordingFile.cpp
@@ -50,7 +50,8 @@ void RecordingFile::appendRecord(const std::vector<msr::airlib::ImageCaptureBase
     }
 
     //write to CSV file
-    if (save_success) {
+    if (save_success || (responses.size() == 0)) {
+        // Either images were saved successfully, or there were no images 
         writeString(vehicle_sim_api->getRecordFileLine(false).append(image_file_names.str()).append("\n"));
 
         //UAirBlueprintLib::LogMessage(TEXT("Screenshot saved to:"), filePath, LogDebugLevel::Success);

--- a/Unreal/Plugins/AirSim/Source/Recording/RecordingFile.cpp
+++ b/Unreal/Plugins/AirSim/Source/Recording/RecordingFile.cpp
@@ -110,10 +110,10 @@ RecordingFile::~RecordingFile()
     stopRecording(true);
 }
 
-void RecordingFile::startRecording(msr::airlib::VehicleSimApiBase* vehicle_sim_api)
+void RecordingFile::startRecording(msr::airlib::VehicleSimApiBase* vehicle_sim_api, const std::string& folder)
 {
     try {
-        std::string log_folderpath = common_utils::FileSystem::getLogFolderPath(true);
+        std::string log_folderpath = common_utils::FileSystem::getLogFolderPath(true, folder);
         image_path_ = common_utils::FileSystem::ensureFolder(log_folderpath, "images");
         std::string log_filepath = common_utils::FileSystem::getLogFileNamePath(log_folderpath, record_filename, "", ".txt", false);
         if (log_filepath != "")

--- a/Unreal/Plugins/AirSim/Source/Recording/RecordingFile.cpp
+++ b/Unreal/Plugins/AirSim/Source/Recording/RecordingFile.cpp
@@ -8,7 +8,8 @@
 
 
 void RecordingFile::appendRecord(const std::vector<msr::airlib::ImageCaptureBase::ImageResponse>& responses, msr::airlib::VehicleSimApiBase* vehicle_sim_api)
-{   bool save_success = false;
+{
+    bool save_success = false;
     std::stringstream image_file_names;
 
     for (auto i = 0; i < responses.size(); ++i) {
@@ -16,7 +17,9 @@ void RecordingFile::appendRecord(const std::vector<msr::airlib::ImageCaptureBase
 
         //build image file name
         std::stringstream image_file_name;
-        image_file_name << "img_" << response.camera_name << "_" <<
+        image_file_name << "img_"
+            << vehicle_sim_api->getVehicleName() << "_" 
+            << response.camera_name << "_" <<
             common_utils::Utils::toNumeric(response.image_type) << "_" <<
             common_utils::Utils::getTimeSinceEpochNanos() << 
             (response.pixels_as_float ? ".pfm" : ".png");

--- a/Unreal/Plugins/AirSim/Source/Recording/RecordingFile.cpp
+++ b/Unreal/Plugins/AirSim/Source/Recording/RecordingFile.cpp
@@ -41,7 +41,7 @@ void RecordingFile::appendRecord(const std::vector<msr::airlib::ImageCaptureBase
         //write image file
         try {
             if (extension == ".pfm") {
-                common_utils::Utils::writePfmFile(response.image_data_float.data(), response.width, response.height,
+                common_utils::Utils::writePFMfile(response.image_data_float.data(), response.width, response.height,
                     image_full_file_path);
             }
             else if (extension == ".ppm") {

--- a/Unreal/Plugins/AirSim/Source/Recording/RecordingFile.cpp
+++ b/Unreal/Plugins/AirSim/Source/Recording/RecordingFile.cpp
@@ -7,16 +7,17 @@
 #include "common/common_utils/FileSystem.hpp"
 
 
-void RecordingFile::appendRecord(const std::vector<msr::airlib::ImageCaptureBase::ImageResponse>& responses, msr::airlib::VehicleSimApiBase* vehicle_sim_api)
+void RecordingFile::appendRecord(const std::vector<msr::airlib::ImageCaptureBase::ImageResponse>& responses,
+    msr::airlib::VehicleSimApiBase* vehicle_sim_api) const
 {
     bool save_success = false;
-    std::stringstream image_file_names;
+    std::ostringstream image_file_names;
 
     for (auto i = 0; i < responses.size(); ++i) {
         const auto& response = responses.at(i);
 
         //build image file name
-        std::stringstream image_file_name;
+        std::ostringstream image_file_name;
         image_file_name << "img_"
             << vehicle_sim_api->getVehicleName() << "_" 
             << response.camera_name << "_" <<
@@ -69,7 +70,6 @@ void RecordingFile::appendRecord(const std::vector<msr::airlib::ImageCaptureBase
         writeString(vehicle_sim_api->getRecordFileLine(false).append(image_file_names.str()).append("\n"));
 
         //UAirBlueprintLib::LogMessage(TEXT("Screenshot saved to:"), filePath, LogDebugLevel::Success);
-        images_saved_++;
     }
 }
 
@@ -92,7 +92,7 @@ void RecordingFile::createFile(const std::string& file_path, const std::string& 
     }
 }
 
-bool RecordingFile::isFileOpen()
+bool RecordingFile::isFileOpen() const
 {
     return log_file_handle_ != nullptr;
 }
@@ -105,11 +105,11 @@ void RecordingFile::closeFile()
     log_file_handle_ = nullptr;
 }
 
-void RecordingFile::writeString(const std::string& str)
+void RecordingFile::writeString(const std::string& str) const
 {
     try {    
         if (log_file_handle_) {
-            FString line_f = FString(str.c_str());
+            FString line_f(str.c_str());
             log_file_handle_->Write((const uint8*)TCHAR_TO_ANSI(*line_f), line_f.Len());
         }
         else
@@ -167,7 +167,7 @@ void RecordingFile::stopRecording(bool ignore_if_stopped)
     UAirBlueprintLib::LogMessage(TEXT("Data saved to: "), FString(image_path_.c_str()), LogDebugLevel::Success);
 }
 
-bool RecordingFile::isRecording()
+bool RecordingFile::isRecording() const
 {
     return is_recording_;
 }

--- a/Unreal/Plugins/AirSim/Source/Recording/RecordingFile.h
+++ b/Unreal/Plugins/AirSim/Source/Recording/RecordingFile.h
@@ -12,21 +12,20 @@ class RecordingFile {
 public:
     ~RecordingFile();
 
-    void appendRecord(const std::vector<msr::airlib::ImageCaptureBase::ImageResponse>& responses, msr::airlib::VehicleSimApiBase* vehicle_sim_api);
+    void appendRecord(const std::vector<msr::airlib::ImageCaptureBase::ImageResponse>& responses, msr::airlib::VehicleSimApiBase* vehicle_sim_api) const;
     void appendColumnHeader(const std::string& header_columns);
     void startRecording(msr::airlib::VehicleSimApiBase* vehicle_sim_api, const std::string& folder="");
     void stopRecording(bool ignore_if_stopped);
-    bool isRecording();
+    bool isRecording() const;
 
 private:
     void createFile(const std::string& file_path, const std::string& header_columns);
     void closeFile();
-    void writeString(const std::string& line);
-    bool isFileOpen();
+    void writeString(const std::string& line) const;
+    bool isFileOpen() const;
 
 private:
-    std::string record_filename = "airsim_rec";     
-    unsigned int images_saved_ = 0;
+    std::string record_filename = "airsim_rec";
     std::string image_path_;
     bool is_recording_ = false;
     IFileHandle* log_file_handle_ = nullptr;

--- a/Unreal/Plugins/AirSim/Source/Recording/RecordingFile.h
+++ b/Unreal/Plugins/AirSim/Source/Recording/RecordingFile.h
@@ -14,7 +14,7 @@ public:
 
     void appendRecord(const std::vector<msr::airlib::ImageCaptureBase::ImageResponse>& responses, msr::airlib::VehicleSimApiBase* vehicle_sim_api);
     void appendColumnHeader(const std::string& header_columns);
-    void startRecording(msr::airlib::VehicleSimApiBase* vehicle_sim_api);
+    void startRecording(msr::airlib::VehicleSimApiBase* vehicle_sim_api, const std::string& folder="");
     void stopRecording(bool ignore_if_stopped);
     bool isRecording();
 

--- a/Unreal/Plugins/AirSim/Source/Recording/RecordingThread.cpp
+++ b/Unreal/Plugins/AirSim/Source/Recording/RecordingThread.cpp
@@ -46,7 +46,7 @@ void FRecordingThread::startRecording(const RecordingSetting& settings,
 
     running_instance_->recording_file_.reset(new RecordingFile());
     // Just need any 1 instance, to set the header line of the record file
-    running_instance_->recording_file_->startRecording(*(vehicle_sim_apis.begin()));
+    running_instance_->recording_file_->startRecording(*(vehicle_sim_apis.begin()), settings.folder);
 }
 
 FRecordingThread::~FRecordingThread()

--- a/Unreal/Plugins/AirSim/Source/Recording/RecordingThread.cpp
+++ b/Unreal/Plugins/AirSim/Source/Recording/RecordingThread.cpp
@@ -42,11 +42,12 @@ void FRecordingThread::startRecording(const RecordingSetting& settings,
 
     running_instance_->last_screenshot_on_ = 0;
 
-    running_instance_->is_ready_ = true;
-
     running_instance_->recording_file_.reset(new RecordingFile());
     // Just need any 1 instance, to set the header line of the record file
     running_instance_->recording_file_->startRecording(*(vehicle_sim_apis.begin()), settings.folder);
+
+    // Set is_ready at the end, setting this before can cause a race when the file isn't open yet
+    running_instance_->is_ready_ = true;
 }
 
 FRecordingThread::~FRecordingThread()
@@ -97,7 +98,7 @@ bool FRecordingThread::Init()
     else {
         finishing_signal_.wait();
     }
-    if (!image_captures_.empty() && recording_file_)
+    if (recording_file_)
     {
         UAirBlueprintLib::LogMessage(TEXT("Initiated recording thread"), TEXT(""), LogDebugLevel::Success);
     }

--- a/Unreal/Plugins/AirSim/Source/Recording/RecordingThread.cpp
+++ b/Unreal/Plugins/AirSim/Source/Recording/RecordingThread.cpp
@@ -15,14 +15,14 @@ bool FRecordingThread::first_ = true;
 
 
 FRecordingThread::FRecordingThread()
-    : stop_task_counter_(0), recording_file_(nullptr), kinematics_(nullptr), is_ready_(false)
+    : stop_task_counter_(0), recording_file_(nullptr), is_ready_(false)
 {
     thread_.reset(FRunnableThread::Create(this, TEXT("FRecordingThread"), 0, TPri_BelowNormal)); // Windows default, possible to specify more priority
 }
 
 
-void FRecordingThread::startRecording(const msr::airlib::ImageCaptureBase* image_capture, const msr::airlib::Kinematics::State* kinematics,
-    const RecordingSetting& settings, msr::airlib::VehicleSimApiBase* vehicle_sim_api)
+void FRecordingThread::startRecording(const RecordingSetting& settings,
+    const common_utils::UniqueValueMap<std::string, VehicleSimApiBase*>& vehicle_sim_apis)
 {
     stopRecording();
 
@@ -30,18 +30,23 @@ void FRecordingThread::startRecording(const msr::airlib::ImageCaptureBase* image
     assert(!isRecording());
 
     running_instance_.reset(new FRecordingThread());
-    running_instance_->image_capture_ = image_capture;
-    running_instance_->kinematics_ = kinematics;
     running_instance_->settings_ = settings;
-    running_instance_->vehicle_sim_api_ = vehicle_sim_api;
+    running_instance_->vehicle_sim_apis_ = vehicle_sim_apis;
+
+    for (const auto& vehicle_sim_api : vehicle_sim_apis) {
+        auto vehicle_name = vehicle_sim_api->getVehicleName();
+
+        running_instance_->image_captures_[vehicle_name] = vehicle_sim_api->getImageCapture();
+        running_instance_->last_poses_[vehicle_name] = msr::airlib::Pose();
+    }
 
     running_instance_->last_screenshot_on_ = 0;
-    running_instance_->last_pose_ = msr::airlib::Pose();
 
     running_instance_->is_ready_ = true;
 
     running_instance_->recording_file_.reset(new RecordingFile());
-    running_instance_->recording_file_->startRecording(vehicle_sim_api);
+    // Just need any 1 instance, to set the header line of the record file
+    running_instance_->recording_file_->startRecording(*(vehicle_sim_apis.begin()));
 }
 
 FRecordingThread::~FRecordingThread()
@@ -92,7 +97,7 @@ bool FRecordingThread::Init()
     else {
         finishing_signal_.wait();
     }
-    if (image_capture_ && recording_file_)
+    if (!image_captures_.empty() && recording_file_)
     {
         UAirBlueprintLib::LogMessage(TEXT("Initiated recording thread"), TEXT(""), LogDebugLevel::Success);
     }
@@ -103,27 +108,31 @@ uint32 FRecordingThread::Run()
 {
     while (stop_task_counter_.GetValue() == 0)
     {
-        //make sire all vars are set up
+        //make sure all vars are set up
         if (is_ready_) {
             bool interval_elapsed = msr::airlib::ClockFactory::get()->elapsedSince(last_screenshot_on_) > settings_.record_interval;
-            bool is_pose_unequal = kinematics_ && last_pose_ != kinematics_->pose;
-            if (interval_elapsed && (!settings_.record_on_move || is_pose_unequal))
-            {
+
+            if (interval_elapsed) {
                 last_screenshot_on_ = msr::airlib::ClockFactory::get()->nowNanos();
-                last_pose_ = kinematics_->pose;
 
-                //TODO: should we go as fast as possible, or should we limit this to a particular number of
-                // frames per second?
+                for (const auto& vehicle_sim_api : vehicle_sim_apis_) {
+                    const auto& vehicle_name = vehicle_sim_api->getVehicleName();
 
-                //BG: Workaround to get sync ground truth. See https://github.com/Microsoft/AirSim/issues/1494 for details
-                uint64_t timestamp_millis = static_cast<uint64_t>(msr::airlib::ClockFactory::get()->nowNanos() / 1.0E6);
-                std::string gt = vehicle_sim_api_->getRecordFileLine(false);
-                std::vector<msr::airlib::ImageCaptureBase::ImageResponse> responses;
+                    const auto* kinematics = vehicle_sim_api->getGroundTruthKinematics();
+                    bool is_pose_unequal = kinematics && last_poses_[vehicle_name] != kinematics->pose;
 
-                image_capture_->getImages(settings_.requests, responses);
-                recording_file_->appendRecord(responses, vehicle_sim_api_);
+                    if (!settings_.record_on_move || is_pose_unequal) {
+                        last_poses_[vehicle_name] = kinematics->pose;
+
+                        std::vector<ImageCaptureBase::ImageResponse> responses;
+
+                        image_captures_[vehicle_name]->getImages(settings_.requests[vehicle_name], responses);
+                        recording_file_->appendRecord(responses, vehicle_sim_api);
+                    }
+                }
             }
         }
+
     }
 
     recording_file_.reset();

--- a/Unreal/Plugins/AirSim/Source/Recording/RecordingThread.h
+++ b/Unreal/Plugins/AirSim/Source/Recording/RecordingThread.h
@@ -16,14 +16,16 @@ class FRecordingThread : public FRunnable
 {
 public:
     typedef msr::airlib::AirSimSettings::RecordingSetting RecordingSetting;
+    typedef msr::airlib::VehicleSimApiBase VehicleSimApiBase;
+    typedef msr::airlib::ImageCaptureBase ImageCaptureBase;
 
 public:
     FRecordingThread();
     virtual ~FRecordingThread();
 
     static void init();
-    static void startRecording(const msr::airlib::ImageCaptureBase* camera, const msr::airlib::Kinematics::State* kinematics, 
-        const RecordingSetting& settings, msr::airlib::VehicleSimApiBase* vehicle_sim_api);
+    static void startRecording(const RecordingSetting& settings,
+        const common_utils::UniqueValueMap<std::string, VehicleSimApiBase*>& vehicle_sim_apis);
     static void stopRecording();
     static void killRecording();
     static bool isRecording();
@@ -48,13 +50,12 @@ private:
     std::unique_ptr<FRunnableThread> thread_;
 
     RecordingSetting settings_;
-    const msr::airlib::ImageCaptureBase* image_capture_;
     std::unique_ptr<RecordingFile> recording_file_;
-    const msr::airlib::Kinematics::State* kinematics_;
-    msr::airlib::VehicleSimApiBase* vehicle_sim_api_;
+    common_utils::UniqueValueMap<std::string, VehicleSimApiBase*> vehicle_sim_apis_;
+    std::unordered_map<std::string, const ImageCaptureBase*> image_captures_;
+    std::unordered_map<std::string, msr::airlib::Pose> last_poses_;
 
     msr::airlib::TTimePoint last_screenshot_on_;
-    msr::airlib::Pose last_pose_;
 
     bool is_ready_;
 };

--- a/Unreal/Plugins/AirSim/Source/Recording/RecordingThread.h
+++ b/Unreal/Plugins/AirSim/Source/Recording/RecordingThread.h
@@ -38,7 +38,6 @@ protected:
 
 private:
     FThreadSafeCounter stop_task_counter_;
-    FRenderCommandFence read_pixel_fence_;
 
     static std::unique_ptr<FRecordingThread> running_instance_;
     static std::unique_ptr<FRecordingThread> finishing_instance_;

--- a/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
@@ -278,10 +278,10 @@ std::string ASimHUD::getSimModeFromUser()
         "Would you like to use car simulation? Choose no to use quadrotor simulation.",
         "Choose Vehicle"))
     {
-        return "Multirotor";
+        return AirSimSettings::kSimModeTypeMultirotor;
     }
     else
-        return "Car";
+        return AirSimSettings::kSimModeTypeCar;
 }
 
 void ASimHUD::loadLevel()
@@ -299,13 +299,13 @@ void ASimHUD::createSimMode()
     simmode_spawn_params.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AdjustIfPossibleButAlwaysSpawn;
 
     //spawn at origin. We will use this to do global NED transforms, for ex, non-vehicle objects in environment
-    if (simmode_name == "Multirotor")
+    if (simmode_name == AirSimSettings::kSimModeTypeMultirotor)
         simmode_ = this->GetWorld()->SpawnActor<ASimModeWorldMultiRotor>(FVector::ZeroVector, 
             FRotator::ZeroRotator, simmode_spawn_params);
-    else if (simmode_name == "Car")
+    else if (simmode_name == AirSimSettings::kSimModeTypeCar)
         simmode_ = this->GetWorld()->SpawnActor<ASimModeCar>(FVector::ZeroVector,
             FRotator::ZeroRotator, simmode_spawn_params);
-    else if (simmode_name == "ComputerVision")
+    else if (simmode_name == AirSimSettings::kSimModeTypeComputerVision)
         simmode_ = this->GetWorld()->SpawnActor<ASimModeComputerVision>(FVector::ZeroVector,
             FRotator::ZeroRotator, simmode_spawn_params);
     else {

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
@@ -470,9 +470,7 @@ void ASimModeBase::stopRecording()
 
 void ASimModeBase::startRecording()
 {
-    FRecordingThread::startRecording(getVehicleSimApi()->getImageCapture(),
-        getVehicleSimApi()->getGroundTruthKinematics(), getSettings().recording_setting ,
-        getVehicleSimApi());
+    FRecordingThread::startRecording(getSettings().recording_setting, getApiProvider()->getVehicleSimApis());
 }
 
 bool ASimModeBase::isRecording() const

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
@@ -140,6 +140,9 @@ void ASimModeBase::BeginPlay()
     setupVehiclesAndCamera();
     FRecordingThread::init();
 
+    if (getSettings().recording_setting.enabled)
+        startRecording();
+
     UWorld* World = GetWorld();
     if (World)
     {

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnSimApi.cpp
@@ -41,20 +41,14 @@ std::string CarPawnSimApi::getRecordFileLine(bool is_header_line) const
                "Throttle\tSteering\tBrake\tGear\tHandbrake\tRPM\tSpeed\t";
     }
 
-    const msr::airlib::Kinematics::State* kinematics = getGroundTruthKinematics();
-    const auto state = pawn_api_->getCarState();
+    const auto& state = pawn_api_->getCarState();
 
-    common_line
-        .append(std::to_string(current_controls_.throttle)).append("\t")
-        .append(std::to_string(current_controls_.steering)).append("\t")
-        .append(std::to_string(current_controls_.brake)).append("\t")
-        .append(std::to_string(state.gear)).append("\t")
-        .append(std::to_string(state.handbrake)).append("\t")
-        .append(std::to_string(state.rpm)).append("\t")
-        .append(std::to_string(state.speed)).append("\t")
-        ;
+    std::ostringstream ss;
+    ss << common_line;
+    ss << current_controls_.throttle << "\t" << current_controls_.steering << "\t" << current_controls_.brake << "\t";
+    ss << state.gear << "\t" << state.handbrake << "\t" << state.rpm << "\t" << state.speed << "\t";
 
-    return common_line;
+    return ss.str();
 }
 
 //these are called on render ticks

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -50,6 +50,7 @@ Below are complete list of settings available along with their default values. I
     "RecordOnMove": false,
     "RecordInterval": 0.05,
     "Folder": "",
+    "Enabled": false,
     "Cameras": [
         { "CameraName": "0", "ImageType": 0, "PixelsAsFloat": false,  "VehicleName": "", "Compress": true }
     ]
@@ -226,6 +227,7 @@ The recording feature allows you to record data such as position, orientation, v
 * `RecordInterval`: specifies minimal interval in seconds between capturing two images.
 * `RecordOnMove`: specifies that do not record frame if there was vehicle's position or orientation hasn't changed.
 * `Folder`: Parent folder where timestamped subfolder with recordings are created. Absolute path of the directory must be specified. If not used, then `Documents/AirSim` folder will be used. E.g. `"Folder": "/home/<user>/Documents"`
+* `Enabled`: Whether Recording should start from the beginning itself, setting to `true` will start recording automatically when the simulation starts. By default, it's set to `false`
 * `Cameras`: this element controls which cameras are used to capture images. By default scene image from camera 0 is recorded as compressed png format. This setting is json array so you can specify multiple cameras to capture images, each with potentially different [image types](settings.md#image-capture-settings). 
     * When `PixelsAsFloat` is true, image is saved as [pfm](pfm.md) file instead of png file.
     * `VehicleName` option allows you to specify separate cameras for individual vehicles. If the `Cameras` element isn't present, `Scene` image from the default camera of each vehicle will be recorded.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -49,8 +49,9 @@ Below are complete list of settings available along with their default values. I
   "Recording": {
     "RecordOnMove": false,
     "RecordInterval": 0.05,
+    "Folder": "",
     "Cameras": [
-        { "CameraName": "0", "ImageType": 0, "PixelsAsFloat": false, "Compress": true }
+        { "CameraName": "0", "ImageType": 0, "PixelsAsFloat": false,  "VehicleName": "", "Compress": true }
     ]
   },
   "CameraDefaults": {
@@ -220,11 +221,25 @@ In case of multiple vehicles, different vehicles can be specified as follows-
 ```
 
 ## Recording
-The recording feature allows you to record data such as position, orientation, velocity along with the captured image at specified intervals. You can start recording by pressing red Record button on lower right or the R key. The data is stored in the `Documents\AirSim` folder, in a time stamped subfolder for each recording session, as tab separated file.
+The recording feature allows you to record data such as position, orientation, velocity along with the captured image at specified intervals. You can start recording by pressing red Record button on lower right or the R key. The data is stored in the `Documents\AirSim` folder (or the folder specified using `Folder`), in a time stamped subfolder for each recording session, as tab separated file.
 
 * `RecordInterval`: specifies minimal interval in seconds between capturing two images.
 * `RecordOnMove`: specifies that do not record frame if there was vehicle's position or orientation hasn't changed.
-* `Cameras`: this element controls which cameras are used to capture images. By default scene image from camera 0 is recorded as compressed png format. This setting is json array so you can specify multiple cameras to capture images, each with potentially different [image types](settings.md#image-capture-settings). When PixelsAsFloat is true, image is saved as [pfm](pfm.md) file instead of png file.
+* `Folder`: Parent folder where timestamped subfolder with recordings are created. Absolute path of the directory must be specified. If not used, then `Documents/AirSim` folder will be used. E.g. `"Folder": "/home/<user>/Documents"`
+* `Cameras`: this element controls which cameras are used to capture images. By default scene image from camera 0 is recorded as compressed png format. This setting is json array so you can specify multiple cameras to capture images, each with potentially different [image types](settings.md#image-capture-settings). 
+    * When `PixelsAsFloat` is true, image is saved as [pfm](pfm.md) file instead of png file.
+    * `VehicleName` option allows you to specify separate cameras for individual vehicles. If the `Cameras` element isn't present, `Scene` image from the default camera of each vehicle will be recorded.
+    * If you don't want to record any images and just the vehicle's physics data, then specify the `Cameras` element but leave it empty, like this: `"Cameras": []`
+
+For example, the `Cameras` element below records scene & segmentation images for `Car1` & scene for `Car2`-
+
+```json
+"Cameras": [
+    { "CameraName": "0", "ImageType": 0, "PixelsAsFloat": false, "VehicleName": "Car1", "Compress": true },
+    { "CameraName": "0", "ImageType": 5, "PixelsAsFloat": false, "VehicleName": "Car1", "Compress": true },
+    { "CameraName": "0", "ImageType": 0, "PixelsAsFloat": false, "VehicleName": "Car2", "Compress": true }
+]
+``` 
 
 ## ClockSpeed
 This setting allows you to set the speed of simulation clock with respect to wall clock. For example, value of 5.0 would mean simulation clock has 5 seconds elapsed when wall clock has 1 second elapsed (i.e. simulation is running faster). The value of 0.1 means that simulation clock is 10X slower than wall clock. The value of 1 means simulation is running in real time. It is important to realize that quality of simulation may decrease as the simulation clock runs faster. You might see artifacts like object moving past obstacles because collision is not detected. However slowing down simulation clock (i.e. values < 1.0) generally improves the quality of simulation.


### PR DESCRIPTION
Replaces #2847 (branch got messed up)

Closes #3029
Closes #3123
Closes #3214

Other related issues - #2307

New Additions -

1. Info of all vehicles is recorded (with additional column `VehicleName`), `VehicleName` parameter in `Cameras` field to specify specific vehicle to use the camera from
2. `Folder` field in settings to change the directory to store data in
3. Allow Recording with no images (just pose, etc data) (#3123)
4. `Enabled` parameter for starting recording when AirSim starts without needing to press R or call API (#3029) (Any naming suggestions are welcome)
5. Add method to write PPM file (for uncompressed images) (#3214)

Also fixes a bug when pressing Esc and Play multiple times causes requests to add in the vector and save multiple images (https://github.com/microsoft/AirSim/issues/1414#issuecomment-505741691)

Example settings - 
```json
{
    "SettingsVersion": 1.2,
    "SimMode": "Car",

    "Vehicles": {
        "Car1": {
          "VehicleType": "PhysXCar",
          "AutoCreate": true
        },
        "Car2": {
          "VehicleType": "PhysXCar",
          "AutoCreate": true,
          "X": 0, "Y": 10, "Z": 0
        }
    },
    "Recording": {
        "RecordOnMove": false,
        "RecordInterval": 1,
        "Cameras": [
            { "CameraName": "0", "ImageType": 0, "PixelsAsFloat": false, "VehicleName": "Car1", "Compress": true },
            { "CameraName": "0", "ImageType": 5, "PixelsAsFloat": false, "VehicleName": "Car1", "Compress": true },
            { "CameraName": "0", "ImageType": 0, "PixelsAsFloat": false, "VehicleName": "Car2", "Compress": true }
        ]
    }

}
```

Recording - [2020-07-11-11-48-51.zip](https://github.com/microsoft/AirSim/files/4906392/2020-07-11-11-48-51.zip)

Testing -
- Multiple Vehicles, with no recording settings (Scene image from each vehicle)
- Multiple Vehicles, specific sensor settings (Settings above)
- Single vehicle, no settings (Scene from that vehicle, former behaviour)

TODO:
- [x] Update docs
- [ ] Unity implementation

Further possible additions -
- [x] Allow user to specify directory to store recordings in (Replacement for `Documents`)
- [x] Currently saving no images is not possible (For some reason this leads to an error in writing to file, even though the file has been created, and there are lines in it already)
      - I suspect this might be a race condition for the first write, since there are no images, no rendering and saving of images is required, so writing of pose data is happening almost instantaneously, but the file to write the data in hasn't still been created.(Haven't confirmed this though, just a thought)
      - Fixed (set `is_ready` flag at the end)

Any testing (especially of `Folder` on Windows) or suggestions would be great!

Came to mind when working on #2841 
Related older issue #1346, Also includes the fix proposed in #1414
