### PR TITLE
Docs: Add plugin for tip, note blocks

### DIFF
--- a/docs/airsim_ros_pkgs.md
+++ b/docs/airsim_ros_pkgs.md
@@ -222,18 +222,20 @@ Once installed, you can switch between WSL1 or WSL2 versions as you prefer.
 
 2. Congratulations, you now have a working Ubuntu subsystem under Windows, you can now go to [Ubuntu 16 / 18 instructions](#setup) and then [How to run Airsim on Windows and ROS wrapper on WSL](#how-to-run-airsim-on-windows-and-ros-wrapper-on-wsl)!
 
-    **Note**:
+!!! note
 
     You can run XWindows applications (including SITL) by installing [VcXsrv](https://sourceforge.net/projects/vcxsrv/)  on Windows. 
     To use it find and run `XLaunch` from the Windows start menu.    
     Select `Multiple Windows` in first popup, `Start no client` in second popup, **only** `Clipboard` in third popup. Do **not** select `Native Opengl` (and if you are not able to connect select `Disable access control`).  
-    You will need to set the DISPLAY variable to point to your display: in WSL it is 127.0.0.1:0, in WSL2 it will be the ip address of the PC's network port and can be set by using the code below. Also in WSL2 you may have to disable the firewall for public networks, or create an exception in order for VcXsrv to communicate with WSL2:
+    You will need to set the DISPLAY variable to point to your display: in WSL it is `127.0.0.1:0`, in WSL2 it will be the ip address of the PC's network port and can be set by using the code below. Also in WSL2 you may have to disable the firewall for public networks, or create an exception in order for VcXsrv to communicate with WSL2:
 
     `export DISPLAY=$(cat /etc/resolv.conf | grep nameserver | awk '{print $2}'):0`
 
-    **tip**: If you add this line to your ~/.bashrc file you won't need to run this command again  
-    **tip**: For code editing you can install VSCode inside WSL.  
-    **Note**: Windows 10 includes "Windows Defender" virus scanner. It will slow down WSL quite a bit. Disabling it greatly improves disk performance but increases your risk to viruses so disable at your own risk. Here is one of many resources/videos that show you how to disable it: https://www.youtube.com/watch?v=FmjblGay3AM  
+!!! tip
+
+    - If you add this line to your ~/.bashrc file you won't need to run this command again  
+    - For code editing you can install VSCode inside WSL.  
+    - Windows 10 includes "Windows Defender" virus scanner. It will slow down WSL quite a bit. Disabling it greatly improves disk performance but increases your risk to viruses so disable at your own risk. Here is one of many resources/videos that show you how to disable it: [How to Disable or Enable Windows Defender on Windows 10](https://youtu.be/FmjblGay3AM)
 
 ##### File System Access between WSL and Windows10
 

--- a/docs/airsim_tutorial_pkgs.md
+++ b/docs/airsim_tutorial_pkgs.md
@@ -19,7 +19,9 @@ If your default GCC isn't 8 or greater (check using `gcc --version`), then compi
 catkin build airsim_tutorial_pkgs -DCMAKE_C_COMPILER=gcc-8 -DCMAKE_CXX_COMPILER=g++-8
 ```
 
-Note: For running examples, and also whenever a new terminal is opened, sourcing the `setup.bash` file is necessary. If you're using the ROS wrapper frequently, it might be helpful to add the `source PATH_TO/AirSim/ros/devel/setup.bash` to your `~/.profile` or `~/.bashrc` to avoid the need to run the command every time a new terminal is opened
+!!! note
+
+    For running examples, and also whenever a new terminal is opened, sourcing the `setup.bash` file is necessary. If you're using the ROS wrapper frequently, it might be helpful to add the `source PATH_TO/AirSim/ros/devel/setup.bash` to your `~/.profile` or `~/.bashrc` to avoid the need to run the command every time a new terminal is opened
 
 ## Examples
 

--- a/docs/build_linux.md
+++ b/docs/build_linux.md
@@ -80,7 +80,9 @@ Once AirSim is setup:
 - After Unreal Editor loads, press Play button.
 
 See [Using APIs](apis.md) and [settings.json](settings.md) for various options available for AirSim usage.
-Tip: go to 'Edit->Editor Preferences', in the 'Search' box type 'CPU' and ensure that the 'Use Less CPU when in Background' is unchecked.
+
+!!! tip
+    Go to 'Edit->Editor Preferences', in the 'Search' box type 'CPU' and ensure that the 'Use Less CPU when in Background' is unchecked.
 
 ### [Optional] Setup Remote Control (Multirotor Only)
 

--- a/docs/build_windows.md
+++ b/docs/build_windows.md
@@ -39,7 +39,10 @@ Once AirSim is set up by following above steps, you can,
 
 1. Double click on .sln file to load the Blocks project in `Unreal\Environments\Blocks` (or .sln file in your own [custom](unreal_custenv.md) Unreal project). If you don't see .sln file then you probably haven't completed steps in Build Unreal Project section above.
 2. Select your Unreal project as Start Up project (for example, Blocks project) and make sure Build config is set to "Develop Editor" and x64.
-3. After Unreal Editor loads, press Play button. Tip: go to 'Edit->Editor Preferences', in the 'Search' box type 'CPU' and ensure that the 'Use Less CPU when in Background' is unchecked.
+3. After Unreal Editor loads, press Play button. 
+
+!!! tip
+    Go to 'Edit->Editor Preferences', in the 'Search' box type 'CPU' and ensure that the 'Use Less CPU when in Background' is unchecked.
 
 See [Using APIs](apis.md) and [settings.json](settings.md) for various options available.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ markdown_extensions:
     - toc:
         permalink: "#"
     - pymdownx.extra:
+    - admonition
 
 remote_branch: gh-pages
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: 
- Enables plugin for note, tip blocks in Mkdocs
- Adds tip, note blocks in a few files   <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
Note, Tip blocks are common in rst files which are converted to HTML by Sphinx, these are more noticable than normal text. Adding this plugin allows similar usage in Mkdocs. Example -

![image](https://user-images.githubusercontent.com/37938604/103127101-85571100-46b6-11eb-9073-f423be8680b8.png)

Came to my mind after seeing https://github.com/microsoft/AirSim/discussions/3245

Only added in a few files right now

<!-- Describe what your PR is about. -->

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->

`mkdocs serve` from the root directory

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/37938604/103127171-bd5e5400-46b6-11eb-8919-753c6e26d200.png)
