### PR TITLE
Update Docker scripts, info

### DIFF
--- a/docker/Dockerfile_binary
+++ b/docker/Dockerfile_binary
@@ -1,26 +1,23 @@
 ARG BASE_IMAGE=nvidia/cudagl:10.0-devel-ubuntu18.04
 FROM $BASE_IMAGE
 
-RUN apt-get update
-RUN apt-get install \
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-install-recommends \
 	python3 \
 	python3-pip \
 	sudo \
 	libglu1-mesa-dev \
 	xdg-user-dirs \
 	pulseaudio \
-	sudo \
-	x11-xserver-utils \
-	-y --no-install-recommends
-RUN pip3 install setuptools wheel
-RUN python3 -m pip install --upgrade pip
-RUN pip3 install scikit-build
-RUN pip3 install airsim
+	x11-xserver-utils
 
-RUN adduser --force-badname --disabled-password --gecos '' --shell /bin/bash airsim_user && \ 
-	echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \ 
-	adduser airsim_user sudo && \ 
-	adduser airsim_user audio && \ 
+RUN python3 -m pip install --upgrade pip && \
+    pip3 install setuptools wheel && \
+    pip3 install airsim
+
+RUN adduser --force-badname --disabled-password --gecos '' --shell /bin/bash airsim_user && \
+	echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
+	adduser airsim_user sudo && \
+	adduser airsim_user audio && \
 	adduser airsim_user video
 
 USER airsim_user

--- a/docker/Dockerfile_source
+++ b/docker/Dockerfile_source
@@ -2,15 +2,13 @@ ARG BASE_IMAGE=adamrehn/ue4-engine:4.19.2-cudagl10.0
 FROM $BASE_IMAGE
 
 USER root
-RUN apt-get update
-RUN apt-get install \
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-install-recommends \
 	rsync \
     sudo \
     wget \
-    x11-xserver-utils \
-    -y --no-install-recommends
+    x11-xserver-utils
 
-RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \ 
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
     adduser ue4 sudo 
 
 USER ue4
@@ -19,5 +17,5 @@ RUN cd /home/ue4 && \
 	cd AirSim && \
 	./setup.sh && \
 	./build.sh
-	
+
 WORKDIR /home/ue4

--- a/docker/download_blocks_env_binary.sh
+++ b/docker/download_blocks_env_binary.sh
@@ -1,4 +1,9 @@
-sudo apt-get install unzip
-wget -c https://github.com/Microsoft/AirSim/releases/download/v1.2.0Linux/Blocks.zip
+#!/bin/bash
+
+if ! which unzip; then
+    sudo apt-get install unzip
+fi
+
+wget -c https://github.com/microsoft/AirSim/releases/download/v1.4.0-linux/Blocks.zip
 unzip Blocks.zip
 rm Blocks.zip

--- a/docker/download_blocks_env_binary.sh
+++ b/docker/download_blocks_env_binary.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
+set -x
 
 if ! which unzip; then
     sudo apt-get install unzip
 fi
 
-wget -c https://github.com/microsoft/AirSim/releases/download/v1.4.0-linux/Blocks.zip
-unzip Blocks.zip
+wget -c https://github.com/microsoft/AirSim/releases/download/v1.6.0-linux/Blocks.zip 
+unzip -q Blocks.zip
 rm Blocks.zip

--- a/docker/run_airsim_image_binary.sh
+++ b/docker/run_airsim_image_binary.sh
@@ -1,9 +1,24 @@
+#!/bin/bash
 DOCKER_IMAGE_NAME=$1
 
 # get the base directory name of the unreal binary's shell script
 # we'll mount this volume while running docker container
 UNREAL_BINARY_PATH=$(dirname $(readlink -f $2))
 UNREAL_BINARY_SHELL_ABSPATH=$(readlink -f $2)
+
+# This is to determine Docker version for the command
+version_less_than_equal_to() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" = "$1"; }
+
+REQ_DOCKER_VERSION=19.03
+docker_version=$(docker -v | cut -d ' ' -f3 | sed 's/,$//')
+
+if version_less_than_equal_to $REQ_DOCKER_VERSION $docker_version; then
+    # Use the normal docker command
+    DOCKER_CMD="docker run --gpus all"
+else
+    # Use nvidia-docker
+    DOCKER_CMD="nvidia-docker run --runtime=nvidia"
+fi
 
 # this block is for running X apps in docker
 XAUTH=/tmp/.docker.xauth
