### PR TITLE
Add ApiServerPort to available AirSim settings

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -37,6 +37,7 @@ Below are complete list of settings available along with their default values. I
   "ClockType": "",
   "ClockSpeed": 1,
   "LocalHostIp": "127.0.0.1",
+  "ApiServerPort": 41451,
   "RecordUIVisible": true,
   "LogMessagesVisible": true,
   "ViewMode": "",

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -405,6 +405,10 @@ be allowed to talk to each other, in which case the UDP messages from one networ
 So the LocalHostIp allows you to configure how you are reaching those machines.  The default of 127.0.0.1 is not able to reach external machines,
 this default is only used when everything you are talking to is contained on a single PC.
 
+### ApiServerPort
+This setting determines the server port that used by airsim clients, default port is 41451.
+By specifying different ports, the user can run multiple environments in parallel to accelerate data collection process.
+
 ### SpeedUnitFactor
 Unit conversion factor for speed related to `m/s`, default is 1. Used in conjunction with SpeedUnitLabel. This may be only used for display purposes for example on-display speed when car is being driven. For example, to get speed in `miles/hr` use factor 2.23694.
 


### PR DESCRIPTION
[The original docs](https://airsim-fork.readthedocs.io/en/latest/settings.html#available-settings-and-their-defaults) omit the "ApiServerPort" option - an option enable the user to modify the default rpc port (41451) used by airsim.

This PR will fix it.