### PR TITLE
Add distortion model and distortion params to ros wrapper

### DIFF
--- a/ros/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
+++ b/ros/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
@@ -1458,6 +1458,9 @@ sensor_msgs::CameraInfo AirsimROSWrapper::generate_cam_info(const std::string& c
     cam_info_msg.header.frame_id = camera_name + "/" + image_type_int_to_string_map_.at(capture_setting.image_type) + "_optical";
     cam_info_msg.height = capture_setting.height;
     cam_info_msg.width = capture_setting.width;
+    //Assume Camera is ideal - zero distortion. TODO Add a way to specify non-ideal distortion params? Also, is this the case for all image types, or only scene?
+    cam_info_msg.distortion_model = "plumb_bob";
+    cam_info_msg.D = {0, 0, 0, 0, 0};
     float f_x = (capture_setting.width / 2.0) / tan(math_common::deg2rad(capture_setting.fov_degrees / 2.0));
     // todo focal length in Y direction should be same as X it seems. this can change in future a scene capture component which exactly correponds to a cine camera
     // float f_y = (capture_setting.height / 2.0) / tan(math_common::deg2rad(fov_degrees / 2.0));


### PR DESCRIPTION
CameraInfo ros messages have a "distortion_model" field, along with a "D" vector. Currently, there does not seem to be a way to specify this in the capture settings. Also, this is not filled out when generating a camera Info message for a given camera in the airsim_ros_wrapper.cpp. 

This PR adds default distortion fields in the camera info message generated in airsim_ros_wrappers.cpp. It is assuming the camera is ideal and using a plumb_bob model with zero distortion. This allows the video from a camera with a "Scene" image type to be used by software which requires distortion params, like [aurco_detect](http://wiki.ros.org/aruco_detect)