### PR TITLE
Add API for list of vehicle names

### DIFF
--- a/AirLib/include/api/RpcLibClientBase.hpp
+++ b/AirLib/include/api/RpcLibClientBase.hpp
@@ -129,6 +129,7 @@ namespace airlib
         bool isRecording();
 
         void simSetWind(const Vector3r& wind) const;
+        vector<string> listVehicles();
 
         std::string getSettingsString() const;
 

--- a/AirLib/include/api/WorldSimApiBase.hpp
+++ b/AirLib/include/api/WorldSimApiBase.hpp
@@ -82,6 +82,7 @@ namespace airlib
         virtual bool isRecording() const = 0;
 
         virtual void setWind(const Vector3r& wind) const = 0;
+        virtual vector<string> listVehicles() const = 0;
 
         virtual std::string getSettingsString() const = 0;
     };

--- a/AirLib/include/common/common_utils/UniqueValueMap.hpp
+++ b/AirLib/include/common/common_utils/UniqueValueMap.hpp
@@ -73,6 +73,15 @@ public:
         return vals_.size();
     }
 
+    std::vector<TKey> keys() const
+    {
+        std::vector<TKey> ret;
+        for (const auto& element : map_) {
+            ret.push_back(element.first);
+        }
+        return ret;
+    }
+
     //TODO: add erase methods
 
 private:

--- a/AirLib/src/api/RpcLibClientBase.cpp
+++ b/AirLib/src/api/RpcLibClientBase.cpp
@@ -483,6 +483,11 @@ __pragma(warning(disable : 4239))
             pimpl_->client.call("simSetWind", conv_wind);
         }
 
+        vector<string> RpcLibClientBase::listVehicles()
+        {
+            return pimpl_->client.call("listVehicles").as<vector<string>>();
+        }
+
         std::string RpcLibClientBase::getSettingsString() const
         {
             return pimpl_->client.call("getSettingsString").as<std::string>();

--- a/AirLib/src/api/RpcLibServerBase.cpp
+++ b/AirLib/src/api/RpcLibServerBase.cpp
@@ -383,6 +383,10 @@ namespace airlib
             getWorldSimApi()->setWind(wind.to());
         });
 
+        pimpl_->server.bind("listVehicles", [&]() -> vector<string> {
+            return getWorldSimApi()->listVehicles();
+        });
+
         pimpl_->server.bind("getSettingsString", [&]() -> std::string {
             return getWorldSimApi()->getSettingsString();
         });

--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -851,12 +851,21 @@ class VehicleClient:
             vehicle_name (str): Name of the vehicle being created
             vehicle_type (str): Type of vehicle, e.g. "simpleflight"
             pose (Pose): Initial pose of the vehicle
-            pawn_path (str): Vehicle blueprint path, default empty wbich uses the default blueprint for the vehicle type
+            pawn_path (str, optional): Vehicle blueprint path, default empty wbich uses the default blueprint for the vehicle type
 
         Returns:
             bool: Whether vehicle was created
         """
         return self.client.call('simAddVehicle', vehicle_name, vehicle_type, pose, pawn_path)
+
+    def listVehicles(self):
+        """
+        Lists the names of current vehicles
+
+        Returns:
+            list[str]: List containing names of all vehicles
+        """
+        return self.client.call('listVehicles')
 
     def getSettingsString(self):
         """

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.cpp
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.cpp
@@ -218,7 +218,17 @@ bool WorldSimApi::isRecording() const
 void WorldSimApi::setWind(const Vector3r& wind) const
 {
     simmode_->setWind(wind);
-};
+}
+
+std::vector<std::string> WorldSimApi::listVehicles() const
+{
+    auto vehicle_names = (simmode_->getApiProvider()->getVehicleSimApis()).keys();
+    // Remove '' from the list, representing default vehicle
+    auto position = std::find(vehicle_names.begin(), vehicle_names.end(), "");
+    if (position != vehicle_names.end())
+        vehicle_names.erase(position);
+    return vehicle_names;
+}
 
 bool WorldSimApi::addVehicle(const std::string& vehicle_name, const std::string& vehicle_type, const WorldSimApi::Pose& pose, const std::string& pawn_path)
 {

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.h
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.h
@@ -65,6 +65,7 @@ public:
     virtual void setWind(const Vector3r& wind) const override;
     virtual bool createVoxelGrid(const Vector3r& position, const int& x_size, const int& y_size, const int& z_size, const float& res, const std::string& output_file) override;
     virtual bool addVehicle(const std::string& vehicle_name, const std::string& vehicle_type, const Pose& pose, const std::string& pawn_path = "") override;
+    virtual std::vector<std::string> listVehicles() const override;
 
     virtual std::string getSettingsString() const override;
 

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
@@ -607,6 +607,22 @@ void WorldSimApi::setWind(const Vector3r& wind) const
     simmode_->setWind(wind);
 }
 
