### PR TITLE
Disable cameras after fetching images, projection matrix

### DIFF
--- a/PythonClient/multirotor/high_res_camera.py
+++ b/PythonClient/multirotor/high_res_camera.py
@@ -1,0 +1,61 @@
+import airsim
+from datetime import datetime
+
+'''
+Simple script with settings to create a high-resolution camera, and fetching it
+
+Settings used-
+{
+    "SettingsVersion": 1.2,
+    "SimMode": "Multirotor",
+    "Vehicles" : {
+        "Drone1" : {
+            "VehicleType" : "SimpleFlight",
+            "AutoCreate" : true,
+            "Cameras" : {
+                "high_res": {
+                    "CaptureSettings" : [
+                        {
+                            "ImageType" : 0,
+                            "Width" : 4320,
+                            "Height" : 2160
+                        }
+                    ],
+                    "X": 0.50, "Y": 0.00, "Z": 0.10,
+                    "Pitch": 0.0, "Roll": 0.0, "Yaw": 0.0
+                },
+                "low_res": {
+                    "CaptureSettings" : [
+                        {
+                            "ImageType" : 0,
+                            "Width" : 256,
+                            "Height" : 144
+                        }
+                    ],
+                    "X": 0.50, "Y": 0.00, "Z": 0.10,
+                    "Pitch": 0.0, "Roll": 0.0, "Yaw": 0.0
+                }
+            }
+        }
+    }
+}
+'''
+
+client = airsim.VehicleClient()
+client.confirmConnection()
+framecounter = 1
+
+prevtimestamp = datetime.now()
+
+while(framecounter <= 500):
+    if framecounter%150 == 0:
+        client.simGetImages([airsim.ImageRequest("high_res", airsim.ImageType.Scene, False, False)])
+        print("High resolution image captured.")
+
+    if framecounter%30 == 0:
+        now = datetime.now()
+        print(f"Time spent for 30 frames: {now-prevtimestamp}")
+        prevtimestamp = now
+
+    client.simGetImages([airsim.ImageRequest("low_res", airsim.ImageType.Scene, False, False)])
+    framecounter += 1

--- a/Unreal/Plugins/AirSim/Source/PIPCamera.cpp
+++ b/Unreal/Plugins/AirSim/Source/PIPCamera.cpp
@@ -86,6 +86,8 @@ void APIPCamera::BeginPlay()
 
 msr::airlib::ProjectionMatrix APIPCamera::getProjectionMatrix(const APIPCamera::ImageType image_type) const
 {
+    msr::airlib::ProjectionMatrix mat;
+
     //TODO: avoid the need to override const cast here
     const_cast<APIPCamera*>(this)->setCameraTypeEnabled(image_type, true);
     const USceneCaptureComponent2D* capture = const_cast<APIPCamera*>(this)->getCaptureComponent(image_type, false);
@@ -161,18 +163,17 @@ msr::airlib::ProjectionMatrix APIPCamera::getProjectionMatrix(const APIPCamera::
         FMatrix projMatTransposeInAirSim = coordinateChangeTranspose * proj_mat_transpose;
 
         //Copy the result to an airlib::ProjectionMatrix while taking transpose.
-        msr::airlib::ProjectionMatrix mat;
         for (auto row = 0; row < 4; ++row)
             for (auto col = 0; col < 4; ++col)
                 mat.matrix[col][row] = projMatTransposeInAirSim.M[row][col];
-
-        return mat;
     }
-    else {
-        msr::airlib::ProjectionMatrix mat;
+    else
         mat.setTo(Utils::nan<float>());
-        return mat;
-    }
+
+    // Disable camera after our work is done
+    const_cast<APIPCamera*>(this)->setCameraTypeEnabled(image_type, false);
+
+    return mat;
 }
 
 void APIPCamera::Tick(float DeltaTime)

--- a/Unreal/Plugins/AirSim/Source/UnrealImageCapture.cpp
+++ b/Unreal/Plugins/AirSim/Source/UnrealImageCapture.cpp
@@ -112,6 +112,10 @@ void UnrealImageCapture::getSceneCaptureImage(const std::vector<msr::airlib::Ima
         response.width = render_results[i]->width;
         response.height = render_results[i]->height;
         response.image_type = request.image_type;
+
+        // Disable camera after fetching images
+        APIPCamera* camera = cameras_->at(request.camera_name);
+        camera->setCameraTypeEnabled(request.image_type, false);
     }
 
 }


### PR DESCRIPTION
Replaces #2465 by doing that internally

Before -
```
Time spent for 30 frames: 0:00:01.302084
Time spent for 30 frames: 0:00:01.319725
Time spent for 30 frames: 0:00:01.312358
Time spent for 30 frames: 0:00:01.333144
High resolution image captured.
Time spent for 30 frames: 0:00:01.675652
Time spent for 30 frames: 0:00:04.904762
Time spent for 30 frames: 0:00:04.817640
Time spent for 30 frames: 0:00:04.800456
Time spent for 30 frames: 0:00:04.828672
High resolution image captured.
Time spent for 30 frames: 0:00:05.155805
Time spent for 30 frames: 0:00:04.922219
```

After -
```
Time spent for 30 frames: 0:00:01.280212
Time spent for 30 frames: 0:00:01.275583
Time spent for 30 frames: 0:00:01.258539
Time spent for 30 frames: 0:00:01.270891
High resolution image captured.
Time spent for 30 frames: 0:00:01.641478
Time spent for 30 frames: 0:00:01.654431
Time spent for 30 frames: 0:00:01.611860
Time spent for 30 frames: 0:00:01.590966
Time spent for 30 frames: 0:00:01.578362
High resolution image captured.
Time spent for 30 frames: 0:00:01.901373
Time spent for 30 frames: 0:00:01.706202
Time spent for 30 frames: 0:00:01.683336
Time spent for 30 frames: 0:00:01.614648
Time spent for 30 frames: 0:00:01.599740
High resolution image captured.
Time spent for 30 frames: 0:00:01.964565
```

Not sure as to what is causing the still present increase in time, but still much better than earlier
Tested whether disabling camera affects subwindow, no effect
Haven't tested the projection matrix one though

Closes #1766, closes #2389, closes #2464