### PR TITLE
Only install packages if required on OSX

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -9,6 +9,9 @@ downloadHighPolySuv=true
 MIN_CMAKE_VERSION=3.10.0
 function version_less_than_equal_to() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" = "$1"; }
 
+# brew gives error if package is already installed
+function brew_install() { brew list $1 &>/dev/null || brew install $1; }
+
 # Parse command line arguments
 while [[ $# -gt 0 ]]
 do
@@ -63,7 +66,8 @@ if [ "$(uname)" == "Darwin" ]; then # osx
         sudo dseditgroup -o edit -a `whoami` -t user dialout
     fi
 
-    brew install wget coreutils
+    brew_install wget
+    brew_install coreutils
 
     if version_less_than_equal_to $cmake_ver $MIN_CMAKE_VERSION; then
         brew install cmake  # should get cmake 3.8


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: MacOS Actions CI    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
Currently, the MacOS build is giving error - `Error: wget 1.20.3_2 is already installed`. This modifies the script to only install the package if required. Based on [this](https://discourse.brew.sh/t/skip-ignore-brew-install-if-package-is-already-installed/633)

Recommended way is to use [homebrew-bundle](https://github.com/Homebrew/homebrew-bundle), but I haven't ever used it and might be a bit overkill, but let me know if that's the better way to go.

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
Github Actions CI

## Screenshots (if appropriate):