### PR TITLE
Update Camera FoV as well when using simSetCameraFoV API 

### DIFF
--- a/PythonClient/computer_vision/fov_change.py
+++ b/PythonClient/computer_vision/fov_change.py
@@ -1,0 +1,53 @@
+import setup_path
+import airsim
+import os
+import tempfile
+
+client = airsim.VehicleClient()
+client.confirmConnection()
+
+tmp_dir = os.path.join(tempfile.gettempdir(), "airsim_cv_mode")
+print ("Saving images to %s" % tmp_dir)
+try:
+    os.makedirs(tmp_dir)
+except OSError:
+    if not os.path.isdir(tmp_dir):
+        raise
+
+CAM_NAME = "front_center"
+print(f"Camera: {CAM_NAME}")
+
+airsim.wait_key('Press any key to get camera parameters')
+
+cam_info = client.simGetCameraInfo(CAM_NAME)
+print(cam_info)
+
+airsim.wait_key(f'Press any key to get images, saving to {tmp_dir}')
+
+requests = [airsim.ImageRequest(CAM_NAME, airsim.ImageType.Scene),
+           airsim.ImageRequest(CAM_NAME, airsim.ImageType.DepthVis)]
+
+def save_images(responses, prefix = ""):
+    for i, response in enumerate(responses):
+        filename = os.path.join(tmp_dir, prefix + "_" + str(i))
+        if response.pixels_as_float:
+            print(f"Type {response.image_type}, size {len(response.image_data_float)}, pos {response.camera_position}")
+            airsim.write_pfm(os.path.normpath(filename + '.pfm'), airsim.get_pfm_array(response))
+        else:
+            print(f"Type {response.image_type}, size {len(response.image_data_uint8)}, pos {response.camera_position}")
+            airsim.write_file(os.path.normpath(filename + '.png'), response.image_data_uint8)
+
+
+responses = client.simGetImages(requests)
+save_images(responses, "old_fov")
+
+airsim.wait_key('Press any key to change FoV and get images')
+
+client.simSetCameraFov(CAM_NAME, 120)
+responses = client.simGetImages(requests)
+save_images(responses, "new_fov")
+
+new_cam_info = client.simGetCameraInfo(CAM_NAME)
+print(new_cam_info)
+
+print(f"Old FOV: {cam_info.fov}, New FOV: {new_cam_info.fov}")

--- a/Unreal/Plugins/AirSim/Source/PIPCamera.cpp
+++ b/Unreal/Plugins/AirSim/Source/PIPCamera.cpp
@@ -288,6 +288,8 @@ void APIPCamera::setCameraFoV(float fov_degrees)
     for (int image_type = 0; image_type < image_count; ++image_type) {
         captures_[image_type]->FOVAngle = fov_degrees;
     }
+
+    camera_->SetFieldOfView(fov_degrees);
 }
 
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes #2977

<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
- Fixes camera FoV not being updated when using the API
- Adds example script for usage of API

Currently, only Render texture FoVs are being updated. This results in an incorrect FoV in the Camera info. **Note** that this is a behavioural change, previously when changing the FoV, the main viewport did not change, only the rendered images were affected. This change will cause the viewport to also change if the camera is the main one, such as the front center camera 

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
Using the script added in this PR, and the output -

<details>
<summary>Output</summary>

```
$ python fov_change.py
Connected!
Client Ver:1 (Min Req: 1), Server Ver:1 (Min Req: 1)

Saving images to /tmp/airsim_cv_mode
Camera: front_center
Press any key to get camera parameters
<CameraInfo> {   'fov': 90.0,
    'pose': <Pose> {   'orientation': <Quaternionr> {   'w_val': 1.0,
    'x_val': -0.0,
    'y_val': 0.0,
    'z_val': 0.0},
    'position': <Vector3r> {   'x_val': 0.0,
    'y_val': 0.0,
    'z_val': -0.0}},
    'proj_mat': <ProjectionMatrix> {   'matrix': [   [   0.0,
                      1.0,
                      0.0,
                      0.0],
                  [   0.0,
                      0.0,
                      -1.7777777910232544,
                      0.0],
                  [   0.0,
                      0.0,
                      0.0,
                      10.0],
                  [   -1.0,
                      0.0,
                      0.0,
                      0.0]]}}
Press any key to get images, saving to /tmp/airsim_cv_mode
Type 0, size 41957, pos <Vector3r> {   'x_val': 0.0,
    'y_val': 0.0,
    'z_val': -0.0}
Type 3, size 1488, pos <Vector3r> {   'x_val': 0.0,
    'y_val': 0.0,
    'z_val': -0.0}
Press any key to change FoV and get images
Type 0, size 41314, pos <Vector3r> {   'x_val': 0.0,
    'y_val': 0.0,
    'z_val': -0.0}
Type 3, size 1656, pos <Vector3r> {   'x_val': 0.0,
    'y_val': 0.0,
    'z_val': -0.0}
<CameraInfo> {   'fov': 120.0,
    'pose': <Pose> {   'orientation': <Quaternionr> {   'w_val': 1.0,
    'x_val': -0.0,
    'y_val': 0.0,
    'z_val': 0.0},
    'position': <Vector3r> {   'x_val': 0.0,
    'y_val': 0.0,
    'z_val': -0.0}},
    'proj_mat': <ProjectionMatrix> {   'matrix': [   [   0.0,
                      0.5773502588272095,
                      0.0,
                      0.0],
                  [   0.0,
                      0.0,
                      -1.0264004468917847,
                      0.0],
                  [   0.0,
                      0.0,
                      0.0,
                      10.0],
                  [   -1.0,
                      0.0,
                      0.0,
                      0.0]]}}
Old FOV: 90.0, New FOV: 120.0
```

</details>

Earlier, the second CameraInfo FoV would be 90.0

## Screenshots (if appropriate):
Old FoV viewport -
![old_fov_viewport](https://user-images.githubusercontent.com/37938604/103785079-c957f780-5060-11eb-9773-d49765320a8e.png)

After FoV update -
![new_fov_viewport](https://user-images.githubusercontent.com/37938604/103785060-c3faad00-5060-11eb-81e8-734b91611cc4.png)

Recorded images -
[airsim_cv_mode.zip](https://github.com/microsoft/AirSim/files/5776549/airsim_cv_mode.zip)

