### PR TITLE
Fixes and improvements to world API

### DIFF
--- a/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
+++ b/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
@@ -248,6 +248,8 @@ void UAirBlueprintLib::GenerateAssetRegistryMap(const AActor* context, TMap<FStr
             FString asset_name = asset.AssetName.ToString();
             asset_map->Add(asset_name, *asset);
         }
+
+        LogMessageString("Asset database ready", "!", LogDebugLevel::Informational); 
     }, true);
 }
 

--- a/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
+++ b/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
@@ -24,6 +24,8 @@
 #include <exception>
 #include "common/common_utils/Utils.hpp"
 #include "Modules/ModuleManager.h"
+#include "ARFilter.h"
+#include "AssetRegistryModule.h"
 
 /*
 //TODO: change naming conventions to same as other files?
@@ -230,14 +232,14 @@ void UAirBlueprintLib::LogMessage(const FString &prefix, const FString &suffix, 
     //GEngine->AddOnScreenDebugMessage(key + 10, 60.0f, color, FString::FromInt(key));
 }
 
-void UAirBlueprintLib::GenerateAssetRegistryMap(const AActor* context, TMap<FString, FAssetData*> *asset_map)
+void UAirBlueprintLib::GenerateAssetRegistryMap(const UObject* context, TMap<FString, FAssetData>& asset_map)
 {
-    UAirBlueprintLib::RunCommandOnGameThread([asset_map]() {
+    UAirBlueprintLib::RunCommandOnGameThread([context, &asset_map]() {
         FARFilter Filter;
         Filter.ClassNames.Add(UStaticMesh::StaticClass()->GetFName());
         Filter.bRecursivePaths = true;
 
-        auto world = simmode_->GetWorld();
+        auto world = context->GetWorld();
         TArray<FAssetData> AssetData;
         FAssetRegistryModule &AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
         AssetRegistryModule.Get().GetAssets(Filter, AssetData);
@@ -246,7 +248,7 @@ void UAirBlueprintLib::GenerateAssetRegistryMap(const AActor* context, TMap<FStr
         for (auto asset : AssetData)
         {
             FString asset_name = asset.AssetName.ToString();
-            asset_map->Add(asset_name, *asset);
+            asset_map.Add(asset_name, asset);
         }
 
         LogMessageString("Asset database ready", "!", LogDebugLevel::Informational); 

--- a/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
+++ b/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
@@ -241,6 +241,8 @@ void UAirBlueprintLib::GenerateAssetRegistryMap(const UObject* context, TMap<FSt
 
         auto world = context->GetWorld();
         TArray<FAssetData> AssetData;
+
+        // Find mesh in /Game and /AirSim asset registry. When more plugins are added this function will have to change
         FAssetRegistryModule &AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
         AssetRegistryModule.Get().GetAssets(Filter, AssetData);
 
@@ -254,6 +256,19 @@ void UAirBlueprintLib::GenerateAssetRegistryMap(const UObject* context, TMap<FSt
         LogMessageString("Asset database ready", "!", LogDebugLevel::Informational); 
     }, true);
 }
+
+
+void UAirBlueprintLib::GenerateActorMap(const UObject* context, TMap<FString, AActor*>& scene_object_map) {
+    auto world = context->GetWorld();
+    for (TActorIterator<AActor> actorIterator(world); actorIterator; ++actorIterator) 
+    {
+        AActor* actor = *actorIterator;
+        FString name = *actor->GetName();
+
+        scene_object_map.Add(name, actor);
+    }
+}
+
 
 void UAirBlueprintLib::setUnrealClockSpeed(const AActor* context, float clock_speed)
 {

--- a/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
+++ b/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
@@ -230,6 +230,27 @@ void UAirBlueprintLib::LogMessage(const FString &prefix, const FString &suffix, 
     //GEngine->AddOnScreenDebugMessage(key + 10, 60.0f, color, FString::FromInt(key));
 }
 
+void UAirBlueprintLib::GenerateAssetRegistryMap(const AActor* context, TMap<FString, FAssetData*> *asset_map)
+{
+    UAirBlueprintLib::RunCommandOnGameThread([asset_map]() {
+        FARFilter Filter;
+        Filter.ClassNames.Add(UStaticMesh::StaticClass()->GetFName());
+        Filter.bRecursivePaths = true;
+
+        auto world = simmode_->GetWorld();
+        TArray<FAssetData> AssetData;
+        FAssetRegistryModule &AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+        AssetRegistryModule.Get().GetAssets(Filter, AssetData);
+
+        UObject *LoadObject = NULL;
+        for (auto asset : AssetData)
+        {
+            FString asset_name = asset.AssetName.ToString();
+            asset_map->Add(asset_name, *asset);
+        }
+    }, true);
+}
+
 void UAirBlueprintLib::setUnrealClockSpeed(const AActor* context, float clock_speed)
 {
     UAirBlueprintLib::RunCommandOnGameThread([context, clock_speed]() {

--- a/Unreal/Plugins/AirSim/Source/AirBlueprintLib.h
+++ b/Unreal/Plugins/AirSim/Source/AirBlueprintLib.h
@@ -85,6 +85,7 @@ public:
     UFUNCTION(BlueprintPure, Category = "AirSim|LevelAPI")
     static TArray<FName> ListWorldsInRegistry();
     static UObject* GetMeshFromRegistry(const std::string& load_object);
+    static void GenerateAssetRegistryMap(TMap<FString, FAssetData*> *asset_map);
 
     static bool HasObstacle(const AActor* actor, const FVector& start, const FVector& end,
         const AActor* ignore_actor = nullptr, ECollisionChannel collision_channel = ECC_Visibility);

--- a/Unreal/Plugins/AirSim/Source/AirBlueprintLib.h
+++ b/Unreal/Plugins/AirSim/Source/AirBlueprintLib.h
@@ -69,6 +69,7 @@ public:
         return nullptr;
     }
 
+
     template<typename T>
     static void FindAllActor(const UObject* context, TArray<AActor*>& foundActors)
     {
@@ -86,6 +87,7 @@ public:
     static TArray<FName> ListWorldsInRegistry();
     static UObject* GetMeshFromRegistry(const std::string& load_object);
     static void GenerateAssetRegistryMap(const UObject* context, TMap<FString, FAssetData>& asset_map);
+    static void GenerateActorMap(const UObject* context, TMap<FString, AActor*>& scene_object_map);
 
     static bool HasObstacle(const AActor* actor, const FVector& start, const FVector& end,
         const AActor* ignore_actor = nullptr, ECollisionChannel collision_channel = ECC_Visibility);

--- a/Unreal/Plugins/AirSim/Source/AirBlueprintLib.h
+++ b/Unreal/Plugins/AirSim/Source/AirBlueprintLib.h
@@ -85,7 +85,7 @@ public:
     UFUNCTION(BlueprintPure, Category = "AirSim|LevelAPI")
     static TArray<FName> ListWorldsInRegistry();
     static UObject* GetMeshFromRegistry(const std::string& load_object);
-    static void GenerateAssetRegistryMap(TMap<FString, FAssetData*> *asset_map);
+    static void GenerateAssetRegistryMap(const UObject* context, TMap<FString, FAssetData>& asset_map);
 
     static bool HasObstacle(const AActor* actor, const FVector& start, const FVector& end,
         const AActor* ignore_actor = nullptr, ECollisionChannel collision_channel = ECC_Visibility);

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
@@ -96,7 +96,7 @@ void ASimModeBase::BeginPlay()
     global_ned_transform_.reset(new NedTransform(player_start_transform, 
         UAirBlueprintLib::GetWorldToMetersScale(this)));
 
-    UAirBlueprintLib::GenerateAssetMap(asset_map);
+    UAirBlueprintLib::GenerateAssetRegistryMap(this, asset_map);
 
     world_sim_api_.reset(new WorldSimApi(this));
     api_provider_.reset(new msr::airlib::ApiProvider(world_sim_api_.get()));

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
@@ -96,6 +96,8 @@ void ASimModeBase::BeginPlay()
     global_ned_transform_.reset(new NedTransform(player_start_transform, 
         UAirBlueprintLib::GetWorldToMetersScale(this)));
 
+    UAirBlueprintLib::GenerateAssetMap(asset_map);
+
     world_sim_api_.reset(new WorldSimApi(this));
     api_provider_.reset(new msr::airlib::ApiProvider(world_sim_api_.get()));
     setupPhysicsLoopPeriod();

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
@@ -125,6 +125,7 @@ void ASimModeBase::BeginPlay()
         UWeatherLib::initWeather(World, spawned_actors_);
         //UWeatherLib::showWeatherMenu(World);
     }
+    UAirBlueprintLib::GenerateActorMap(this, scene_object_map);
 
     loading_screen_widget_->AddToViewport();
     loading_screen_widget_->SetVisibility(ESlateVisibility::Hidden);

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.h
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.h
@@ -89,6 +89,7 @@ public:
     }
 
     TMap<FString, FAssetData> asset_map;
+    TMap<FString, AActor*> scene_object_map;
 
 protected: //must overrides
     typedef msr::airlib::AirSimSettings AirSimSettings;

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.h
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.h
@@ -88,6 +88,9 @@ public:
         return static_cast<PawnSimApi*>(api_provider_->getVehicleSimApi(vehicle_name));
     }
 
+    UPROPERTY()
+        TMap<FString, FAssetData*> asset_map;
+
 protected: //must overrides
     typedef msr::airlib::AirSimSettings AirSimSettings;
 

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.h
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.h
@@ -88,8 +88,7 @@ public:
         return static_cast<PawnSimApi*>(api_provider_->getVehicleSimApi(vehicle_name));
     }
 
-    UPROPERTY()
-        TMap<FString, FAssetData*> asset_map;
+    TMap<FString, FAssetData> asset_map;
 
 protected: //must overrides
     typedef msr::airlib::AirSimSettings AirSimSettings;

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
@@ -84,9 +84,12 @@ std::string WorldSimApi::spawnObject(std::string& object_name, const std::string
     bool found_object;
     UAirBlueprintLib::RunCommandOnGameThread([this, load_object, &object_name, &actor_transform, &found_object, &scale]() {
             // Find mesh in /Game and /AirSim asset registry. When more plugins are added this function will have to change
-            UStaticMesh* LoadObject = dynamic_cast<UStaticMesh*>(UAirBlueprintLib::GetMeshFromRegistry(load_object));
-            if (LoadObject)
+            FString asset_name = FString(load_object.c_str());
+            FAssetData *LoadAsset = simmode_->asset_map.Find(asset_name);
+            
+            if (LoadAsset)
             {
+                UStaticMesh* LoadObject = dynamic_cast<UStaticMesh*>(LoadAsset->GetAsset());
                 std::vector<std::string> matching_names = UAirBlueprintLib::ListMatchingActors(simmode_->GetWorld(), ".*"+object_name+".*");
                 if (matching_names.size() > 0)
                 {

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
@@ -84,7 +84,7 @@ std::string WorldSimApi::spawnObject(std::string& object_name, const std::string
     // Create struct for Location and Rotation of actor in Unreal
     FTransform actor_transform = simmode_->getGlobalNedTransform().fromGlobalNed(pose);
     bool found_object = false, spawned_object = false;
-    UAirBlueprintLib::RunCommandOnGameThread([this, load_object, &object_name, &actor_transform, &found_object, &scale]() {
+    UAirBlueprintLib::RunCommandOnGameThread([this, load_object, &object_name, &actor_transform, &found_object, &spawned_object, &scale]() {
             // Find mesh in /Game and /AirSim asset registry. When more plugins are added this function will have to change
             FString asset_name = FString(load_object.c_str());
             FAssetData *LoadAsset = simmode_->asset_map.Find(asset_name);

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
@@ -88,7 +88,7 @@ std::string WorldSimApi::spawnObject(std::string& object_name, const std::string
     FTransform actor_transform = simmode_->getGlobalNedTransform().fromGlobalNed(pose);
 
     bool found_object = false, spawned_object = false;
-    UAirBlueprintLib::RunCommandOnGameThread([this, load_object, &object_name, &actor_transform, &found_object, &spawned_object, &scale]() {
+    UAirBlueprintLib::RunCommandOnGameThread([this, load_object, &object_name, &actor_transform, &found_object, &spawned_object, &scale, &physics_enabled]() {
             FString asset_name = FString(load_object.c_str());
             FAssetData *LoadAsset = simmode_->asset_map.Find(asset_name);
             

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
@@ -5,6 +5,7 @@
 #include "common/common_utils/Utils.hpp"
 #include "Weather/WeatherLib.h"
 #include "DrawDebugHelpers.h"
+#include "Runtime/Engine/Classes/Engine/Engine.h"
 #include <cstdlib>
 #include <ctime>
 

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.h
@@ -64,7 +64,7 @@ public:
     virtual bool isRecording() const override;
 
 private:
-    void createNewActor(const FActorSpawnParameters& spawn_params, const FTransform& actor_transform, const Vector3r& scale, UStaticMesh* static_mesh);
+    AActor* createNewActor(const FActorSpawnParameters& spawn_params, const FTransform& actor_transform, const Vector3r& scale, UStaticMesh* static_mesh);
     void spawnPlayer();
 
 private:


### PR DESCRIPTION
Consolidating some bug fixes and improvements to the world API. **Work in progress**.

- Handle the corner case when UE deletes an actor visually and from the actor list but reference still exists in memory, causing fatal errors when another object of the same name is spawned.
- Queue up garbage collection when an actor is destroyed.
- Use a TMap for name<->asset mapping, instead of iterating through all assets in the database in `GetMeshfromRegistry` at every spawn.
- Use a TMap for name<->actor mapping, instead of iterating through all actors in scene at every object API call.