### PR TITLE
Fixed Nested Bullet Point Rendering for airsim_ros_pkgs.md docs

### DIFF
--- a/docs/airsim_ros_pkgs.md
+++ b/docs/airsim_ros_pkgs.md
@@ -8,12 +8,12 @@ A ROS wrapper over the AirSim C++ client library.
 Verify version by `gcc --version`
 
 - Ubuntu 16.04
-  * Install [ROS kinetic](https://wiki.ros.org/kinetic/Installation/Ubuntu)
-  * Install tf2 sensor and mavros packages: `sudo apt-get install ros-kinetic-tf2-sensor-msgs ros-kinetic-mavros*`
+    * Install [ROS kinetic](https://wiki.ros.org/kinetic/Installation/Ubuntu)
+    * Install tf2 sensor and mavros packages: `sudo apt-get install ros-kinetic-tf2-sensor-msgs ros-kinetic-mavros*`
 
 - Ubuntu 18.04
-  * Install [ROS melodic](https://wiki.ros.org/melodic/Installation/Ubuntu)
-  * Install tf2 sensor and mavros packages: `sudo apt-get install ros-melodic-tf2-sensor-msgs ros-melodic-mavros*`
+    * Install [ROS melodic](https://wiki.ros.org/melodic/Installation/Ubuntu)
+    * Install tf2 sensor and mavros packages: `sudo apt-get install ros-melodic-tf2-sensor-msgs ros-melodic-mavros*`
 
 - Install [catkin_tools](https://catkin-tools.readthedocs.io/en/latest/installing.html)
     `sudo apt-get install python-catkin-tools` or


### PR DESCRIPTION
As you can see from below the docs for Airsim render differently to Github, this because of how [mkdocs](https://github.com/squidfunk/mkdocs-material/issues/508) renders nested lists.

The Docs             |  Github
:-------------------------:|:-------------------------:
![Screenshot from 2020-08-03 23-34-18](https://user-images.githubusercontent.com/9270934/89234739-85aa1f00-d5e4-11ea-852e-39871dc073b4.png)  |  ![Screenshot from 2020-08-03 23-34-31](https://user-images.githubusercontent.com/9270934/89234680-64493300-d5e4-11ea-83e7-be5ec4d1606d.png)

The quick fix is to add two more spaces for indentation.

Before            |  After
:-------------------------:|:-------------------------:
![Screenshot from 2020-08-03 23-35-35](https://user-images.githubusercontent.com/9270934/89234911-fe10e000-d5e4-11ea-9bea-199f6d70e49c.png) | ![Screenshot from 2020-08-03 23-35-15](https://user-images.githubusercontent.com/9270934/89234923-0701b180-d5e5-11ea-88a9-4208173690f0.png)

It's a very minor fix, but makes digesting information easier for new comers like me :smile: 

