### PR TITLE
Update docker_ubuntu.md to recommend a compatible version of ubuntu

### DIFF
--- a/docker/Dockerfile_binary
+++ b/docker/Dockerfile_binary
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=nvidia/cudagl:10.0-devel-ubuntu16.04
+ARG BASE_IMAGE=nvidia/cudagl:10.0-devel-ubuntu18.04
 FROM $BASE_IMAGE
 
 RUN apt-get update

--- a/docker/build_airsim_image.py
+++ b/docker/build_airsim_image.py
@@ -22,7 +22,7 @@ def build_docker_image(args):
     else:
         dockerfile = 'Dockerfile_binary'
         if not args.base_image:
-            args.base_image = "nvidia/cudagl:10.0-devel-ubuntu16.04"
+            args.base_image = "nvidia/cudagl:10.0-devel-ubuntu18.04"
         target_image_tag = args.base_image.split(":")[1] # take tag from base image
         if not args.target_image:
             args.target_image = 'airsim_binary' + ':' + target_image_tag

--- a/docs/docker_ubuntu.md
+++ b/docs/docker_ubuntu.md
@@ -7,7 +7,7 @@ We've two options for docker. You can either build an image for running [airsim 
 
 #### Build the docker image
 - Below are the default arguments.   
-  `--base_image`: This is image over which we'll install airsim. We've tested on Ubuntu 18.04 + CUDA 10.0.  
+  `--base_image`: This is image over which we'll install airsim. We've tested on Ubuntu 18.04 with CUDA 10.0.  
    You can specify any [NVIDIA cudagl](https://hub.docker.com/r/nvidia/cudagl/) at your own risk.    
    `--target_image` is the desired name of your docker image.    
    Defaults to `airsim_binary` with same tag as the base image

--- a/docs/docker_ubuntu.md
+++ b/docs/docker_ubuntu.md
@@ -7,15 +7,15 @@ We've two options for docker. You can either build an image for running [airsim 
 
 #### Build the docker image
 - Below are the default arguments.   
-  `--base_image`: This is image over which we'll install airsim. We've tested on Ubuntu 16.04 + CUDA 10.0.  
+  `--base_image`: This is image over which we'll install airsim. We've tested on Ubuntu 18.04 + CUDA 10.0.  
    You can specify any [NVIDIA cudagl](https://hub.docker.com/r/nvidia/cudagl/) at your own risk.    
    `--target_image` is the desired name of your docker image.    
    Defaults to `airsim_binary` with same tag as the base image
    ```
    $ cd Airsim/docker;
    $ python build_airsim_image.py \
-      --base_image=nvidia/cudagl:10.0-devel-ubuntu16.04 \
-      --target_image=airsim_binary:10.0-devel-ubuntu16.04
+      --base_image=nvidia/cudagl:10.0-devel-ubuntu18.04 \
+      --target_image=airsim_binary:10.0-devel-ubuntu18.04
    ```
 
 - Verify you have an image by:
@@ -35,9 +35,9 @@ You can download it by running
    ```
     $ ./run_airsim_image_binary.sh DOCKER_IMAGE_NAME UNREAL_BINARY_SHELL_SCRIPT UNREAL_BINARY_ARGUMENTS -- headless     
    ```
-   For blocks, you can do a `$ ./run_airsim_image_binary.sh airsim_binary:10.0-devel-ubuntu16.04 Blocks/Blocks.sh -windowed -ResX=1080 -ResY=720`
+   For blocks, you can do a `$ ./run_airsim_image_binary.sh airsim_binary:10.0-devel-ubuntu18.04 Blocks/Blocks.sh -windowed -ResX=1080 -ResY=720`
 
-   * `DOCKER_IMAGE_NAME`: Same as `target_image` parameter in previous step. By default, enter `airsim_binary:10.0-devel-ubuntu16.04`   
+   * `DOCKER_IMAGE_NAME`: Same as `target_image` parameter in previous step. By default, enter `airsim_binary:10.0-devel-ubuntu18.04`   
    * `UNREAL_BINARY_SHELL_SCRIPT`: for Blocks enviroment, it will be `Blocks/Blocks.sh`
    * [`UNREAL_BINARY_ARGUMENTS`](https://docs.unrealengine.com/en-us/Programming/Basics/CommandLineArguments):
       For airsim, most relevant would be `-windowed`, `-ResX`, `-ResY`. Click on link to see all options. 


### PR DESCRIPTION
Numpy now require python 3.6, which is not available without extra ppa on ubuntu 16.04. Updating the documentation to make sure that we recommend a version that works with the Dockerfile provided