### PR TITLE
Voxel grid construction

### DIFF
--- a/AirLib/include/api/RpcLibClientBase.hpp
+++ b/AirLib/include/api/RpcLibClientBase.hpp
@@ -107,7 +107,7 @@ public:
     void simSetCameraFov(const std::string& camera_name, float fov_degrees, const std::string& vehicle_name = "");
     // This is a backwards-compatibility wrapper over simSetCameraPose, and can be removed in future major releases
     void simSetCameraOrientation(const std::string& camera_name, const Quaternionr& orientation, const std::string& vehicle_name = "");
-    void simCreateVoxelGrid(const Vector3r& position, const int& x_size, const int& y_size, const int& z_size, const float& res, const std::string& output_file);
+    bool simCreateVoxelGrid(const Vector3r& position, const int& x_size, const int& y_size, const int& z_size, const float& res, const std::string& output_file);
     msr::airlib::Kinematics::State simGetGroundTruthKinematics(const std::string& vehicle_name = "") const;
     msr::airlib::Environment::State simGetGroundTruthEnvironment(const std::string& vehicle_name = "") const;
 

--- a/AirLib/include/api/RpcLibClientBase.hpp
+++ b/AirLib/include/api/RpcLibClientBase.hpp
@@ -107,7 +107,7 @@ public:
     void simSetCameraFov(const std::string& camera_name, float fov_degrees, const std::string& vehicle_name = "");
     // This is a backwards-compatibility wrapper over simSetCameraPose, and can be removed in future major releases
     void simSetCameraOrientation(const std::string& camera_name, const Quaternionr& orientation, const std::string& vehicle_name = "");
-
+    void simCreateVoxelGrid(const Vector3r& position, const int& x_size, const int& y_size, const int& z_size, const float& res, const std::string& output_file);
     msr::airlib::Kinematics::State simGetGroundTruthKinematics(const std::string& vehicle_name = "") const;
     msr::airlib::Environment::State simGetGroundTruthEnvironment(const std::string& vehicle_name = "") const;
 

--- a/AirLib/include/api/WorldSimApiBase.hpp
+++ b/AirLib/include/api/WorldSimApiBase.hpp
@@ -67,7 +67,7 @@ public:
 	virtual std::unique_ptr<std::vector<std::string>> swapTextures(const std::string& tag, int tex_id = 0, int component_id = 0, int material_id = 0) = 0;
     virtual vector<MeshPositionVertexBuffersResponse> getMeshPositionVertexBuffers() const = 0;
 
-    virtual void createVoxelGrid(const Vector3r& position, const int& x_size, const int& y_size, const int& z_size, const float& res, const std::string& output_file) = 0;
+    virtual bool createVoxelGrid(const Vector3r& position, const int& x_size, const int& y_size, const int& z_size, const float& res, const std::string& output_file) = 0;
 
     // Recording APIs
     virtual void startRecording() = 0;

--- a/AirLib/include/api/WorldSimApiBase.hpp
+++ b/AirLib/include/api/WorldSimApiBase.hpp
@@ -67,6 +67,8 @@ public:
 	virtual std::unique_ptr<std::vector<std::string>> swapTextures(const std::string& tag, int tex_id = 0, int component_id = 0, int material_id = 0) = 0;
     virtual vector<MeshPositionVertexBuffersResponse> getMeshPositionVertexBuffers() const = 0;
 
+    virtual void createVoxelGrid(const Vector3r& position, const int& x_size, const int& y_size, const int& z_size, const float& res, const std::string& output_file) = 0;
+
     // Recording APIs
     virtual void startRecording() = 0;
     virtual void stopRecording() = 0;

