### PR TITLE
[ros] Fix AirSim root directory path in CMakeLists.txt

### DIFF
--- a/ros/src/airsim_ros_pkgs/CMakeLists.txt
+++ b/ros/src/airsim_ros_pkgs/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.10.0)
 project(airsim_ros_pkgs)
 
 # set this to path to AirSim root folder if you want your catkin workspace in a custom directory
-set(AIRSIM_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../../../AirSim/)
+set(AIRSIM_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../../)
 
 add_subdirectory("${AIRSIM_ROOT}/cmake/rpclib_wrapper" rpclib_wrapper)
 add_subdirectory("${AIRSIM_ROOT}/cmake/AirLib" AirLib)


### PR DESCRIPTION
Earlier, it was going to the parent directory in which AirSim is present, and then into `AirSim` folder, which fails when the folder is not named `AirSim`.

Noticed during #2955 