### PR TITLE
fix error type of first parameter of simGetImage

### DIFF
--- a/DroneShell/src/main.cpp
+++ b/DroneShell/src/main.cpp
@@ -1221,7 +1221,7 @@ public:
         
         for (int i = 0; i < iterations; i++) {
 
-            auto image = context->client.simGetImage(0, imageType);  
+            auto image = context->client.simGetImage("0", imageType);  
 
             if (image.size() == 0) {
                 std::cout << "error getting image, check sim for error messages" << endl;


### PR DESCRIPTION
The first parameter of simGetImage should be of type string not integer. 