### PR TITLE
Event camera simulation

### DIFF
--- a/PythonClient/eventcamera_sim/event_simulator.py
+++ b/PythonClient/eventcamera_sim/event_simulator.py
@@ -114,8 +114,6 @@ class EventSimulator:
         self.event_count = 0
         self.spikes = np.zeros((self.npix))
 
-    # One of the trick here for good performance is to avoid allocating
-    # memory here because we will be calling it very often
     def image_callback(self, new_image, new_time):
         if self.last_image is None:
             self.init(new_image, new_time)
@@ -125,7 +123,6 @@ class EventSimulator:
         assert new_image.shape == self.resolution
         new_image = new_image.reshape(-1)  # Free operation
 
-        # Copy is faster than reallocating memory
         np.copyto(self.current_image, new_image)
 
         delta_time = new_time - self.last_time
@@ -158,5 +155,3 @@ class EventSimulator:
         result.sort(order=["timestamp"], axis=0)
 
         return self.spikes, result
-
-        # TODO sort events or insert them into a heap

--- a/PythonClient/eventcamera_sim/event_simulator.py
+++ b/PythonClient/eventcamera_sim/event_simulator.py
@@ -35,7 +35,7 @@ def esim(
     n_pix_row,
 ):
     count = 0
-    maxSpikes = int(delta_time / (refractory_period_ns * 1e-3))
+    max_spikes = int(delta_time / (refractory_period_ns * 1e-3))
     for x in prange(x_end):
         itdt = np.log(current_image[x])
         it = np.log(previous_image[x])
