### PR TITLE
Correct PX4 'params' to 'Parameters'

### DIFF
--- a/docs/px4_sitl.md
+++ b/docs/px4_sitl.md
@@ -48,7 +48,7 @@ The default ports have changed recently, so check them closely to make sure AirS
                 "UseTcp": true,
                 "TcpPort": 4560,
                 "ControlPort": 14580,
-                "params": {
+                "Parameters": {
                     "NAV_RCL_ACT": 0,
                     "NAV_DLL_ACT": 0,
                     "LPE_LAT": 47.641468,


### PR DESCRIPTION
PX4 Parameters are read by line 692 in AirSimSettings.hpp. The key word looked for is "Parameters", rather than "params" which is the current word used in documentation for settings.json in PX4 in SITL.

Before Correction:
Changes to parameter values in settings.json did not take effect on the running PX4 instance 

After Correction:
Changes to parameter values in settings.json successfully took effect on the running PX4 instance

Please let me know if you have any questions!