### PR TITLE
Fix compilation warnings with UE 4.25

### DIFF
--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
@@ -219,7 +219,7 @@ void ASimModeBase::initializeTimeOfDay()
         sky_sphere_ = sky_spheres[0];
         static const FName sun_prop_name(TEXT("Directional light actor"));
         auto* p = sky_sphere_class_->FindPropertyByName(sun_prop_name);
-        UObjectProperty* sun_prop = Cast<UObjectProperty>(p);
+        FObjectProperty* sun_prop = CastFieldChecked<FObjectProperty>(p);
         UObject* sun_obj = sun_prop->GetObjectPropertyValue_InContainer(sky_sphere_);
         sun_ = Cast<ADirectionalLight>(sun_obj);
         if (sun_)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: Compilation Warnings with UE 4.25    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
Currently, when using 4.25, the following compilation warnings occur (truncated) - 

```
/home/rajat/AirSim/Unreal/Environments/Blocks/Plugins/AirSim/Source/SimMode/SimModeBase.cpp:222:9: warning: UObjectProperty has been renamed to FObjectProperty Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-W#pragma-messages]
        UObjectProperty* sun_prop = Cast<UObjectProperty>(p);
        ^

In file included from /home/rajat/UnrealEngine/UE_4.25/Engine/Source/Runtime/Engine/Public/EngineSharedPCH.h:290:
/home/rajat/UnrealEngine/UE_4.25/Engine/Source/Runtime/CoreUObject/Public/Templates/Casts.h:221:30: warning: 'DoCast' is deprecated: Cast<>() and CastChecked<>() should not be used with FProperties. Use CastField<>() or CastFieldChecked<>() instead. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
        return TCastImpl<From, To>::DoCast(Src);
                                    ^
/home/rajat/AirSim/Unreal/Environments/Blocks/Plugins/AirSim/Source/SimMode/SimModeBase.cpp:222:37: note: in instantiation of function template specialization 'Cast<FObjectProperty, FProperty>' requested here
        UObjectProperty* sun_prop = Cast<UObjectProperty>(p);
                                    ^
```


This will, however, break compilation on 4.24

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
Compilation and running in Editor on Linux

## Screenshots (if appropriate):