### PR TITLE
Fixed OriginGeopoint GPS error

### DIFF
--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
@@ -92,8 +92,15 @@ void ASimModeBase::BeginPlay()
     //get player start
     //this must be done from within actor otherwise we don't get player start
     APlayerController* player_controller = this->GetWorld()->GetFirstPlayerController();
+    // Grab player location
     FTransform player_start_transform = player_controller->GetViewTarget()->GetActorTransform();
-    global_ned_transform_.reset(new NedTransform(player_start_transform, 
+    FVector player_loc = player_start_transform.GetLocation();
+    // Move the world origin to the player's location (this moves the coordinate system and adds
+    // a corresponding offset to all positions to compensate for the shift)
+    this->GetWorld()->SetNewWorldOrigin(FIntVector(player_loc) + this->GetWorld()->OriginLocation);
+    // Regrab the player's position after the offset has been added (which should be 0,0 now)
+    player_start_transform = player_controller->GetViewTarget()->GetActorTransform();
+    global_ned_transform_.reset(new NedTransform(player_start_transform,
         UAirBlueprintLib::GetWorldToMetersScale(this)));
 
     UAirBlueprintLib::GenerateAssetRegistryMap(this, asset_map);


### PR DESCRIPTION
Fixes #2588, #2575
Currently, "OriginGeopoint" in settings.json is the Lat/Lon location of the world coordinate system origin of the Unreal level  (0,0,0) while it is described in the documentation as the Lat/Lon location of the PlayerStart/Vehicle.

This results in an offset in Lat/Lon between the OriginGeopoint specified and that of the vehicle (reported by the API or by QGC in HITL or SITL):
![image](https://user-images.githubusercontent.com/49626509/99434997-204d1600-28d5-11eb-8b20-f645fc9d8be0.png)
With PlayerStart at 
![image](https://user-images.githubusercontent.com/49626509/99438358-51c7e080-28d9-11eb-8195-23e32575ff5b.png), we get:
![image](https://user-images.githubusercontent.com/49626509/99434915-01e71a80-28d5-11eb-8d27-4c2387ace66a.png)

This PR fixes the issue by using the PlayerStart location to set a new origin for the world coordinate system. Doing so moves the world frame to the PlayerStart point without moving the Player or any of the objects in the scene. We then re-grab the 'new' player start position (which is now 0,0,0 in relation to the new world origin). 
This results in the OriginGeopoint falling right where the Player/Vehicle is (since the player is at the world origin now) while reporting the correct PlayerStart location in reference to the level origin.

After the fix, for the same OriginGeopoint and PlayerStart position as above we get:
![image](https://user-images.githubusercontent.com/49626509/99435911-68206d00-28d6-11eb-8b26-36f2d9e22c7e.png)

(Thanks to @jonyMarino for his help with this)