### PR TITLE
Fixed Quadrotor moveOnPath

### DIFF
--- a/AirLib/src/vehicles/multirotor/api/MultirotorApiBase.cpp
+++ b/AirLib/src/vehicles/multirotor/api/MultirotorApiBase.cpp
@@ -269,7 +269,7 @@ bool MultirotorApiBase::moveOnPath(const vector<Vector3r>& path, float velocity,
     float goal_dist = 0;
 
     //until we are at the end of the path (last seg is always zero size)
-    while (!waiter.isTimeout() && (next_path_loc.seg_index < path_segs.size()-1 || goal_dist > 0)
+    while (!waiter.isTimeout() && !waiter.isComplete() && (next_path_loc.seg_index < path_segs.size() || goal_dist > 0)
         ) { //current position is approximately at the last end point
 
         float seg_velocity = path_segs.at(next_path_loc.seg_index).seg_velocity;


### PR DESCRIPTION
As explained in #2917 , the last segment of path of moveOnPath (that affects to more functions to move the drone) was not taken into account so the drone did not move if the stated distance was low (and bigger than the lookahead_error).

By adding these two conditions to the loop, the bug seems to be fixed.