### PR TITLE
Revert "Disable cameras after fetching images, projection matrix (#2881)"

### DIFF
--- a/Unreal/Plugins/AirSim/Source/PIPCamera.cpp
+++ b/Unreal/Plugins/AirSim/Source/PIPCamera.cpp
@@ -170,9 +170,6 @@ msr::airlib::ProjectionMatrix APIPCamera::getProjectionMatrix(const APIPCamera::
     else
         mat.setTo(Utils::nan<float>());
 
-    // Disable camera after our work is done
-    const_cast<APIPCamera*>(this)->setCameraTypeEnabled(image_type, false);
-
     return mat;
 }
 

--- a/Unreal/Plugins/AirSim/Source/UnrealImageCapture.cpp
+++ b/Unreal/Plugins/AirSim/Source/UnrealImageCapture.cpp
@@ -112,10 +112,6 @@ void UnrealImageCapture::getSceneCaptureImage(const std::vector<msr::airlib::Ima
         response.width = render_results[i]->width;
         response.height = render_results[i]->height;
         response.image_type = request.image_type;
-
-        // Disable camera after fetching images
-        APIPCamera* camera = cameras_->at(request.camera_name);
-        camera->setCameraTypeEnabled(request.image_type, false);
     }
 
 }


### PR DESCRIPTION
Running the Image API continuously seems to trigger exceptions

This reverts commit ba4be152b5f06279261150aada9af510e6e1b431.