### PR TITLE
Add Github Actions CI Checks

### DIFF
--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -1,0 +1,18 @@
+name: MacOS Build
+
+# Controls when the action will run.
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup
+        run: ./setup.sh
+
+      - name: Build AirLib
+        run: ./build.sh

--- a/.github/workflows/test_ubuntu.yml
+++ b/.github/workflows/test_ubuntu.yml
@@ -16,3 +16,9 @@ jobs:
 
       - name: Build AirLib
         run: ./build.sh
+
+      - name: Unity Build
+        run: |
+          sudo apt-get install libboost-all-dev
+          cd Unity
+          ./build.sh

--- a/.github/workflows/test_ubuntu.yml
+++ b/.github/workflows/test_ubuntu.yml
@@ -1,0 +1,18 @@
+name: Ubuntu Build
+
+# Controls when the action will run.
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup
+        run: ./setup.sh
+
+      - name: Build AirLib
+        run: ./build.sh

--- a/.github/workflows/test_ubuntu.yml
+++ b/.github/workflows/test_ubuntu.yml
@@ -7,7 +7,6 @@ jobs:
   build:
     runs-on: ubuntu-18.04
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - uses: actions/checkout@v2
 
@@ -22,3 +21,10 @@ jobs:
           sudo apt-get install libboost-all-dev
           cd Unity
           ./build.sh
+
+      - name: Build ROS Wrapper
+        run: |
+          ./tools/install_ros_deps.sh
+          source /opt/ros/*/setup.bash
+          cd ros
+          catkin build -DCMAKE_C_COMPILER=gcc-8 -DCMAKE_CXX_COMPILER=g++-8

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -1,0 +1,19 @@
+name: Windows Build
+
+# Controls when the action will run.
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Enable Developer Command Prompt
+        uses: ilammy/msvc-dev-cmd@v1.4.1
+
+      - name: Build
+        shell: cmd
+        run: build.cmd

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -14,6 +14,12 @@ jobs:
       - name: Enable Developer Command Prompt
         uses: ilammy/msvc-dev-cmd@v1.4.1
 
-      - name: Build
+      - name: Build AirLib
         shell: cmd
         run: build.cmd
+
+      - name: Unity build
+        shell: cmd
+        run: |
+          cd Unity
+          build.cmd

--- a/docs/airsim_ros_pkgs.md
+++ b/docs/airsim_ros_pkgs.md
@@ -8,11 +8,11 @@ Verify installation by `gcc-8 --version`
 
 - Ubuntu 16.04
     * Install [ROS kinetic](https://wiki.ros.org/kinetic/Installation/Ubuntu)
-    * Install tf2 sensor and mavros packages: `sudo apt-get install ros-kinetic-tf2-sensor-msgs ros-kinetic-mavros*`
+    * Install tf2 sensor and mavros packages: `sudo apt-get install ros-kinetic-tf2-sensor-msgs ros-kinetic-tf2-geometry-msgs ros-kinetic-mavros*`
 
 - Ubuntu 18.04
     * Install [ROS melodic](https://wiki.ros.org/melodic/Installation/Ubuntu)
-    * Install tf2 sensor and mavros packages: `sudo apt-get install ros-melodic-tf2-sensor-msgs ros-melodic-mavros*`
+    * Install tf2 sensor and mavros packages: `sudo apt-get install ros-melodic-tf2-sensor-msgs ros-melodic-tf2-geometry-msgs ros-melodic-mavros*`
 
 - Install [catkin_tools](https://catkin-tools.readthedocs.io/en/latest/installing.html)
     `sudo apt-get install python-catkin-tools` or

--- a/ros/src/airsim_ros_pkgs/CMakeLists.txt
+++ b/ros/src/airsim_ros_pkgs/CMakeLists.txt
@@ -40,6 +40,7 @@ find_package(catkin REQUIRED COMPONENTS
   tf2
   tf2_ros
   tf2_sensor_msgs
+  tf2_geometry_msgs
 )
 
 add_message_files(

--- a/tools/install_ros_deps.sh
+++ b/tools/install_ros_deps.sh
@@ -14,17 +14,22 @@ fi
 sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
 sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
-sudo apt update
-sudo apt install -qq ros-$ROS_DISTRO-desktop-full
+sudo apt-get update
+sudo apt-get install -qq ros-$ROS_DISTRO-ros-base
 
 echo "source /opt/ros/$ROS_DISTRO/setup.bash" >> ~/.bashrc
 
-sudo apt install python3-pip python3-yaml python3-setuptools
+sudo apt-get install python3-pip python3-yaml python3-setuptools
 sudo pip3 install rosdep rosinstall rospkg catkin-pkg
 sudo rosdep init
 rosdep update
 
 # AirSim ROS Wrapper dependencies
+
+# Only needed for CI due to base install
+sudo apt-get install ros-$ROS_DISTRO-vision-opencv \
+                     ros-$ROS_DISTRO-image-transport \
+                     libyaml-cpp-dev
 
 if [[ "$DISTRO" == "xenial" ]]; then
     sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
@@ -32,7 +37,7 @@ if [[ "$DISTRO" == "xenial" ]]; then
 fi
 
 sudo apt-get install gcc-8 g++-8
-sudo apt-get install ros-$ROS_DISTRO-mavros* ros-$ROS_DISTRO-tf2-sensor-msgs
+sudo apt-get install ros-$ROS_DISTRO-mavros* ros-$ROS_DISTRO-tf2-sensor-msgs ros-$ROS_DISTRO-tf2-geometry-msgs
 
 # TODO: Remove this if-block when new 0.7.0 release of catkin_tools is available
 if [[ "$DISTRO" == "focal" ]]; then


### PR DESCRIPTION
Currently adds Ubuntu, Windows builds

TODO:

- [x] OSX
- [x] Unity build
- [x] Ubuntu ROS Wrapper compilation

Workflow to publish the GitHub pages can also be added, so the maintainers no longer need to do that manually 

See https://github.com/rajat2004/AirSim/pull/26 on my fork which shows the checks