### PR TITLE
Add Actions script to build and deploy to gh-pages

### DIFF
--- a/.github/workflows/test_docs.yml
+++ b/.github/workflows/test_docs.yml
@@ -1,0 +1,47 @@
+name: Documentation Build & Deploy
+
+# Controls when the action will run.
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+          architecture: 'x64'
+
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install mkdocs pymdown-extensions    # Mkdocs requirements
+
+      - name: Build API reference docs
+        run: |
+          python3 -m venv .env                            # Virtual env to avoid dep. issues 
+          source .env/bin/activate
+          pip install Sphinx sphinx_rtd_theme numpy msgpack-rpc-python
+
+          pushd PythonClient >/dev/null
+          ./build_api_docs.sh
+          popd >/dev/null
+          cp -r PythonClient/docs/_build docs/api_docs/   # Copy generated files
+
+          deactivate
+
+      - name: Build AirSim Documentation
+        run: ./build_docs.sh
+
+      # Only on commits to 'master' branch
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        with:
+          github_token: $
+          publish_dir: ./build_docs
+

--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -796,10 +796,12 @@ class VehicleClient:
 
         Args:
             position (Vector3r): Position around which voxel grid is centered in m
-            x, y, z (float): Size of each voxel grid dimension in m
+            x, y, z (int): Size of each voxel grid dimension in m
             res (float): Resolution of voxel grid in m
             of (str): Name of output file to save voxel grid as
 
+        Returns:
+            bool: True if output written to file successfully, else False
         """
         return self.client.call('simCreateVoxelGrid', position, x, y, z, res, of)
 

--- a/PythonClient/airsim/utils.py
+++ b/PythonClient/airsim/utils.py
@@ -6,7 +6,6 @@ import os
 import inspect
 import types
 import re
-import cv2      # pip install opencv-python
 import logging
 
 from .types import *
@@ -202,6 +201,8 @@ def write_pfm(file, image, scale=1):
 def write_png(filename, image):
     """ image must be numpy array H X W X channels
     """
+    import cv2      # pip install opencv-python
+
     ret = cv2.imwrite(filename, image)
     if not ret:
         logging.error(f"Writing PNG file {filename} failed")

--- a/PythonClient/build_api_docs.sh
+++ b/PythonClient/build_api_docs.sh
@@ -1,2 +1,4 @@
-cd docs;
-make html;
+#!/bin/sh
+
+cd docs
+make html


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: 
- Adds GitHub Action to build docs including API reference docs, and deploy to `gh-pages` on push to master branch (requires maintainer to add GITHUB_TOKEN key!)
- Small cleanup of `build_api_docs.sh` script, `uitls.py` and fixes [`simCreateVoxelGrid` docstring](https://github.com/microsoft/AirSim/pull/3209#discussion_r544612920)
<!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
Currently, pushing the updated files to `gh-pages` is done manually by the maintainers, which frequently results in the .md files and documentation website being out of sync for months. Automating the deployment will update the github pages website everytime a push is made to master branch, also keeping the API reference docs up to date

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
Docs build can be checked locally, however the deployment hasn't been tested, and needs to be done by maintainers to add the secret token.

## Screenshots (if appropriate):