### PR TITLE
Don't delete files when using update_to_git.sh

### DIFF
--- a/Unreal/Environments/Blocks/update_to_git.sh
+++ b/Unreal/Environments/Blocks/update_to_git.sh
@@ -8,8 +8,8 @@ pushd "$SCRIPT_DIR" >/dev/null
 set -e
 set -x
 
-rsync -a  --exclude 'temp' --delete Plugins/AirSim ../../Plugins/
-rsync -a  --exclude 'temp' --delete Plugins/AirSim/Source/AirLib ../../../
+rsync -a --exclude 'temp' --delete Plugins/AirSim ../../Plugins/
+rsync -a --exclude 'temp' Plugins/AirSim/Source/AirLib ../../../
 
 popd >/dev/null
 set +x


### PR DESCRIPTION
`update_to_git.sh` currently deletes all the files in `Airlib/src` since they are removed in [`build.sh`](https://github.com/microsoft/AirSim/blob/master/build.sh#L114)
This does have a caveat where it won't delete the files deliberately deleted like in `include`, need to use a better way