+std::vector<std::string> WorldSimApi::listVehicles() const
+{
+    std::vector<std::string> vehicle_names;
+
+    UAirBlueprintLib::RunCommandOnGameThread([this, &vehicle_names]() {
+        vehicle_names = (simmode_->getApiProvider()->getVehicleSimApis()).keys();
+    },
+                                             true);
+
+    // Remove '' from the list, representing default vehicle
+    auto position = std::find(vehicle_names.begin(), vehicle_names.end(), "");
+    if (position != vehicle_names.end())
+        vehicle_names.erase(position);
+    return vehicle_names;
+}
+
 std::string WorldSimApi::getSettingsString() const
 {
     return msr::airlib::AirSimSettings::singleton().settings_text_;

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.h
@@ -70,6 +70,7 @@ public:
 
     virtual void setWind(const Vector3r& wind) const override;
     virtual bool createVoxelGrid(const Vector3r& position, const int& x_size, const int& y_size, const int& z_size, const float& res, const std::string& output_file) override;
+    virtual std::vector<std::string> listVehicles() const override;
 
     virtual std::string getSettingsString() const override;
 

--- a/docs/multi_vehicle.md
+++ b/docs/multi_vehicle.md
@@ -53,5 +53,12 @@ The new APIs since AirSim 1.2 allows you to specify `vehicle_name`. This name co
 
 [Example code for multirotors](https://github.com/Microsoft/AirSim/tree/master/PythonClient//multirotor/multi_agent_drone.py)
 
+Using APIs for multi-vehicles requires specifying the `vehicle_name`, which needs to be hardcoded in the script or requires parsing of the settings file. There's also a simple API `listVehicles()` which returns a list (vector in C++) of strings containing names of the current vehicles. For example, with the above settings for 2 Cars -
+
+```
+>>> client.listVehicles()
+['Car1', 'Car2']
+```
+
 ### Demo
 [![AirSimMultiple Vehicles Demo Video](images/demo_multi_vehicles.png)](https://youtu.be/35dgcuLuF5M)


### PR DESCRIPTION
Settings -
```json
{
    "SettingsVersion": 1.2,
    "SimMode": "Car",

    "Vehicles": {
        "Car1": {
          "VehicleType": "PhysXCar"
        },
        "Car2": {
          "VehicleType": "PhysXCar",
          "X": 0, "Y": 10, "Z": 0
        }
    }
}
```
API -
```
>>> client.listVehicles()
['Car1', 'Car2']
>>> 
```

Came to mind in #2921, just wrote it since was straightforward to implement

The keys contain an empty string, coming from it being used to refer to the default vehicle, see [ApiProvider.hpp](https://github.com/microsoft/AirSim/blob/master/AirLib/include/api/ApiProvider.hpp#L67) being called from [SimModeBase.cpp](https://github.com/microsoft/AirSim/blob/master/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp#L589)
A simple way is to just remove the empty string ourselves, which is being done right now.
However, the API could also mean - return a list of _valid vehicle names which can be passed to APIs_, in which case empty string is valid. But it could also introduce more complexity to the client code, such as removing the empty string if data of each vehicle is required only once, and having an empty string will duplicate calls for one vehicle.
I'm leaning towards removing the empty string, and will add that behaviour in the PR. But do comment if the second behaviour makes more sense. 

Could be particularly useful if #2390 goes in (which I hope to update in the next few days)
Not much of an use-case otherwise, just allows the user to avoid parsing the settings for getting the vehicle names