### PR TITLE
Redirect clean_rebuild.bat arguments to build.cmd

### DIFF
--- a/clean_rebuild.bat
+++ b/clean_rebuild.bat
@@ -6,4 +6,5 @@ set ROOT_DIR=%~dp0
 rd /s/q external
 git clean -ffdx
 git pull
-build.cmd
+REM // Redirect command line arguments
+build.cmd %*


### PR DESCRIPTION
Included `%*` so that `clean_rebuild.bat` redirects its arguments to `build.cmd`.

This enables us to specify that we don't want the car assets to be downloaded, by calling it like:
```bash
$ clean_rebuild.bat --no-full-poly-car
```

Reference: https://stackoverflow.com/a/382312