### PR TITLE
fix typo

### DIFF
--- a/DroneShell/src/main.cpp
+++ b/DroneShell/src/main.cpp
@@ -1344,7 +1344,7 @@ bool parseCommandLine(int argc, const char* argv[])
 }
 
 void printUsage() {
-    std::cout << "Usage: DroneServer [-server 127.0.0.1]" << std::endl;
+    std::cout << "Usage: DroneShell [-server 127.0.0.1]" << std::endl;
     std::cout << "The default server address is 127.0.0.1, but use the -server option to specify a different address for the server" << std::endl;
 }
 


### PR DESCRIPTION
It's should print DroneShell instead of DroneServer