### PR TITLE
Fix issue with building after upgrading UE 4.26

### DIFF
--- a/Unreal/Plugins/AirSim/Source/AirSim.Build.cs
+++ b/Unreal/Plugins/AirSim/Source/AirSim.Build.cs
@@ -78,7 +78,7 @@ public class AirSim : ModuleRules
 
         bEnableExceptions = true;
 
-        PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "ImageWrapper", "RenderCore", "RHI", "AssetRegistry","PhysXVehicles", "PhysXVehicleLib", "PhysX", "APEX", "Landscape" });
+        PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "ImageWrapper", "RenderCore", "RHI", "AssetRegistry", "PhysicsCore", "PhysXVehicles", "PhysXVehicleLib", "PhysX", "APEX", "Landscape" });
         PrivateDependencyModuleNames.AddRange(new string[] { "UMG", "Slate", "SlateCore" });
 
         //suppress VC++ proprietary warnings


### PR DESCRIPTION
add extra dependency on "PhysicsCore" to load definition for UPhysicalMaterial::StaticClass symbol

<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #3183 

## About
This PR fixes a LNK2001 error that occurs when building the AimSim plugin with Unreal Engine 4.26. The LNK2001 error occurs due to a missing object for the UPhysicalMaterial::StaticClass symbol. This is happening because the UPhysicalMaterial class was moved from the "Engine" module to the "PhysicsCore" module. This PR updates the build configuration for the AirSim plugin to add an extra dependency for the "PhysicsCore" module.

## How Has This Been Tested?
The new build configuration was used to build the Blocks environment.

## Screenshots (if appropriate):