### PR TITLE
add az pipelines for windows and linux

### DIFF
--- a/Unreal/Environments/Blocks/update_from_git_ci.bat
+++ b/Unreal/Environments/Blocks/update_from_git_ci.bat
@@ -1,0 +1,34 @@
+@echo off
+REM //---------- set up variable ----------
+setlocal
+set ROOT_DIR=%~dp0
+
+set AirSimPath=%1
+
+REM default path works for Blocks environment
+if "%AirSimPath%"=="" set "AirSimPath=..\..\.."
+
+IF NOT EXIST "%AirSimPath%" (
+	echo "AirSimPath %AirSimPath% was not found"
+	goto :failed
+)
+
+echo Using AirSimPath = %AirSimPath%
+
+robocopy /MIR "%AirSimPath%\Unreal\Plugins\AirSim" Plugins\AirSim /XD temp *. /njh /njs /ndl /np
+robocopy /MIR "%AirSimPath%\AirLib" Plugins\AirSim\Source\AirLib /XD temp *. /njh /njs /ndl /np
+robocopy  /njh /njs /ndl /np "%AirSimPath%\Unreal\Environments\Blocks" "." *.bat 
+robocopy  /njh /njs /ndl /np "%AirSimPath%\Unreal\Environments\Blocks" "." *.sh  
+rem robocopy /njh /njs /ndl /np "%AirSimPath%" "." *.gitignore
+
+REM cmd /c clean.bat
+REM cmd /c GenerateProjectFiles.bat
+
+goto :done
+
+:failed
+echo Error occured while updating.
+exit /b 1
+
+:done
+REM if "%1"=="" pause

--- a/build.cmd
+++ b/build.cmd
@@ -157,15 +157,15 @@ IF NOT EXIST AirLib\deps\eigen3 goto :buildfailed
 
 REM //---------- now we have all dependencies to compile AirSim.sln which will also compile MavLinkCom ----------
 if "%buildMode%" == "--Debug" (
-msbuild /p:Platform=x64 /p:Configuration=Debug AirSim.sln
+msbuild -maxcpucount:12 /p:Platform=x64 /p:Configuration=Debug AirSim.sln
 if ERRORLEVEL 1 goto :buildfailed
 ) else if "%buildMode%" == "--Release" (
-msbuild /p:Platform=x64 /p:Configuration=Release AirSim.sln
+msbuild -maxcpucount:12 /p:Platform=x64 /p:Configuration=Release AirSim.sln
 if ERRORLEVEL 1 goto :buildfailed
 ) else (
-msbuild /p:Platform=x64 /p:Configuration=Debug AirSim.sln
+msbuild -maxcpucount:12 /p:Platform=x64 /p:Configuration=Debug AirSim.sln
 if ERRORLEVEL 1 goto :buildfailed
-msbuild /p:Platform=x64 /p:Configuration=Release AirSim.sln 
+msbuild -maxcpucount:12 /p:Platform=x64 /p:Configuration=Release AirSim.sln 
 if ERRORLEVEL 1 goto :buildfailed
 )
 

