### PR TITLE
Fix compilation & API docs build error

### DIFF
--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -254,7 +254,7 @@ class VehicleClient:
         """
         responses_raw = self.client.call('simGetImages', requests, vehicle_name)
         return [ImageResponse.from_msgpack(response_raw) for response_raw in responses_raw]
-	
+
     def simRunConsoleCommand(self, command):
         """
         Allows the client to execute a command in Unreal's native console, via an API.
@@ -267,7 +267,7 @@ class VehicleClient:
         Returns:
             [bool]: Success
         """
-	    return self.client.call('simRunConsoleCommand', command)
+        return self.client.call('simRunConsoleCommand', command)
 
     # gets the static meshes in the unreal scene
     def simGetMeshPositionVertexBuffers(self):

--- a/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
@@ -319,16 +319,16 @@ void ASimHUD::initializeSubWindows()
     if (!simmode_)
         return;
 
-    auto vehicle_sim_api = simmode_->getVehicleSimApi();
+    auto default_vehicle_sim_api = simmode_->getVehicleSimApi();
 
-    if (vehicle_sim_api) {
-        auto camera_count = vehicle_sim_api->getCameraCount();
+    if (default_vehicle_sim_api) {
+        auto camera_count = default_vehicle_sim_api->getCameraCount();
 
         //setup defaults
         if (camera_count > 0) {
-            subwindow_cameras_[0] = vehicle_sim_api->getCamera("");
-            subwindow_cameras_[1] = vehicle_sim_api->getCamera(""); //camera_count > 3 ? 3 : 0
-            subwindow_cameras_[2] = vehicle_sim_api->getCamera(""); //camera_count > 4 ? 4 : 0
+            subwindow_cameras_[0] = default_vehicle_sim_api->getCamera("");
+            subwindow_cameras_[1] = default_vehicle_sim_api->getCamera(""); //camera_count > 3 ? 3 : 0
+            subwindow_cameras_[2] = default_vehicle_sim_api->getCamera(""); //camera_count > 4 ? 4 : 0
         }
         else
             subwindow_cameras_[0] = subwindow_cameras_[1] = subwindow_cameras_[2] = nullptr;


### PR DESCRIPTION
Sphinx gives the following error - 
```
WARNING: autodoc: failed to import module 'utils' from module 'airsim'; the following exception was raised:
Traceback (most recent call last):
  File "/home/rajat/.py-envs/airsim/lib/python3.6/site-packages/sphinx/ext/autodoc/importer.py", line 66, in import_module
    return importlib.import_module(modname)
  File "/usr/lib/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 994, in _gcd_import
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/rajat/AirSim/PythonClient/airsim/__init__.py", line 1, in <module>
    from .client import *
  File "/home/rajat/AirSim/PythonClient/airsim/client.py", line 270
    return self.client.call('simRunConsoleCommand', command)
                                                           ^
TabError: inconsistent use of tabs and spaces in indentation
```

And the second one fixes the compilation caught in CI, introduced by #2841
```
 C:/__w/14/s/Unreal/Environments/Blocks/Plugins/AirSim/Source/SimHUD/SimHUD.cpp(340): error C4456: declaration of 'vehicle_sim_api' hides previous local declaration
  C:/__w/14/s/Unreal/Environments/Blocks/Plugins/AirSim/Source/SimHUD/SimHUD.cpp(322): note: see declaration of 'vehicle_sim_api'
```