@@ -46,34 +46,34 @@ def esim(
 
         pol = np.sign(deltaL)
 
-        crossUpdate = pol * TOL
-        crossings[x] = np.log(crossings[x]) + crossUpdate
+        cross_update = pol * TOL
+        crossings[x] = np.log(crossings[x]) + cross_update
 
         lb = crossings[x] - it
         ub = crossings[x] - itdt
 
-        posCheck = lb > 0 and (pol == 1) and ub < 0
-        negCheck = lb < 0 and (pol == -1) and ub > 0
+        pos_check = lb > 0 and (pol == 1) and ub < 0
+        neg_check = lb < 0 and (pol == -1) and ub > 0
 
-        spikeNums = (itdt - crossings[x]) / TOL
-        crossCheck = posCheck + negCheck
-        spikeNums = np.abs(int(spikeNums * crossCheck))
+        spike_nums = (itdt - crossings[x]) / TOL
+        cross_check = pos_check + neg_check
+        spike_nums = np.abs(int(spike_nums * cross_check))
 
-        crossings[x] = itdt - crossUpdate
-        if spikeNums > 0:
+        crossings[x] = itdt - cross_update
+        if spike_nums > 0:
             spikes[x] = pol
 
-        spikeNums = maxSpikes if spikeNums > maxSpikes else spikeNums
+        spike_nums = max_spikes if spike_nums > max_spikes else spike_nums
 
         current_time = last_time
-        for i in range(spikeNums):
+        for i in range(spike_nums):
             output_events[count].x = x // n_pix_row
             output_events[count].y = x % n_pix_row
             output_events[count].timestamp = np.round(current_time * 1e-6, 6)
             output_events[count].polarity = 1 if pol > 0 else -1
 
             count += 1
-            current_time += (delta_time) / spikeNums
+            current_time += (delta_time) / spike_nums
 
             if count == max_events_per_frame:
                 return count

--- a/PythonClient/eventcamera_sim/event_simulator.py
+++ b/PythonClient/eventcamera_sim/event_simulator.py
@@ -70,7 +70,7 @@ def esim(
             output_events[count].x = x // n_pix_row
             output_events[count].y = x % n_pix_row
             output_events[count].timestamp = np.round(current_time * 1e-6, 6)
-            output_events[count].polarity = pol > 0
+            output_events[count].polarity = 1 if pol > 0 else -1
 
             count += 1
             current_time += (delta_time) / spikeNums

--- a/PythonClient/eventcamera_sim/event_simulator.py
+++ b/PythonClient/eventcamera_sim/event_simulator.py
@@ -1,0 +1,162 @@
+from numba.np.ufunc import parallel
+import numpy as np
+from types import SimpleNamespace
+from numba import njit, prange, set_num_threads
+
+EVENT_TYPE = np.dtype(
+    [("timestamp", "f8"), ("x", "u2"), ("y", "u2"), ("polarity", "b")], align=True
+)
+
+TOL = 0.5
+MINIMUM_CONTRAST_THRESHOLD = 0.01
+
+CONFIG = SimpleNamespace(
+    **{
+        "contrast_thresholds": (0.01, 0.01),
+        "sigma_contrast_thresholds": (0.0, 0.0),
+        "refractory_period_ns": 1000,
+        "max_events_per_frame": 200000,
+    }
+)
+
+
+@njit(parallel=True)
+def esim(
+    x_end,
+    current_image,
+    previous_image,
+    delta_time,
+    crossings,
+    last_time,
+    output_events,
+    spikes,
+    refractory_period_ns,
+    max_events_per_frame,
+    n_pix_row,
+):
+    count = 0
+    maxSpikes = int(delta_time / (refractory_period_ns * 1e-3))
+    for x in prange(x_end):
+        itdt = np.log(current_image[x])
+        it = np.log(previous_image[x])
+        deltaL = itdt - it
+
+        if np.abs(deltaL) < TOL:
+            continue
+
+        pol = np.sign(deltaL)
+
+        crossUpdate = pol * TOL
+        crossings[x] = np.log(crossings[x]) + crossUpdate
+
+        lb = crossings[x] - it
+        ub = crossings[x] - itdt
+
+        posCheck = lb > 0 and (pol == 1) and ub < 0
+        negCheck = lb < 0 and (pol == -1) and ub > 0
+
+        spikeNums = (itdt - crossings[x]) / TOL
+        crossCheck = posCheck + negCheck
+        spikeNums = np.abs(int(spikeNums * crossCheck))
+
+        crossings[x] = itdt - crossUpdate
+        if spikeNums > 0:
+            spikes[x] = pol
+
+        spikeNums = maxSpikes if spikeNums > maxSpikes else spikeNums
+
+        current_time = last_time
+        for i in range(spikeNums):
+            output_events[count].x = x // n_pix_row
+            output_events[count].y = x % n_pix_row
+            output_events[count].timestamp = np.round(current_time * 1e-6, 6)
+            output_events[count].polarity = pol > 0
+
+            count += 1
+            current_time += (delta_time) / spikeNums
+
+            if count == max_events_per_frame:
+                return count
+
+    return count
+
+
+class EventSimulator:
+    def __init__(self, H, W, first_image=None, first_time=None, config=CONFIG):
+        self.H = H
+        self.W = W
+        self.config = config
+        self.last_image = None
+        if first_image is not None:
+            assert first_time is not None
+            self.init(first_image, first_time)
+
+        self.npix = H * W
+
+    def init(self, first_image, first_time):
+        print("Initialized event camera simulator with sensor size:", first_image.shape)
+
+        self.resolution = first_image.shape  # The resolution of the image
+
+        # We ignore the 2D nature of the problem as it is not relevant here
+        # It makes multi-core processing more straightforward
+        first_image = first_image.reshape(-1)
+
+        # Allocations
+        self.last_image = first_image.copy()
+        self.current_image = first_image.copy()
+
+        self.last_time = first_time
+
+        self.output_events = np.zeros(
+            (self.config.max_events_per_frame), dtype=EVENT_TYPE
+        )
+        self.event_count = 0
+        self.spikes = np.zeros((self.npix))
+
+    # One of the trick here for good performance is to avoid allocating
+    # memory here because we will be calling it very often
+    def image_callback(self, new_image, new_time):
+        if self.last_image is None:
+            self.init(new_image, new_time)
+            return None, None
+
+        assert new_time > 0
+        assert new_image.shape == self.resolution
+        new_image = new_image.reshape(-1)  # Free operation
+
+        # Copy is faster than reallocating memory
+        np.copyto(self.current_image, new_image)
+
+        delta_time = new_time - self.last_time
+
+        config = self.config
+        self.output_events = np.zeros(
+            (self.config.max_events_per_frame), dtype=EVENT_TYPE
+        )
+        self.spikes = np.zeros((self.npix))
+
+        self.crossings = self.last_image.copy()
+        self.event_count = esim(
+            self.current_image.size,
+            self.current_image,
+            self.last_image,
+            delta_time,
+            self.crossings,
+            self.last_time,
+            self.output_events,
+            self.spikes,
+            config.refractory_period_ns,
+            config.max_events_per_frame,
+            self.W,
+        )
+
+        np.copyto(self.last_image, self.current_image)
+        self.last_time = new_time
+
+        result = self.output_events[: self.event_count]
+        result.sort(order=["timestamp"], axis=0)
+
+        return self.spikes, result
+
+        # TODO sort events or insert them into a heap

--- a/PythonClient/eventcamera_sim/test_event_sim.py
+++ b/PythonClient/eventcamera_sim/test_event_sim.py
@@ -1,0 +1,88 @@
+import numpy as np
+import airsim
+import time
+import cv2
+import matplotlib.pyplot as plt
+
+from event_simulator import *
+
+
+class AirSimEventGen:
+    def __init__(self, W, H, debug=False):
+        self.ev_sim = EventSimulator(W, H)
+        self.W = W
+        self.H = H
+
+        self.image_request = airsim.ImageRequest(
+            "0", airsim.ImageType.Scene, False, False
+        )
+
+        self.client = airsim.VehicleClient()
+        self.client.confirmConnection()
+        self.init = True
+        self.start_ts = None
+
+        self.rgb_image_shape = [H, W, 3]
+        self.debug = debug
+
+        if debug:
+            self.fig, self.ax = plt.subplots(1, 1)
+
+    def visualize_events(self, event_img):
+        event_img = self.convert_event_img_rgb(event_img)
+        self.ax.cla()
+        self.ax.imshow(event_img, cmap="viridis")
+        plt.draw()
+        plt.pause(0.01)
+
+    def convert_event_img_rgb(self, image):
+        image = image.reshape(self.H, self.W)
+        out = np.zeros((self.H, self.W, 3), dtype=np.uint8)
+        out[:, :, 0] = np.clip(image, 0, 1) * 255
+        out[:, :, 2] = np.clip(image, -1, 0) * -255
+
+        return out
+
+
+if __name__ == "__main__":
+    event_generator = AirSimEventGen(256, 144, debug=True)
+    i = 0
+    start_time = 0
+    t_start = time.time()
+
+    while True:
+        image_request = airsim.ImageRequest("0", airsim.ImageType.Scene, False, False)
+
+        response = event_generator.client.simGetImages([event_generator.image_request])
+        while response[0].height == 0 or response[0].width == 0:
+            response = event_generator.client.simGetImages(
+                [event_generator.image_request]
+            )
+
+        ts = time.time_ns()
+
+        if event_generator.init:
+            event_generator.start_ts = ts
+            event_generator.init = False
+
+        img = np.reshape(
+            np.fromstring(response[0].image_data_uint8, dtype=np.uint8),
+            event_generator.rgb_image_shape,
+        )
+
+        img = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY).astype(np.float32)
+        img = cv2.add(img, 0.001)
+
+        ts = time.time_ns()
+        ts_delta = (ts - event_generator.start_ts) * 1e-3
+        start = time.time()
+        event_img, events = event_generator.ev_sim.image_callback(img, ts_delta)
+        print(f"Time: {time.time() - start}")
+        bytestream = []
+
+        if events is not None and events.shape[0] > 0:
+            bytestream = events.tolist()
+            print(len(bytestream))
+
+            event_generator.visualize_events(event_img)
+


### PR DESCRIPTION
This PR introduces a simple event camera simulation in Python, using numba for performance. 

The event simulator uses two consecutive RGB images (converted to grayscale), and computes "events" based on the change in log luminance between the images. These events are reported as a stream of bytes, following this format:

`<x> <y> <timestamp> <pol>`

x and y are the pixel locations of the event firing, timestamp is the global timestamp in microseconds and pol is either +1/-1 depending on whether the brightness increased or decreased. Along with this bytestream, an accumulation of events over a 2D frame is also constructed, known as an 'event image' that visualizes +1 events as red and -1 as blue pixels. 

![image](https://user-images.githubusercontent.com/2274262/101719509-4b500300-3a58-11eb-9c96-d6397b66d547.png)

There are quite a few parameters that can be tuned to achieve a level of visual fidelity/performance. The main factors would be the resolution of the camera and the log luminance threshold (TOL) that determines whether or not a detected change counts as an event. There is also currently a max limit on the number of events generated per pair of images, which can also be tuned. 


- [X] Event simulator backend
- [X] Event image visualization
- [x] Return list of bytes for each new image obtained
- [x] Save events to a file if needed