@@ -46,7 +61,7 @@ done
 # now, let's mount the user directory which points to the unreal binary (UNREAL_BINARY_PATH)
 # set the environment varible SDL_VIDEODRIVER to SDL_VIDEODRIVER_VALUE
 # and tell the docker container to execute UNREAL_BINARY_COMMAND
-nvidia-docker run -it \
+$DOCKER_CMD -it \
     -v $(pwd)/settings.json:/home/airsim_user/Documents/AirSim/settings.json \
     -v $UNREAL_BINARY_PATH:$UNREAL_BINARY_PATH \
     -e SDL_VIDEODRIVER=$SDL_VIDEODRIVER_VALUE \
@@ -57,7 +72,6 @@ nvidia-docker run -it \
     --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" \
     -env="XAUTHORITY=$XAUTH" \
     --volume="$XAUTH:$XAUTH" \
-    --runtime=nvidia \
     --rm \
     $DOCKER_IMAGE_NAME \
     /bin/bash -c "$UNREAL_BINARY_COMMAND"

--- a/docs/docker_ubuntu.md
+++ b/docs/docker_ubuntu.md
@@ -3,13 +3,13 @@ We've two options for docker. You can either build an image for running [airsim 
 
 ## Binaries
 #### Requirements:
-- Install [nvidia-docker2](https://github.com/NVIDIA/nvidia-docker/wiki/Installation-(version-2.0))
+- Install [nvidia-docker2](https://github.com/NVIDIA/nvidia-docker#quickstart)
 
 #### Build the docker image
-- Below are the default arguments.   
-  `--base_image`: This is image over which we'll install airsim. We've tested on Ubuntu 18.04 with CUDA 10.0.  
-   You can specify any [NVIDIA cudagl](https://hub.docker.com/r/nvidia/cudagl/) at your own risk.    
-   `--target_image` is the desired name of your docker image.    
+- Below are the default arguments.
+  `--base_image`: This is image over which we'll install airsim. We've tested on Ubuntu 18.04 with CUDA 10.0.
+   You can specify any [NVIDIA cudagl](https://hub.docker.com/r/nvidia/cudagl/) at your own risk.
+   `--target_image` is the desired name of your docker image.
    Defaults to `airsim_binary` with same tag as the base image
 
 ```bash
@@ -20,11 +20,11 @@ $ python build_airsim_image.py \
 ```
 
 - Verify you have an image by:
- `$ docker images | grep airsim`   
+ `$ docker images | grep airsim`
 
-#### Running an unreal binary inside a docker container 
-- Get [an unreal binary](https://github.com/Microsoft/AirSim/releases/tag/v1.2.0Linux) or package your own project in Ubuntu.   
-Let's take the Blocks binary as an example.   
+#### Running an unreal binary inside a docker container
+- Get [a Linux binary](https://github.com/Microsoft/AirSim/releases) or package your own project in Ubuntu.
+Let's take the Blocks binary as an example.
 You can download it by running
 
 ```bash
@@ -32,57 +32,60 @@ You can download it by running
    $ ./download_blocks_env_binary.sh
 ```
 
-- Running an unreal binary inside a docker container 
+This currently downloads release `v1.3.1` Linux Blocks binary, modify it to fetch the binary required.
+
+- Running an unreal binary inside a docker container
    The syntax is:
 
 ```bash
-   $ ./run_airsim_image_binary.sh DOCKER_IMAGE_NAME UNREAL_BINARY_SHELL_SCRIPT UNREAL_BINARY_ARGUMENTS -- headless     
+   $ ./run_airsim_image_binary.sh DOCKER_IMAGE_NAME UNREAL_BINARY_SHELL_SCRIPT UNREAL_BINARY_ARGUMENTS -- headless
 ```
 
-   For blocks, you can do a `$ ./run_airsim_image_binary.sh airsim_binary:10.0-devel-ubuntu18.04 Blocks/Blocks.sh -windowed -ResX=1080 -ResY=720`
+   For Blocks, you can do a `$ ./run_airsim_image_binary.sh airsim_binary:10.0-devel-ubuntu18.04 Blocks/Blocks.sh -windowed -ResX=1080 -ResY=720`
 
-   * `DOCKER_IMAGE_NAME`: Same as `target_image` parameter in previous step. By default, enter `airsim_binary:10.0-devel-ubuntu18.04`   
+   * `DOCKER_IMAGE_NAME`: Same as `target_image` parameter in previous step. By default, enter `airsim_binary:10.0-devel-ubuntu18.04`
    * `UNREAL_BINARY_SHELL_SCRIPT`: for Blocks enviroment, it will be `Blocks/Blocks.sh`
    * [`UNREAL_BINARY_ARGUMENTS`](https://docs.unrealengine.com/en-us/Programming/Basics/CommandLineArguments):
-      For airsim, most relevant would be `-windowed`, `-ResX`, `-ResY`. Click on link to see all options. 
-         
-  * Running in Headless mode:    
+      For airsim, most relevant would be `-windowed`, `-ResX`, `-ResY`. Click on link to see all options.
+
+  * Running in Headless mode:
       Suffix `-- headless` at the end:
 ```bash
 $ ./run_airsim_image_binary.sh Blocks/Blocks.sh -- headless
 ```
 
-- [Specifying a `settings.json`](docker_ubuntu.md#airsim_binary-docker-image)
+- [Specifying a `settings.json`](#specifying-settingsjson)
 
 ## Source
 #### Requirements:
-- Install [nvidia-docker2](https://github.com/NVIDIA/nvidia-docker/wiki/Installation-(version-2.0))
+- Install [nvidia-docker2](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)
 - Install [ue4-docker](https://docs.adamrehn.com/ue4-docker/configuration/configuring-linux)
 
 #### Build Unreal Engine inside docker:
- * To get access to Unreal Engine's source code, register on Epic Games' website and link it to your github account, as explained in the `Required Steps` section [here](https://docs.unrealengine.com/en-us/Platforms/Linux/BeginnerLinuxDeveloper/SettingUpAnUnrealWorkflow).    
-    Note that you don't need to do `Step 2: Downloading UE4 on Linux`! 
+- To get access to Unreal Engine's source code, register on Epic Games' website and link it to your github account, as explained in the `Required Steps` section [here](https://docs.unrealengine.com/en-us/Platforms/Linux/BeginnerLinuxDeveloper/SettingUpAnUnrealWorkflow).
 
- * Build unreal engine 4.19.2 docker image. We're going to use CUDA 10.0 in our example.    
-    `$ ue4-docker build 4.19.2 --cuda=10.0 --no-full`   
-    [optional] `$ ue4-docker clean` to free up some space. [Details here](https://docs.adamrehn.com/ue4-docker/commands/clean) 
-   - `ue4-docker` supports all CUDA version listed on NVIDIA's cudagl dockerhub [here](https://hub.docker.com/r/nvidia/cudagl/).    
-   - Please see [this page](https://docs.adamrehn.com/ue4-docker/building-images/advanced-build-options) for advanced configurations using `ue4-docker`   
+    Note that you don't need to do `Step 2: Downloading UE4 on Linux`!
 
- * Disk space:
-   - The unreal images and containers can take up a lot of space, especially if you try more than one version.    
-   - Here's a list of useful links to monitor space used by docker and clean up intermediate builds:
-     * [Large container images primer](https://docs.adamrehn.com/ue4-docker/read-these-first/large-container-images-primer)  
-     * [$ `docker system df`](https://docs.docker.com/engine/reference/commandline/system_df/)   
-       [$ `docker container prune`](https://docs.docker.com/engine/reference/commandline/container_prune/)   
-       [$ `docker image prune`](https://docs.docker.com/engine/reference/commandline/image_prune/)   
-       [$ `docker system prune`](https://docs.docker.com/engine/reference/commandline/system_df/)   
+- Build unreal engine 4.19.2 docker image. We're going to use CUDA 10.0 in our example.
+    `$ ue4-docker build 4.19.2 --cuda=10.0 --no-full`
+    - [optional] `$ ue4-docker clean` to free up some space. [Details here](https://docs.adamrehn.com/ue4-docker/commands/clean)
+    - `ue4-docker` supports all CUDA version listed on NVIDIA's cudagl dockerhub [here](https://hub.docker.com/r/nvidia/cudagl/).
+    - Please see [this page](https://docs.adamrehn.com/ue4-docker/building-images/advanced-build-options) for advanced configurations using `ue4-docker`
+
+- Disk space:
+    - The unreal images and containers can take up a lot of space, especially if you try more than one version.
+    - Here's a list of useful links to monitor space used by docker and clean up intermediate builds:
+        - [Large container images primer](https://docs.adamrehn.com/ue4-docker/read-these-first/large-container-images-primer)
+        - [`docker system df`](https://docs.docker.com/engine/reference/commandline/system_df/)
+        - [`docker container prune`](https://docs.docker.com/engine/reference/commandline/container_prune/)
+        - [`docker image prune`](https://docs.docker.com/engine/reference/commandline/image_prune/)
+        - [`docker system prune`](https://docs.docker.com/engine/reference/commandline/system_prune/)
 
 #### Building AirSim inside UE4 docker container:
-* Build AirSim docker image (which lays over the unreal image we just built)   
-  Below are the default arguments.   
-  `--base_image`: This is image over which we'll install airsim. We've tested on `adamrehn/ue4-engine:4.19.2-cudagl10.0`. See [ue4-docker](https://docs.adamrehn.com/ue4-docker/building-images/available-container-images) for other versions.     
-   `--target_image` is the desired name of your docker image.    
+* Build AirSim docker image (which lays over the unreal image we just built)
+  Below are the default arguments.
+    - `--base_image`: This is image over which we'll install airsim. We've tested on `adamrehn/ue4-engine:4.19.2-cudagl10.0`. See [ue4-docker](https://docs.adamrehn.com/ue4-docker/building-images/available-container-images) for other versions.
+    - `--target_image` is the desired name of your docker image.
    Defaults to `airsim_source` with same tag as the base image
 
 ```bash
@@ -101,17 +104,17 @@ $ python build_airsim_image.py \
 ```
 
    Syntax is `./run_airsim_image_source.sh DOCKER_IMAGE_NAME -- headless`
-   `-- headless`: suffix this to run in optional headless mode. 
+   `-- headless`: suffix this to run in optional headless mode.
 
-* Inside the container, you can see `UnrealEngine` and `AirSim` under `/home/ue4`. 
-* Start unreal engine inside the container:   
+* Inside the container, you can see `UnrealEngine` and `AirSim` under `/home/ue4`.
+* Start unreal engine inside the container:
    `ue4@HOSTMACHINE:~$ /home/ue4/UnrealEngine/Engine/Binaries/Linux/UE4Editor`
-* See [Specifying an airsim settings.json](docker_ubuntu.md#airsim_source-docker-image) below.
-* Continue with [AirSim's Linux docs](build_linux.md#build-unreal-environment). 
+* [Specifying an airsim settings.json](#specifying-settingsjson)
+* Continue with [AirSim's Linux docs](build_linux.md#build-unreal-environment).
 
 #### [Misc] Packaging Unreal Environments in `airsim_source` containers
-* Let's take the Blocks environment as an example.    
-    In the following script, specify the full path to your unreal uproject file by `project` and the directory where you want the binaries to be placed by `archivedirectory` 
+* Let's take the Blocks environment as an example.
+    In the following script, specify the full path to your unreal uproject file by `project` and the directory where you want the binaries to be placed by `archivedirectory`
 
 ```bash
 $ /home/ue4/UnrealEngine/Engine/Build/BatchFiles/RunUAT.sh BuildCookRun -platform=Linux -clientconfig=Shipping -serverconfig=Shipping -noP4 -cook -allmaps -build -stage -prereqs -pak -archive \
@@ -119,16 +122,16 @@ $ /home/ue4/UnrealEngine/Engine/Build/BatchFiles/RunUAT.sh BuildCookRun -platfor
 -project=/home/ue4/AirSim/Unreal/Environments/Blocks/Blocks.uproject
 ```
 
-    This would create a Blocks binary in `/home/ue4/Binaries/Blocks/`.   
-    You can test it by running `/home/ue4/Binaries/Blocks/LinuxNoEditor/Blocks.sh -windowed`   
+This would create a Blocks binary in `/home/ue4/Binaries/Blocks/`.
+You can test it by running `/home/ue4/Binaries/Blocks/LinuxNoEditor/Blocks.sh -windowed`
 
-### Specifying an airsim settings.json
+### Specifying settings.json
 #### `airsim_binary` docker image:
-  - We're mapping the host machine's `PATH/TO/Airsim/docker/settings.json` to the docker container's `/home/airsim_user/Documents/AirSim/settings.json`.    
-  - Hence, we can load any settings file by simply modifying `PATH_TO_YOUR/settings.json` by modifying the following snippets in * [`run_airsim_image_binary.sh`](https://github.com/Microsoft/AirSim/blob/master/docker/run_airsim_image_binary.sh)
+  - We're mapping the host machine's `PATH/TO/Airsim/docker/settings.json` to the docker container's `/home/airsim_user/Documents/AirSim/settings.json`.
+  - Hence, we can load any settings file by simply modifying `PATH_TO_YOUR/settings.json` by modifying the following snippets in [`run_airsim_image_binary.sh`](https://github.com/Microsoft/AirSim/blob/master/docker/run_airsim_image_binary.sh)
 
 ```bash
-nvidia-docker run -it \
+nvidia-docker run --runtime=nvidia -it \
       -v $PATH_TO_YOUR/settings.json:/home/airsim_user/Documents/AirSim/settings.json \
       -v $UNREAL_BINARY_PATH:$UNREAL_BINARY_PATH \
       -e SDL_VIDEODRIVER=$SDL_VIDEODRIVER_VALUE \
@@ -139,19 +142,25 @@ nvidia-docker run -it \
       --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" \
       -env="XAUTHORITY=$XAUTH" \
       --volume="$XAUTH:$XAUTH" \
-      --runtime=nvidia \
       --rm \
       $DOCKER_IMAGE_NAME \
       /bin/bash -c "$UNREAL_BINARY_COMMAND"
 ```
 
+**Note:** Docker version >=19.03 (check using `docker -v`), natively supports Nvidia GPUs, so run using `--gpus all` flag as given -
+
+```bash
+docker run --gpus all -it \
+    ...
+```
+
 ####  `airsim_source` docker image:
 
-  * We're mapping the host machine's `PATH/TO/Airsim/docker/settings.json` to the docker container's `/home/airsim_user/Documents/AirSim/settings.json`.    
+  * We're mapping the host machine's `PATH/TO/Airsim/docker/settings.json` to the docker container's `/home/airsim_user/Documents/AirSim/settings.json`.
   * Hence, we can load any settings file by simply modifying `PATH_TO_YOUR/settings.json` by modifying the following snippets in [`run_airsim_image_source.sh`](https://github.com/Microsoft/AirSim/blob/master/docker/run_airsim_image_source.sh):
 
 ```bash
-   nvidia-docker run -it \
+   nvidia-docker run --runtime=nvidia -it \
       -v $(pwd)/settings.json:/home/airsim_user/Documents/AirSim/settings.json \
       -e SDL_VIDEODRIVER=$SDL_VIDEODRIVER_VALUE \
       -e SDL_HINT_CUDA_DEVICE='0' \
@@ -161,7 +170,6 @@ nvidia-docker run -it \
       --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" \
       -env="XAUTHORITY=$XAUTH" \
       --volume="$XAUTH:$XAUTH" \
-      --runtime=nvidia \
       --rm \
    $DOCKER_IMAGE_NAME
 ```

--- a/docs/docker_ubuntu.md
+++ b/docs/docker_ubuntu.md
@@ -32,7 +32,7 @@ You can download it by running
    $ ./download_blocks_env_binary.sh
 ```
 
-This currently downloads release `v1.3.1` Linux Blocks binary, modify it to fetch the binary required.
+Modify it to fetch the specific binary required.
 
 - Running an unreal binary inside a docker container
    The syntax is:


### PR DESCRIPTION
Docker version >= 19.03 natively supports Nvidia GPUs, and there's no need to run using `nvidia-docker2` which has been deprecated. Update the script to use the correct command as required, also update some links for installation

This currently uses OpenGL, which is deprecated
Also using `-- headless` causes an error -
```
[2020.08.19-04.58.16:458][  0]LogHAL: Warning: Splash screen image not found.
[2020.08.19-04.58.16:461][  0]LogSlate: New Slate User Created.  User Index 0, Is Virtual User: 0
[2020.08.19-04.58.16:461][  0]LogSlate: Slate User Registered.  User Index 0, Is Virtual User: 0
[2020.08.19-04.58.16:462][  0]LogInit: Using SDL_WINDOW_OPENGL
Signal 11 caught.
Malloc Size=65538 LargeMemoryPoolOffset=65554 
CommonUnixCrashHandler: Signal=11
Malloc Size=65535 LargeMemoryPoolOffset=131119 
Malloc Size=107920 LargeMemoryPoolOffset=239056 
Failed to find symbol file, expected location:
"/home/rajat/AirSim/docker/Blocks/Blocks/Binaries/Linux/Blocks.sym"
```
