### PR TITLE
Removed double inclusion of static_transforms.launch

### DIFF
--- a/ros/src/airsim_ros_pkgs/launch/airsim_with_simple_PD_position_controller.launch
+++ b/ros/src/airsim_ros_pkgs/launch/airsim_with_simple_PD_position_controller.launch
@@ -6,6 +6,4 @@
 	<include file="$(find airsim_ros_pkgs)/launch/dynamic_constraints.launch"/>
 <!-- Simple PID Position Controller -->
 	<include file="$(find airsim_ros_pkgs)/launch/position_controller_simple.launch"/>
-<!-- Static transforms -->
-	<include file="$(find airsim_ros_pkgs)/launch/static_transforms.launch"/>
 </launch>


### PR DESCRIPTION
Mentioned in #2789: removed double inclusion of `static_transforms.launch` from `airsim_with_simple_PD_position_controller.launch` (`static_transforms.launch` is included in `airsim_node.launch`)