### PR TITLE
Update build_linux.md

### DIFF
--- a/docs/build_linux.md
+++ b/docs/build_linux.md
@@ -51,8 +51,6 @@ cd AirSim
 
 ```bash
 ./setup.sh
-./build.sh
-# use ./build.sh --debug to build in debug mode
 ```
 
 ### Build Unreal Environment


### PR DESCRIPTION
removed _build.sh_ from docs for Linux install of Unreal engine since it is no longer present