--- a/AirLib/src/api/RpcLibClientBase.cpp
+++ b/AirLib/src/api/RpcLibClientBase.cpp
@@ -406,6 +406,11 @@ msr::airlib::Environment::State RpcLibClientBase::simGetGroundTruthEnvironment(c
 {
     return pimpl_->client.call("simGetGroundTruthEnvironment", vehicle_name).as<RpcLibAdapatorsBase::EnvironmentState>().to();;
 }
+void RpcLibClientBase::simCreateVoxelGrid(const msr::airlib::Vector3r& position, const int& x, const int& y, const int& z, const float& res, const std::string& output_file)
+{
+    pimpl_->client.call("simCreateVoxelGrid", RpcLibAdapatorsBase::Vector3r(position), x, y, z, res, output_file);
+}
+
 
 void RpcLibClientBase::cancelLastTask(const std::string& vehicle_name)
 {

--- a/AirLib/src/api/RpcLibClientBase.cpp
+++ b/AirLib/src/api/RpcLibClientBase.cpp
@@ -408,7 +408,7 @@ msr::airlib::Environment::State RpcLibClientBase::simGetGroundTruthEnvironment(c
 }
 bool RpcLibClientBase::simCreateVoxelGrid(const msr::airlib::Vector3r& position, const int& x, const int& y, const int& z, const float& res, const std::string& output_file)
 {
-    return pimpl_->client.call("simCreateVoxelGrid", RpcLibAdapatorsBase::Vector3r(position), x, y, z, res, output_file);
+    return pimpl_->client.call("simCreateVoxelGrid", RpcLibAdapatorsBase::Vector3r(position), x, y, z, res, output_file).as<bool>();
 }
 
 

--- a/AirLib/src/api/RpcLibClientBase.cpp
+++ b/AirLib/src/api/RpcLibClientBase.cpp
@@ -406,9 +406,9 @@ msr::airlib::Environment::State RpcLibClientBase::simGetGroundTruthEnvironment(c
 {
     return pimpl_->client.call("simGetGroundTruthEnvironment", vehicle_name).as<RpcLibAdapatorsBase::EnvironmentState>().to();;
 }
-void RpcLibClientBase::simCreateVoxelGrid(const msr::airlib::Vector3r& position, const int& x, const int& y, const int& z, const float& res, const std::string& output_file)
+bool RpcLibClientBase::simCreateVoxelGrid(const msr::airlib::Vector3r& position, const int& x, const int& y, const int& z, const float& res, const std::string& output_file)
 {
-    pimpl_->client.call("simCreateVoxelGrid", RpcLibAdapatorsBase::Vector3r(position), x, y, z, res, output_file);
+    return pimpl_->client.call("simCreateVoxelGrid", RpcLibAdapatorsBase::Vector3r(position), x, y, z, res, output_file);
 }
 
 

--- a/AirLib/src/api/RpcLibServerBase.cpp
+++ b/AirLib/src/api/RpcLibServerBase.cpp
@@ -344,6 +344,9 @@ RpcLibServerBase::RpcLibServerBase(ApiProvider* api_provider, const std::string&
         const Environment::State& result = (*getVehicleSimApi(vehicle_name)->getGroundTruthEnvironment()).getState();
         return RpcLibAdapatorsBase::EnvironmentState(result);
     });
+    pimpl_->server.bind("simCreateVoxelGrid", [&](const RpcLibAdapatorsBase::Vector3r& position, const int& x, const int& y, const int& z, const float& res, const std::string& output_file) -> void {
+        return getWorldSimApi()->createVoxelGrid(position.to(), x, y, z, res, output_file);
+    });
 
     pimpl_->server.bind("cancelLastTask", [&](const std::string& vehicle_name) -> void {
         getVehicleApi(vehicle_name)->cancelLastTask();

--- a/AirLib/src/api/RpcLibServerBase.cpp
+++ b/AirLib/src/api/RpcLibServerBase.cpp
@@ -344,7 +344,7 @@ RpcLibServerBase::RpcLibServerBase(ApiProvider* api_provider, const std::string&
         const Environment::State& result = (*getVehicleSimApi(vehicle_name)->getGroundTruthEnvironment()).getState();
         return RpcLibAdapatorsBase::EnvironmentState(result);
     });
-    pimpl_->server.bind("simCreateVoxelGrid", [&](const RpcLibAdapatorsBase::Vector3r& position, const int& x, const int& y, const int& z, const float& res, const std::string& output_file) -> void {
+    pimpl_->server.bind("simCreateVoxelGrid", [&](const RpcLibAdapatorsBase::Vector3r& position, const int& x, const int& y, const int& z, const float& res, const std::string& output_file) -> bool {
         return getWorldSimApi()->createVoxelGrid(position.to(), x, y, z, res, output_file);
     });
 

--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -790,7 +790,7 @@ class VehicleClient:
         """
         self.client.call('simSetWind', wind)
 
-    def createVoxelGrid(self, position, x, y, z, res, of):
+    def simCreateVoxelGrid(self, position, x, y, z, res, of):
         """
         Construct and save a binvox-formatted voxel grid of environment
 

--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -790,6 +790,19 @@ class VehicleClient:
         """
         self.client.call('simSetWind', wind)
 
+    def createVoxelGrid(self, position, x, y, z, res, of):
+        """
+        Construct and save a binvox-formatted voxel grid of environment
+
+        Args:
+            position (Vector3r): Position around which voxel grid is centered in m
+            x, y, z (float): Size of each voxel grid dimension in m
+            res (float): Resolution of voxel grid in m
+            of (str): Name of output file to save voxel grid as
+
+        """
+        self.client.call('simCreateVoxelGrid', position, x, y, z, res, of)
+
 # -----------------------------------  Multirotor APIs ---------------------------------------------
 class MultirotorClient(VehicleClient, object):
     def __init__(self, ip = "", port = 41451, timeout_value = 3600):

--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -801,7 +801,7 @@ class VehicleClient:
             of (str): Name of output file to save voxel grid as
 
         """
-        self.client.call('simCreateVoxelGrid', position, x, y, z, res, of)
+        return self.client.call('simCreateVoxelGrid', position, x, y, z, res, of)
 
 # -----------------------------------  Multirotor APIs ---------------------------------------------
 class MultirotorClient(VehicleClient, object):

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.cpp
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.cpp
@@ -103,6 +103,11 @@ void WorldSimApi::setWeatherParameter(WeatherParameter param, float val)
     //TODO: implement weather for Unity
 }
 
+bool WorldSimApi::createVoxelGrid(const Vector3r& position, const int& x_size, const int& y_size, const int& z_size, const float& res, const std::string& output_file)
+{
+    return false;
+}
+
 //----------------Plotting APIs-----------/
 void WorldSimApi::simFlushPersistentMarkers()
 {

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.h
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.h
@@ -62,6 +62,7 @@ public:
     virtual bool isRecording() const override;
 
     virtual void setWind(const Vector3r& wind) const override;
+    virtual bool createVoxelGrid(const Vector3r& position, const int& x_size, const int& y_size, const int& z_size, const float& res, const std::string& output_file) override;
 
 private:
 	SimModeBase * simmode_;

--- a/Unreal/Environments/Blocks/Blocks.uproject
+++ b/Unreal/Environments/Blocks/Blocks.uproject
@@ -19,12 +19,12 @@
 			"Enabled": true
 		},
 		{
-            		"Name": "SteamVR",
-		        "Enabled": false
-	        },
-        	{
-		        "Name": "OculusVR",
-		        "Enabled": false
-	        },
+			"Name": "SteamVR",
+			"Enabled": false
+		},
+		{
+			"Name": "OculusVR",
+			"Enabled": false
+		}
 	]
 }

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
@@ -170,8 +170,7 @@ void WorldSimApi::createVoxelGrid(const Vector3r& position, const int& x_size, c
     voxel_grid_.resize(ncells_x * ncells_y * ncells_z);
 
     int ctr = 0;
-    float scale = res;
-    float scale_cm = scale * 100;
+    float scale_cm = res * 100;
     FCollisionQueryParams params;
     params.bFindInitialOverlaps = true;
     params.bTraceComplex = false;
@@ -182,26 +181,25 @@ void WorldSimApi::createVoxelGrid(const Vector3r& position, const int& x_size, c
             for (float j = 0; j < ncells_y; j++) {
                 int idx = i + ncells_x * (k + ncells_z * j);
                 FVector position = FVector((i - ncells_x /2) * scale_cm, (j - ncells_y /2) * scale_cm, (k - ncells_z /2) * scale_cm) + position_in_UE_frame;
-                voxel_grid_[idx] = (unsigned int)simmode_->GetWorld()->OverlapBlockingTestByChannel(position, FQuat::Identity, ECollisionChannel::ECC_Pawn, FCollisionShape::MakeBox(FVector(scale_cm /2)), params);
-
+                voxel_grid_[idx] = simmode_->GetWorld()->OverlapBlockingTestByChannel(position, FQuat::Identity, ECollisionChannel::ECC_Pawn, FCollisionShape::MakeBox(FVector(scale_cm /2)), params);
             }
         }
     }
     
-    std::ofstream* output = new std::ofstream(output_file, std::ios::out | std::ios::binary);
-    if (!output->good())
+    std::ofstream output(output_file, std::ios::out | std::ios::binary);
+    if (!output.good())
     {
-        std::cerr << "Error: Could not open output file " << output << "!" << std::endl;
+        std::cerr << "Error: Could not open output file " << &output << "!" << std::endl;
         exit(1);
     }
 
     // Write the binvox file using run-length encoding
     // where each pair of bytes is of the format (run value, run length)
-    *output << "#binvox 1\n";
-    *output << "dim " << ncells_x << " " << ncells_z << " " << ncells_y << "\n";
-    *output << "translate " << int(-x_size/2) << " " << int(-y_size / 2) << " " << 0 << "\n";
-    *output << "scale " << 1/x_size << "\n";
-    *output << "data\n";
+    output << "#binvox 1\n";
+    output << "dim " << ncells_x << " " << ncells_z << " " << ncells_y << "\n";
+    output << "translate " << int(-x_size/2) << " " << int(-y_size / 2) << " " << int(-z_size/2) << "\n";
+    output << "scale " << 1/x_size << "\n";
+    output << "data\n";
     bool run_value = voxel_grid_[0];
     unsigned int run_length = 0;
     for (size_t i = 0; i < voxel_grid_.size(); ++i)
@@ -212,26 +210,26 @@ void WorldSimApi::createVoxelGrid(const Vector3r& position, const int& x_size, c
             run_length++;
             if (run_length == 255)
             {
-                *output << static_cast<char>(run_value);
-                *output << static_cast<char>(run_length);
+                output << static_cast<char>(run_value);
+                output << static_cast<char>(run_length);
                 run_length = 0;
             }
         }
         else
         {
             // End of a run
-            *output << static_cast<char>(run_value);
-            *output << static_cast<char>(run_length);
+            output << static_cast<char>(run_value);
+            output << static_cast<char>(run_length);
             run_value = voxel_grid_[i];
             run_length = 1;
         }
     }
     if (run_length > 0)
     {
-        *output << static_cast<char>(run_value);
-        *output << static_cast<char>(run_length);
+        output << static_cast<char>(run_value);
+        output << static_cast<char>(run_length);
     }
