### PR TITLE
Disable LogMessages if set to false

### DIFF
--- a/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
+++ b/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
@@ -189,6 +189,15 @@ IImageWrapperModule* UAirBlueprintLib::getImageWrapperModule()
     return image_wrapper_module_;
 }
 
+void UAirBlueprintLib::setLogMessagesVisibility(bool is_visible)
+{
+    log_messages_hidden_ = !is_visible;
+
+    // if hidden, clear any existing messages
+    if (!is_visible && GEngine)
+        GEngine->ClearOnScreenDebugMessages();
+}
+
 void UAirBlueprintLib::LogMessage(const FString &prefix, const FString &suffix, LogDebugLevel level, float persist_sec)
 {
     if (log_messages_hidden_)

--- a/Unreal/Plugins/AirSim/Source/AirBlueprintLib.h
+++ b/Unreal/Plugins/AirSim/Source/AirBlueprintLib.h
@@ -171,10 +171,8 @@ public:
     {
         return log_messages_hidden_;
     }
-    static void setLogMessagesHidden(bool is_hidden)
-    {
-        log_messages_hidden_ = is_hidden;
-    }
+    static void setLogMessagesVisibility(bool is_visible);
+
     static void SetMeshNamingMethod(msr::airlib::AirSimSettings::SegmentationSetting::MeshNamingMethodType method)
     {
         mesh_naming_method_ = method;

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
@@ -98,6 +98,9 @@ void ASimModeBase::BeginPlay()
 
     world_sim_api_.reset(new WorldSimApi(this));
     api_provider_.reset(new msr::airlib::ApiProvider(world_sim_api_.get()));
+
+    UAirBlueprintLib::setLogMessagesVisibility(getSettings().log_messages_visible);
+
     setupPhysicsLoopPeriod();
 
     setupClockSpeed();


### PR DESCRIPTION
Settings - 
```
{
  "SettingsVersion": 1.2,
  "SimMode": "Car",
  "RecordUIVisible": false,
  "LogMessagesVisible": false
}
```

![Screenshot from 2020-08-18 11-06-07](https://user-images.githubusercontent.com/37938604/90474491-03bd0880-e143-11ea-809b-78d5d82fa5f2.png)

Closes #1007

If OnScreenMessages aren't cleared, then the settings log message appears since it's being done before others, remains for 60sec.
Thanks to #1583 for how to clear the debug messages