--- a/pipelines/ci.yml
+++ b/pipelines/ci.yml
@@ -1,0 +1,128 @@
+variables:
+  container_linux: airsimci.azurecr.io/ue4p25p1/ubuntu18:debugeditor_fulldebugoff
+  ue4_root_linux: /home/ue4/ue-4.25.1-linux-debugeditor
+  container_win: airsimci.azurecr.io/ue4p25p1/win1809:pipe
+  ue4_root_win: C:\ue-4.25.1-win
+
+stages:
+  - stage: AirSimCI
+    jobs:
+      - job: Ubuntu_1804
+        pool:
+          name: 'AirSim'
+          demands:
+            - Spec -equals Ubuntu_18.04
+        container:
+          image: $(container_linux)
+          endpoint: airsimci_acr_connection
+        variables:
+          ue4_root: $(ue4_root_linux)
+        workspace:
+          clean: all
+        steps:
+          # Setup / Prereq
+          - checkout: self
+          - script: |
+              ./setup.sh
+            displayName: Install system dependencies
+
+          # Build AirLib
+          - script: |
+              ./build.sh
+            displayName: Build AirLib
+
+          # Build UE Blocks project
+          - script: |
+              ./update_from_git.sh
+            workingDirectory: Unreal/Environments/Blocks
+            displayName: Copy AirLib to Blocks (update_from_git.sh)
+            
+          # Build Blocks
+          - script: |
+              $(UE4_ROOT)/Engine/Build/BatchFiles/Linux/Build.sh Blocks Linux Development \
+                -project=$(pwd)/Unreal/Environments/Blocks/Blocks.uproject
+              $(UE4_ROOT)/Engine/Build/BatchFiles/Linux/Build.sh BlocksEditor Linux Development \
+                -project=$(pwd)/Unreal/Environments/Blocks/Blocks.uproject
+            displayName: Build Blocks - Development
+     
+          # Package Blocks
+          - script: |
+              $(UE4_ROOT)/Engine/Build/BatchFiles/RunUAT.sh BuildCookRun \
+                -project="$(pwd)/Unreal/Environments/Blocks/Blocks.uproject" \
+                -nop4 -nocompile -build -cook -compressed -pak -allmaps -stage \
+                -archive -archivedirectory="$(pwd)/Unreal/Environments/Blocks/Packaged/Development" \
+                -clientconfig=Development -clean -utf8output
+            displayName: Package Blocks - Development
+            
+          # Publish Artifact for Blocks Linux
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: 'Unreal/Environments/Blocks/Packaged'
+              artifactName: 'Blocks_Linux'
+            displayName: Artifact for Blocks Linux
+            condition: succeededOrFailed()
+
+          - task: ArchiveFiles@2
+            displayName: Blocks Linux Zip
+            inputs:
+              rootFolderOrFile: 'Unreal/Environments/Blocks/Packaged'
+              includeRootFolder: false
+              archiveType: 'zip'
+              archiveFile: 'Unreal/Environments/Blocks/Packaged/Blocks_Linux.zip'
+              replaceExistingArchive: true
+
+      - job: Windows_VS2019
+        pool:
+          name: 'AirSim'
+          demands:
+            - Spec -equals WinServer2019_VS2019_Datacenter
+        container:
+          image: $(container_win)
+          endpoint: airsimci_acr_connection
+        variables:
+          ue4_root: $(ue4_root_win)
+        workspace:
+          clean: all
+
+        steps:
+          - checkout: self
+
+          # Build AirLib
+          - script: |
+              call "C:\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+              call .\build.cmd
+            displayName: Build AirLib
+
+          - script: |
+              call "C:\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+              call .\update_from_git.bat
+            workingDirectory: Unreal/Environments/Blocks
+            displayName: Copy AirLib to Blocks (update_from_git.bat)
+
+          # Build Blocks
+          - script: |
+              call "%UE4_ROOT%\Engine\Build\BatchFiles\Build.bat" Blocks Win64 Development -project="%CD%\Unreal\Environments\Blocks\Blocks.uproject"
+              call "%UE4_ROOT%\Engine\Build\BatchFiles\Build.bat" BlocksEditor Win64 Development -project="%CD%\Unreal\Environments\Blocks\Blocks.uproject"
+            displayName: Build Blocks - Development
+
+          # Package Blocks
+          - script: |
+              call "%UE4_ROOT%\Engine\Build\BatchFiles\RunUAT.bat" BuildCookRun -project="%CD%\Unreal\Environments\Blocks\Blocks.uproject" -nop4 -nocompile -build -cook -compressed -pak -allmaps -stage -archive -archivedirectory="%CD%\Unreal\Environments\Blocks\Packaged\Development" -clientconfig=Development -clean -utf8output
+            displayName: Package Blocks - Development
+
+          # Publish Artifact for Blocks Windows
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: 'Unreal/Environments/Blocks/Packaged'
+              artifactName: 'Blocks_Windows'
+            displayName: Artifact for Blocks Windows
+            condition: succeededOrFailed()
+
+          - task: ArchiveFiles@2
+            displayName: Blocks Windows Zip
+            inputs:
+              rootFolderOrFile: 'Unreal/Environments/Blocks/Packaged'
+              includeRootFolder: false
+              archiveType: 'zip'
+              archiveFile: 'Unreal/Environments/Blocks/Packaged/Blocks_Windows.zip'
+              replaceExistingArchive: true

--- a/pipelines/ci.yml
+++ b/pipelines/ci.yml
@@ -95,9 +95,9 @@ stages:
 
           - script: |
               call "C:\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
-              call .\update_from_git.bat
+              call .\update_from_git_ci.bat
             workingDirectory: Unreal/Environments/Blocks
-            displayName: Copy AirLib to Blocks (update_from_git.bat)
+            displayName: Copy AirLib to Blocks (update_from_git_ci.bat)
 
           # Build Blocks
           - script: |

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,4 @@
 #! /bin/bash
-set -e
 set -x
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -48,6 +47,13 @@ else #linux
     sudo apt-get install -y clang-8 clang++-8 libc++-8-dev libc++abi-8-dev
 fi
 
+if ! which cmake; then
+    # CMake not installed
+    cmake_ver=0
+else
+    cmake_ver=$(cmake --version 2>&1 | head -n1 | cut -d ' ' -f3 | awk '{print $NF}')
+fi
+
 #give user perms to access USB port - this is not needed if not using PX4 HIL
 #TODO: figure out how to do below in travis
 if [ "$(uname)" == "Darwin" ]; then # osx
@@ -57,7 +63,9 @@ if [ "$(uname)" == "Darwin" ]; then # osx
 
     brew install wget
     brew install coreutils
-    brew install cmake  # should get cmake 3.8
+    if version_less_than_equal_to $cmake_ver $MIN_CMAKE_VERSION; then
+        brew install cmake  # should get cmake 3.8
+    fi
 
 else #linux
     if [[ ! -z "${whoami}" ]]; then #this happens when running in travis
@@ -86,12 +94,6 @@ if [ "$(uname)" == "Linux" ]; then
     fi
 fi
 
-if ! which cmake; then
-    # CMake not installed
-    cmake_ver=0
-else
-    cmake_ver=$(cmake --version 2>&1 | head -n1 | cut -d ' ' -f3 | awk '{print $NF}')
-fi
 
 #download cmake - v3.10.2 is not out of box in Ubuntu 16.04
 if version_less_than_equal_to $cmake_ver $MIN_CMAKE_VERSION; then


### PR DESCRIPTION
This PR adds CI with self-hosted VMs for Windows and Linux builds of AirSim. 
The main new addition is building and packaging of the Unreal Engine Blocks project for both OS'es, with UE 4.25.1. 

The VMs and pipelines results are in a private Azure DevOps organization right now, however if the build fails, a reasonable error message does get looped back to the github UI. We may change this in future if it turns to be problematic for users. 

Here's a little snippet of a linux build: 

![Screenshot from 2020-07-20 14-19-48](https://user-images.githubusercontent.com/6305323/87999356-602ef880-caaf-11ea-86a0-79cebf32c83e.png)

Both linux and windows build take roughly 30 minutes