### PR TITLE
remove mislead comment on vs version

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -77,7 +77,6 @@ REM //---------- Build rpclib ------------
 ECHO Starting cmake to build rpclib...
 IF NOT EXIST external\rpclib\rpclib-2.2.1\build mkdir external\rpclib\rpclib-2.2.1\build
 cd external\rpclib\rpclib-2.2.1\build
-REM cmake -G"Visual Studio 14 2015 Win64" ..
 cmake -G"Visual Studio 16 2019" ..
 
 if "%buildMode%" == "--Debug" (


### PR DESCRIPTION
Remove the obsolete comments. And the reason to removing it instead of updating is due to the fact the the command explain itself very clear, adding a comment just do nothing good but increasing maintenance works.
 