-    output->close();
+    output.close();
 }
 
 bool WorldSimApi::isPaused() const

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
@@ -170,7 +170,7 @@ void WorldSimApi::createVoxelGrid(const Vector3r& position, const int& x_size, c
     voxel_grid_.resize(ncells_x * ncells_y * ncells_z);
 
     int ctr = 0;
-    float scale = 1 / res;
+    float scale = res;
     float scale_cm = scale * 100;
     FCollisionQueryParams params;
     params.bFindInitialOverlaps = true;
@@ -182,7 +182,7 @@ void WorldSimApi::createVoxelGrid(const Vector3r& position, const int& x_size, c
             for (float j = 0; j < ncells_y; j++) {
                 int idx = i + ncells_x * (k + ncells_z * j);
                 FVector position = FVector((i - ncells_x /2) * scale_cm, (j - ncells_y /2) * scale_cm, (k - ncells_z /2) * scale_cm) + position_in_UE_frame;
-                voxel_grid_[idx] = (unsigned int)simmode_->GetWorld()->OverlapBlockingTestByChannel(position, FQuat::Identity, ECollisionChannel::ECC_Pawn, FCollisionShape::MakeBox(FVector(res/50)), params);
+                voxel_grid_[idx] = (unsigned int)simmode_->GetWorld()->OverlapBlockingTestByChannel(position, FQuat::Identity, ECollisionChannel::ECC_Pawn, FCollisionShape::MakeBox(FVector(scale_cm /2)), params);
 
             }
         }
@@ -199,8 +199,8 @@ void WorldSimApi::createVoxelGrid(const Vector3r& position, const int& x_size, c
     // where each pair of bytes is of the format (run value, run length)
     *output << "#binvox 1\n";
     *output << "dim " << ncells_x << " " << ncells_z << " " << ncells_y << "\n";
-    *output << "translate " << int(-x_size/2) << " " << int(-y_size / 2) << " " << int(-z_size / 2) << "\n";
-    *output << "scale " << scale << "\n";
+    *output << "translate " << int(-x_size/2) << " " << int(-y_size / 2) << " " << 0 << "\n";
+    *output << "scale " << 1/x_size << "\n";
     *output << "data\n";
     bool run_value = voxel_grid_[0];
     unsigned int run_length = 0;

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
@@ -170,7 +170,6 @@ bool WorldSimApi::createVoxelGrid(const Vector3r& position, const int& x_size, c
     
     voxel_grid_.resize(ncells_x * ncells_y * ncells_z);
 
-    int ctr = 0;
     float scale_cm = res * 100;
     FCollisionQueryParams params;
     params.bFindInitialOverlaps = true;
@@ -190,7 +189,7 @@ bool WorldSimApi::createVoxelGrid(const Vector3r& position, const int& x_size, c
     std::ofstream output(output_file, std::ios::out | std::ios::binary);
     if (!output.good())
     {
-        UE_LOG(LogTemp, Error, TEXT("Could not open output file for voxel grid!"));
+        UE_LOG(LogTemp, Error, TEXT("Could not open output file to write voxel grid!"));
         return success;
     }
 
@@ -198,8 +197,8 @@ bool WorldSimApi::createVoxelGrid(const Vector3r& position, const int& x_size, c
     // where each pair of bytes is of the format (run value, run length)
     output << "#binvox 1\n";
     output << "dim " << ncells_x << " " << ncells_z << " " << ncells_y << "\n";
-    output << "translate " << int(-x_size/2) << " " << int(-y_size / 2) << " " << int(-z_size/2) << "\n";
-    output << "scale " << 1/x_size << "\n";
+    output << "translate " << -x_size * 0.5 << " " << -y_size * 0.5 << " " << -z_size * 0.5 << "\n";
+    output << "scale " << 1.0f/x_size << "\n";
     output << "data\n";
     bool run_value = voxel_grid_[0];
     unsigned int run_length = 0;

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
@@ -161,8 +161,9 @@ AActor* WorldSimApi::createNewActor(const FActorSpawnParameters& spawn_params, c
     return NewActor;
 }
 
-void WorldSimApi::createVoxelGrid(const Vector3r& position, const int& x_size, const int& y_size, const int& z_size, const float& res, const std::string& output_file)
+bool WorldSimApi::createVoxelGrid(const Vector3r& position, const int& x_size, const int& y_size, const int& z_size, const float& res, const std::string& output_file)
 {
+    bool success = false;
     int ncells_x = x_size / res;
     int ncells_y = y_size / res;
     int ncells_z = z_size / res;
@@ -189,8 +190,8 @@ void WorldSimApi::createVoxelGrid(const Vector3r& position, const int& x_size, c
     std::ofstream output(output_file, std::ios::out | std::ios::binary);
     if (!output.good())
     {
-        std::cerr << "Error: Could not open output file " << &output << "!" << std::endl;
-        exit(1);
+        UE_LOG(LogTemp, Error, TEXT("Could not open output file for voxel grid!"));
+        return success;
     }
 
     // Write the binvox file using run-length encoding
@@ -230,6 +231,8 @@ void WorldSimApi::createVoxelGrid(const Vector3r& position, const int& x_size, c
         output << static_cast<char>(run_length);
     }
     output.close();
+    success = true;
+    return success;
 }
 
 bool WorldSimApi::isPaused() const

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.h
@@ -65,7 +65,7 @@ public:
     virtual bool isRecording() const override;
 
     virtual void setWind(const Vector3r& wind) const override;
-    virtual void createVoxelGrid(const Vector3r& position, const int& x_size, const int& y_size, const int& z_size, const float& res, const std::string& output_file) override;
+    virtual bool createVoxelGrid(const Vector3r& position, const int& x_size, const int& y_size, const int& z_size, const float& res, const std::string& output_file) override;
 
 private:
     AActor* createNewActor(const FActorSpawnParameters& spawn_params, const FTransform& actor_transform, const Vector3r& scale, UStaticMesh* static_mesh);

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.h
@@ -65,6 +65,7 @@ public:
     virtual bool isRecording() const override;
 
     virtual void setWind(const Vector3r& wind) const override;
+    virtual void createVoxelGrid(const Vector3r& position, const int& x_size, const int& y_size, const int& z_size, const float& res, const std::string& output_file) override;
 
 private:
     AActor* createNewActor(const FActorSpawnParameters& spawn_params, const FTransform& actor_transform, const Vector3r& scale, UStaticMesh* static_mesh);

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.h
@@ -74,4 +74,5 @@ private:
 private:
     ASimModeBase* simmode_;
     ULevelStreamingDynamic* current_level_;
+    std::vector<bool> voxel_grid_;
 };


### PR DESCRIPTION
### About
This PR introduces a feature that constructs ground truth voxel grids of the world directly from Unreal Engine. The voxel grids are stored in a [binvox format](https://www.patrickmin.com/binvox/binvox.html) which can then be converted by the user into an octomap .bt or any other relevant, desired format. Subsequently, these voxel grids/octomaps can be used within mapping/planning.

The logic for constructing the voxel grid is in WorldSimApi.cpp->createVoxelGrid(). For now, the assumption is that the voxel grid is a cube - and the API call is:

```
createVoxelGrid(self, position, x, y, z, res, of)

position (Vector3r): Global position around which voxel grid is centered in m
x, y, z (float): Size of each voxel grid dimension in m
res (float): Resolution of voxel grid in m
of (str): Name of output file to save voxel grid as
```

### How Has This Been Tested?
Simple test script:
```
import airsim
c = airsim.VehicleClient()
center = a.Vector3r(0, 0, 0)
c.createVoxelGrid(center, 100, 100, 100, 0.5, "map.binvox")
```

[viewvox](https://www.patrickmin.com/viewvox/) is a nifty little utility to then visualize the created binvox file. Similarly, `binvox2bt` can convert the binvox to an octomap file.

### Example voxel grid in Blocks:
![image](https://user-images.githubusercontent.com/2274262/101970694-c7755280-3be0-11eb-886c-74f05c839478.png)
