### PR TITLE
Clarified multifile pre-compiled binary download instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ For complete list of changes, view our [Changelog](docs/CHANGELOG.md)
 
 ## How to Get It
 
+[![Build Status](https://travis-ci.org/Microsoft/AirSim.svg?branch=master)](https://travis-ci.org/Microsoft/AirSim)
+
 ### Windows
 * [Download binaries](https://github.com/Microsoft/AirSim/releases)
 * [Build it](https://microsoft.github.io/AirSim/build_windows)
@@ -44,7 +46,7 @@ For complete list of changes, view our [Changelog](docs/CHANGELOG.md)
 ### macOS
 * [Build it](https://microsoft.github.io/AirSim/build_linux)
 
-[![Build Status](https://travis-ci.org/Microsoft/AirSim.svg?branch=master)](https://travis-ci.org/Microsoft/AirSim)
+Some pre-compiled environment binaries may include multiple files (i.e. City.zip.001, City.zip.002). Make sure to download both files before starting the environment.
 
 ## How to Use It
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ For complete list of changes, view our [Changelog](docs/CHANGELOG.md)
 ### macOS
 * [Build it](https://microsoft.github.io/AirSim/build_linux)
 
-Some pre-compiled environment binaries may include multiple files (i.e. City.zip.001, City.zip.002). Make sure to download both files before starting the environment.
+For more details, see the [use precompiled binaries](docs/use_precompiled.md) document. 
 
 ## How to Use It
 

--- a/docs/use_precompiled.md
+++ b/docs/use_precompiled.md
@@ -4,7 +4,7 @@ You can simply download precompiled binaries and run to get started immediately.
 
 ### Unreal Engine
 
-**Windows, Linux**: Download the binaries for the environment of your choice from the [latest release](https://github.com/Microsoft/AirSim/releases).
+**Windows, Linux**: Download the binaries for the environment of your choice from the [latest release](https://github.com/Microsoft/AirSim/releases). Some pre-compiled environment binaries may include multiple files (i.e. City.zip.001, City.zip.002). Make sure to download both files before starting the environment.
 
 **macOS**:  You will need to [build it yourself](https://microsoft.github.io/AirSim/build_linux/)
 

--- a/docs/use_precompiled.md
+++ b/docs/use_precompiled.md
@@ -4,7 +4,7 @@ You can simply download precompiled binaries and run to get started immediately.
 
 ### Unreal Engine
 
-**Windows, Linux**: Download the binaries for the environment of your choice from the [latest release](https://github.com/Microsoft/AirSim/releases). Some pre-compiled environment binaries may include multiple files (i.e. City.zip.001, City.zip.002). Make sure to download both files before starting the environment.
+**Windows, Linux**: Download the binaries for the environment of your choice from the [latest release](https://github.com/Microsoft/AirSim/releases). Some pre-compiled environment binaries may include multiple files (i.e. City.zip.001, City.zip.002). Make sure to download both files before starting the environment. You may need to concatenate both files to unzip them.
 
 **macOS**:  You will need to [build it yourself](https://microsoft.github.io/AirSim/build_linux/)
 


### PR DESCRIPTION
Some environment precompiled binaries span multiple files. It can be confusing as to whether they are different environments or environments spanning multiple files. I added some instructions to clarify this point and make sure to inform users to download both binaries before starting an environment.