### PR TITLE
Fix Weather API crash

### DIFF
--- a/PythonClient/environment/setup_path.py
+++ b/PythonClient/environment/setup_path.py
@@ -1,0 +1,52 @@
+# Import this module to automatically setup path to local airsim module
+# This module first tries to see if airsim module is installed via pip
+# If it does then we don't do anything else
+# Else we look up grand-parent folder to see if it has airsim folder
+#    and if it does then we add that in sys.path
+
+import os,sys,inspect,logging
+
+#this class simply tries to see if airsim 
+class SetupPath:
+    @staticmethod
+    def getDirLevels(path):
+        path_norm = os.path.normpath(path)
+        return len(path_norm.split(os.sep))
+
+    @staticmethod
+    def getCurrentPath():
+        cur_filepath = os.path.abspath(inspect.getfile(inspect.currentframe()))
+        return os.path.dirname(cur_filepath)
+
+    @staticmethod
+    def getGrandParentDir():
+        cur_path = SetupPath.getCurrentPath()
+        if SetupPath.getDirLevels(cur_path) >= 2:
+            return os.path.dirname(os.path.dirname(cur_path))
+        return ''
+
+    @staticmethod
+    def getParentDir():
+        cur_path = SetupPath.getCurrentPath()
+        if SetupPath.getDirLevels(cur_path) >= 1:
+            return os.path.dirname(cur_path)
+        return ''
+
+    @staticmethod
+    def addAirSimModulePath():
+        # if airsim module is installed then don't do anything else
+        #import pkgutil
+        #airsim_loader = pkgutil.find_loader('airsim')
+        #if airsim_loader is not None:
+        #    return
+
+        parent = SetupPath.getParentDir()
+        if parent !=  '':
+            airsim_path = os.path.join(parent, 'airsim')
+            client_path = os.path.join(airsim_path, 'client.py')
+            if os.path.exists(client_path):
+                sys.path.insert(0, parent)
+        else:
+            logging.warning("airsim module not found in parent folder. Using installed package (pip install airsim).")
+
+SetupPath.addAirSimModulePath()

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
@@ -377,7 +377,10 @@ bool WorldSimApi::setObjectScale(const std::string& object_name, const Vector3r&
 
 void WorldSimApi::enableWeather(bool enable)
 {
-    UWeatherLib::setWeatherEnabled(simmode_->GetWorld(), enable);
+    UAirBlueprintLib::RunCommandOnGameThread([this, enable]() {
+        UWeatherLib::setWeatherEnabled(simmode_->GetWorld(), enable);
+    },
+                                             true);
 }
 
 void WorldSimApi::setWeatherParameter(WeatherParameter param, float val)
@@ -385,7 +388,10 @@ void WorldSimApi::setWeatherParameter(WeatherParameter param, float val)
     unsigned char param_n = static_cast<unsigned char>(msr::airlib::Utils::toNumeric<WeatherParameter>(param));
     EWeatherParamScalar param_e = msr::airlib::Utils::toEnum<EWeatherParamScalar>(param_n);
 
-    UWeatherLib::setWeatherParamScalar(simmode_->GetWorld(), param_e, val);
+    UAirBlueprintLib::RunCommandOnGameThread([this, param_e, val]() {
+        UWeatherLib::setWeatherParamScalar(simmode_->GetWorld(), param_e, val);
+    },
+                                             true);
 }
 
 std::unique_ptr<std::vector<std::string>> WorldSimApi::swapTextures(const std::string& tag, int tex_id, int component_id, int material_id)


### PR DESCRIPTION
Fixes: #2988

With the latest release binary, using the `simEnableWeather` API causes crash, with the following error -
```
Assertion failed: IsInGameThread() [File:/home/ue4/UnrealEngine-4.24.2-linux-all-glsl/Engine/Source/Runtime/CoreUObject/Private/UObject/UObjectGlobals.cpp] [Line: 1065] 
Unable to load /AirSim/Weather/WeatherFX/WeatherGlobalParams. Objects and Packages can only be loaded from the game thread.
```

Note that it'll work fine in the Editor, with or without the fix and the next problem described below

Quite clear, and so added the `RunOnGameThread` part, which exposes the more serious problem, the Weather assets are not being packaged
Issue which brought this problem to light - https://github.com/microsoft/AirSim/issues/2988 (Described in more detail as well)

There is a workaround mentioned in the issue, but I think it'll be better to fix this at the root itself (unless turns out to be too difficult)
Haven't yet figured out how to load the asset correctly using C++ though

A Linux binary with the game thread fix applied - https://drive.google.com/file/d/1kEEhSq0u5UGiCQs3bnlZKENx7A1cnW4Q/view?usp=sharing
Current error message -
```
[2020.09.07-11.34.37:392][ 50]LogStreaming: Error: Couldn't find file for package /AirSim/Weather/WeatherFX/WeatherGlobalParams requested by async loading code. NameToLoad: /AirSim/Weather/WeatherFX/WeatherGlobalParams
[2020.09.07-11.34.37:392][ 50]LogStreaming: Error: Found 0 dependent packages...
[2020.09.07-11.34.37:392][ 50]LogUObjectGlobals: Warning: Failed to find object 'MaterialParameterCollection None./AirSim/Weather/WeatherFX/WeatherGlobalParams'
[2020.09.07-11.34.37:392][ 50]LogTemp: Warning: Warning, WeatherAPI could NOT get WeatherParameterCollection1!
[2020.09.07-11.34.37:392][ 50]LogTemp: Warning: Warning, WeatherAPI could NOT get MaterialCollectionInstance!

```