### PR TITLE
[Travis] Add Ubuntu 20.04, OSX XCode 11.5 jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ jobs:
       os: linux
       dist: bionic
 
+    - name: Ubuntu 20.04
+      os: linux
+      dist: focal
+
     - name: Ubuntu 16.04
       os: linux
       dist: xenial
@@ -16,9 +20,13 @@ jobs:
         - MSBUILD_PATH="c:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\16.0\Bin"
         - PATH_FIX="C:\Windows\System32"
 
-    - name: MacOS
+    - name: XCode 11.4.1
       os: osx
       osx_image: xcode11.4
+
+    - name: XCode 11.5
+      os: osx
+      osx_image: xcode11.5
 
 
 before_install:

--- a/tools/install_ros_deps.sh
+++ b/tools/install_ros_deps.sh
@@ -15,11 +15,12 @@ sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main
 sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 sudo apt update
-sudo apt install ros-$ROS_DISTRO-desktop-full
+sudo apt install -qq ros-$ROS_DISTRO-desktop-full
 
 echo "source /opt/ros/$ROS_DISTRO/setup.bash" >> ~/.bashrc
 
-sudo apt install python-rosdep python-rosinstall python-rosinstall-generator python-wstool build-essential
+sudo apt install python3-pip python3-yaml python3-setuptools
+sudo pip3 install rosdep rosinstall rospkg catkin-pkg
 sudo rosdep init
 rosdep update
 
@@ -33,4 +34,4 @@ fi
 sudo apt-get install gcc-8 g++-8
 sudo apt-get install ros-$ROS_DISTRO-mavros*
 sudo apt-get install ros-$ROS_DISTRO-tf2-sensor-msgs
-sudo apt-get install python-catkin-tools
+sudo pip3 install catkin-tools

--- a/tools/install_ros_deps.sh
+++ b/tools/install_ros_deps.sh
@@ -32,6 +32,11 @@ if [[ "$DISTRO" == "xenial" ]]; then
 fi
 
 sudo apt-get install gcc-8 g++-8
-sudo apt-get install ros-$ROS_DISTRO-mavros*
-sudo apt-get install ros-$ROS_DISTRO-tf2-sensor-msgs
-sudo pip3 install catkin-tools
+sudo apt-get install ros-$ROS_DISTRO-mavros* ros-$ROS_DISTRO-tf2-sensor-msgs
+
+# TODO: Remove this if-block when new 0.7.0 release of catkin_tools is available
+if [[ "$DISTRO" == "focal" ]]; then
+    sudo pip3 install "git+https://github.com/catkin/catkin_tools.git#egg=catkin_tools"
+else
+    sudo pip3 install catkin-tools
+fi

--- a/tools/install_ros_deps.sh
+++ b/tools/install_ros_deps.sh
@@ -3,7 +3,9 @@
 set -x
 
 DISTRO="$(lsb_release -sc)"
-if [[ "$DISTRO" == "bionic" ]]; then
+if [[ "$DISTRO" == "focal" ]]; then
+    ROS_DISTRO="noetic"
+elif [[ "$DISTRO" == "bionic" ]]; then
     ROS_DISTRO="melodic"
 elif [[ "$DISTRO" == "xenial" ]]; then
     ROS_DISTRO="kinetic"


### PR DESCRIPTION
No documentation changes until tested, currently Focal build fails due to a Python package `trollius` not working on Python 3.8, used in ROS somewhere