### PR TITLE
Add support for fixed external cameras

### DIFF
--- a/AirLib/include/api/RpcLibClientBase.hpp
+++ b/AirLib/include/api/RpcLibClientBase.hpp
@@ -74,10 +74,10 @@ namespace airlib
         int simGetSegmentationObjectID(const std::string& mesh_name) const;
         void simPrintLogMessage(const std::string& message, std::string message_param = "", unsigned char severity = 0);
 
-        void simAddDetectionFilterMeshName(const std::string& camera_name, const std::string& mesh_name, const std::string& vehicle_name = "");
-        void simSetDetectionFilterRadius(const std::string& camera_name, const float radius_cm, const std::string& vehicle_name = "");
-        void simClearDetectionMeshNames(const std::string& camera_name, const std::string& vehicle_name = "");
-        vector<DetectionInfo> simGetDetections(const std::string& camera_name, ImageCaptureBase::ImageType image_type, const std::string& vehicle_name = "");
+        void simAddDetectionFilterMeshName(const std::string& camera_name, const std::string& mesh_name, const std::string& vehicle_name = "", bool external = false);
+        void simSetDetectionFilterRadius(const std::string& camera_name, const float radius_cm, const std::string& vehicle_name = "", bool external = false);
+        void simClearDetectionMeshNames(const std::string& camera_name, const std::string& vehicle_name = "", bool external = false);
+        vector<DetectionInfo> simGetDetections(const std::string& camera_name, ImageCaptureBase::ImageType image_type, const std::string& vehicle_name = "", bool external = false);
 
         void simFlushPersistentMarkers();
         void simPlotPoints(const vector<Vector3r>& points, const vector<float>& color_rgba, float size, float duration, bool is_persistent);

--- a/AirLib/include/api/RpcLibClientBase.hpp
+++ b/AirLib/include/api/RpcLibClientBase.hpp
@@ -108,8 +108,8 @@ namespace airlib
         void simSetVehiclePose(const Pose& pose, bool ignore_collision, const std::string& vehicle_name = "");
         void simSetTraceLine(const std::vector<float>& color_rgba, float thickness = 3.0f, const std::string& vehicle_name = "");
 
-        vector<ImageCaptureBase::ImageResponse> simGetImages(vector<ImageCaptureBase::ImageRequest> request, const std::string& vehicle_name = "");
-        vector<uint8_t> simGetImage(const std::string& camera_name, ImageCaptureBase::ImageType type, const std::string& vehicle_name = "");
+        vector<ImageCaptureBase::ImageResponse> simGetImages(vector<ImageCaptureBase::ImageRequest> request, const std::string& vehicle_name = "", bool external = false);
+        vector<uint8_t> simGetImage(const std::string& camera_name, ImageCaptureBase::ImageType type, const std::string& vehicle_name = "", bool external = false);
 
         bool simTestLineOfSightToPoint(const msr::airlib::GeoPoint& point, const std::string& vehicle_name = "");
         bool simTestLineOfSightBetweenPoints(const msr::airlib::GeoPoint& point1, const msr::airlib::GeoPoint& point2);

--- a/AirLib/include/api/RpcLibClientBase.hpp
+++ b/AirLib/include/api/RpcLibClientBase.hpp
@@ -120,7 +120,7 @@ namespace airlib
 
         CollisionInfo simGetCollisionInfo(const std::string& vehicle_name = "") const;
 
-        CameraInfo simGetCameraInfo(const std::string& camera_name, const std::string& vehicle_name = "") const;
+        CameraInfo simGetCameraInfo(const std::string& camera_name, const std::string& vehicle_name = "", bool external = false) const;
         void simSetDistortionParam(const std::string& camera_name, const std::string& param_name, float value, const std::string& vehicle_name = "");
         std::vector<float> simGetDistortionParams(const std::string& camera_name, const std::string& vehicle_name = "");
         void simSetCameraPose(const std::string& camera_name, const Pose& pose, const std::string& vehicle_name = "");
@@ -152,4 +152,5 @@ namespace airlib
     };
 }
 } //namespace
+
 #endif

--- a/AirLib/include/api/RpcLibClientBase.hpp
+++ b/AirLib/include/api/RpcLibClientBase.hpp
@@ -125,8 +125,6 @@ namespace airlib
         std::vector<float> simGetDistortionParams(const std::string& camera_name, const std::string& vehicle_name = "", bool external = false);
         void simSetCameraPose(const std::string& camera_name, const Pose& pose, const std::string& vehicle_name = "", bool external = false);
         void simSetCameraFov(const std::string& camera_name, float fov_degrees, const std::string& vehicle_name = "", bool external = false);
-        // This is a backwards-compatibility wrapper over simSetCameraPose, and can be removed in future major releases
-        void simSetCameraOrientation(const std::string& camera_name, const Quaternionr& orientation, const std::string& vehicle_name = "", bool external = false);
 
         bool simCreateVoxelGrid(const Vector3r& position, const int& x_size, const int& y_size, const int& z_size, const float& res, const std::string& output_file);
         msr::airlib::Kinematics::State simGetGroundTruthKinematics(const std::string& vehicle_name = "") const;

--- a/AirLib/include/api/RpcLibClientBase.hpp
+++ b/AirLib/include/api/RpcLibClientBase.hpp
@@ -121,12 +121,13 @@ namespace airlib
         CollisionInfo simGetCollisionInfo(const std::string& vehicle_name = "") const;
 
         CameraInfo simGetCameraInfo(const std::string& camera_name, const std::string& vehicle_name = "", bool external = false) const;
-        void simSetDistortionParam(const std::string& camera_name, const std::string& param_name, float value, const std::string& vehicle_name = "");
-        std::vector<float> simGetDistortionParams(const std::string& camera_name, const std::string& vehicle_name = "");
-        void simSetCameraPose(const std::string& camera_name, const Pose& pose, const std::string& vehicle_name = "");
-        void simSetCameraFov(const std::string& camera_name, float fov_degrees, const std::string& vehicle_name = "");
+        void simSetDistortionParam(const std::string& camera_name, const std::string& param_name, float value, const std::string& vehicle_name = "", bool external = false);
+        std::vector<float> simGetDistortionParams(const std::string& camera_name, const std::string& vehicle_name = "", bool external = false);
+        void simSetCameraPose(const std::string& camera_name, const Pose& pose, const std::string& vehicle_name = "", bool external = false);
+        void simSetCameraFov(const std::string& camera_name, float fov_degrees, const std::string& vehicle_name = "", bool external = false);
         // This is a backwards-compatibility wrapper over simSetCameraPose, and can be removed in future major releases
-        void simSetCameraOrientation(const std::string& camera_name, const Quaternionr& orientation, const std::string& vehicle_name = "");
+        void simSetCameraOrientation(const std::string& camera_name, const Quaternionr& orientation, const std::string& vehicle_name = "", bool external = false);
+
         bool simCreateVoxelGrid(const Vector3r& position, const int& x_size, const int& y_size, const int& z_size, const float& res, const std::string& output_file);
         msr::airlib::Kinematics::State simGetGroundTruthKinematics(const std::string& vehicle_name = "") const;
         msr::airlib::Environment::State simGetGroundTruthEnvironment(const std::string& vehicle_name = "") const;

--- a/AirLib/include/api/VehicleSimApiBase.hpp
+++ b/AirLib/include/api/VehicleSimApiBase.hpp
@@ -59,11 +59,6 @@ namespace airlib
         virtual const Kinematics::State* getGroundTruthKinematics() const = 0;
         virtual const msr::airlib::Environment* getGroundTruthEnvironment() const = 0;
 
-        virtual void setCameraPose(const std::string& camera_name, const Pose& pose) = 0;
-        virtual void setCameraFoV(const std::string& camera_name, float fov_degrees) = 0;
-        virtual void setDistortionParam(const std::string& camera_name, const std::string& param_name, float value) = 0;
-        virtual std::vector<float> getDistortionParams(const std::string& camera_name) const = 0;
-
         virtual CollisionInfo getCollisionInfo() const = 0;
         virtual int getRemoteControlID() const = 0; //which RC to use, 0 is first one, -1 means disable RC (use keyborad)
         virtual RCData getRCData() const = 0; //get reading from RC from simulator's host OS

--- a/AirLib/include/api/VehicleSimApiBase.hpp
+++ b/AirLib/include/api/VehicleSimApiBase.hpp
@@ -59,7 +59,6 @@ namespace airlib
         virtual const Kinematics::State* getGroundTruthKinematics() const = 0;
         virtual const msr::airlib::Environment* getGroundTruthEnvironment() const = 0;
 
-        virtual CameraInfo getCameraInfo(const std::string& camera_name) const = 0;
         virtual void setCameraPose(const std::string& camera_name, const Pose& pose) = 0;
         virtual void setCameraFoV(const std::string& camera_name, float fov_degrees) = 0;
         virtual void setDistortionParam(const std::string& camera_name, const std::string& param_name, float value) = 0;

--- a/AirLib/include/api/VehicleSimApiBase.hpp
+++ b/AirLib/include/api/VehicleSimApiBase.hpp
@@ -49,9 +49,6 @@ namespace airlib
 
         virtual void initialize() = 0;
 
-        virtual std::vector<ImageCaptureBase::ImageResponse> getImages(const std::vector<ImageCaptureBase::ImageRequest>& request) const = 0;
-        virtual std::vector<uint8_t> getImage(const std::string& camera_name, ImageCaptureBase::ImageType image_type) const = 0;
-
         virtual bool testLineOfSightToPoint(const GeoPoint& point) const = 0;
 
         virtual Pose getPose() const = 0;

--- a/AirLib/include/api/VehicleSimApiBase.hpp
+++ b/AirLib/include/api/VehicleSimApiBase.hpp
@@ -63,7 +63,7 @@ namespace airlib
         virtual void setCameraPose(const std::string& camera_name, const Pose& pose) = 0;
         virtual void setCameraFoV(const std::string& camera_name, float fov_degrees) = 0;
         virtual void setDistortionParam(const std::string& camera_name, const std::string& param_name, float value) = 0;
-        virtual std::vector<float> getDistortionParams(const std::string& camera_name) = 0;
+        virtual std::vector<float> getDistortionParams(const std::string& camera_name) const = 0;
 
         virtual CollisionInfo getCollisionInfo() const = 0;
         virtual int getRemoteControlID() const = 0; //which RC to use, 0 is first one, -1 means disable RC (use keyborad)

--- a/AirLib/include/api/VehicleSimApiBase.hpp
+++ b/AirLib/include/api/VehicleSimApiBase.hpp
@@ -64,11 +64,6 @@ namespace airlib
         virtual void toggleTrace() = 0;
         virtual void setTraceLine(const std::vector<float>& color_rgba, float thickness) = 0;
 
-        virtual void addDetectionFilterMeshName(const std::string& camera_name, ImageCaptureBase::ImageType image_type, const std::string& mesh_name) = 0;
-        virtual void setDetectionFilterRadius(const std::string& camera_name, ImageCaptureBase::ImageType image_type, const float radius_cm) = 0;
-        virtual void clearDetectionMeshNames(const std::string& camera_name, ImageCaptureBase::ImageType image_type) = 0;
-        virtual std::vector<DetectionInfo> getDetections(const std::string& camera_name, ImageCaptureBase::ImageType image_type) const = 0;
-
         //use pointer here because of derived classes for VehicleSetting
         const AirSimSettings::VehicleSetting* getVehicleSetting() const
         {

--- a/AirLib/include/api/WorldSimApiBase.hpp
+++ b/AirLib/include/api/WorldSimApiBase.hpp
@@ -88,7 +88,11 @@ namespace airlib
 
         virtual bool testLineOfSightBetweenPoints(const msr::airlib::GeoPoint& point1, const msr::airlib::GeoPoint& point2) const = 0;
         virtual vector<msr::airlib::GeoPoint> getWorldExtents() const = 0;
+
+        // Image APIs
+        virtual CameraInfo getCameraInfo(const std::string& camera_name, const std::string& vehicle_name = "", bool external = false) const = 0;
     };
 }
 } //namespace
+
 #endif

--- a/AirLib/include/api/WorldSimApiBase.hpp
+++ b/AirLib/include/api/WorldSimApiBase.hpp
@@ -5,7 +5,7 @@
 #define air_WorldSimApiBase_hpp
 
 #include "common/CommonStructs.hpp"
-#include "common/AirSimSettings.hpp"
+#include "common/ImageCaptureBase.hpp"
 
 namespace msr
 {

--- a/AirLib/include/api/WorldSimApiBase.hpp
+++ b/AirLib/include/api/WorldSimApiBase.hpp
@@ -91,6 +91,14 @@ namespace airlib
 
         // Image APIs
         virtual CameraInfo getCameraInfo(const std::string& camera_name, const std::string& vehicle_name = "", bool external = false) const = 0;
+        virtual void setCameraPose(const std::string& camera_name, const msr::airlib::Pose& pose,
+                                   const std::string& vehicle_name = "", bool external = false) = 0;
+        virtual void setCameraFoV(const std::string& camera_name, float fov_degrees,
+                                  const std::string& vehicle_name = "", bool external = false) = 0;
+        virtual void setDistortionParam(const std::string& camera_name, const std::string& param_name, float value,
+                                        const std::string& vehicle_name = "", bool external = false) = 0;
+        virtual std::vector<float> getDistortionParams(const std::string& camera_name, const std::string& vehicle_name = "",
+                                                       bool external = false) const = 0;
     };
 }
 } //namespace

--- a/AirLib/include/api/WorldSimApiBase.hpp
+++ b/AirLib/include/api/WorldSimApiBase.hpp
@@ -89,7 +89,7 @@ namespace airlib
         virtual bool testLineOfSightBetweenPoints(const msr::airlib::GeoPoint& point1, const msr::airlib::GeoPoint& point2) const = 0;
         virtual vector<msr::airlib::GeoPoint> getWorldExtents() const = 0;
 
-        // Image APIs
+        // Camera APIs
         virtual CameraInfo getCameraInfo(const std::string& camera_name, const std::string& vehicle_name = "", bool external = false) const = 0;
         virtual void setCameraPose(const std::string& camera_name, const msr::airlib::Pose& pose,
                                    const std::string& vehicle_name = "", bool external = false) = 0;
@@ -97,13 +97,22 @@ namespace airlib
                                   const std::string& vehicle_name = "", bool external = false) = 0;
         virtual void setDistortionParam(const std::string& camera_name, const std::string& param_name, float value,
                                         const std::string& vehicle_name = "", bool external = false) = 0;
-        virtual std::vector<float> getDistortionParams(const std::string& camera_name, const std::string& vehicle_name = "",
-                                                       bool external = false) const = 0;
+        virtual std::vector<float> getDistortionParams(const std::string& camera_name,
+                                                       const std::string& vehicle_name = "", bool external = false) const = 0;
 
         virtual std::vector<ImageCaptureBase::ImageResponse> getImages(const std::vector<ImageCaptureBase::ImageRequest>& requests,
                                                                        const std::string& vehicle_name = "", bool external = false) const = 0;
         virtual std::vector<uint8_t> getImage(const std::string& camera_name, ImageCaptureBase::ImageType image_type,
                                               const std::string& vehicle_name = "", bool external = false) const = 0;
+
+        virtual void addDetectionFilterMeshName(const std::string& camera_name, ImageCaptureBase::ImageType image_type, const std::string& mesh_name,
+                                                const std::string& vehicle_name = "", bool external = false) = 0;
+        virtual void setDetectionFilterRadius(const std::string& camera_name, ImageCaptureBase::ImageType image_type, float radius_cm,
+                                              const std::string& vehicle_name = "", bool external = false) = 0;
+        virtual void clearDetectionMeshNames(const std::string& camera_name, ImageCaptureBase::ImageType image_type,
+                                             const std::string& vehicle_name = "", bool external = false) = 0;
+        virtual std::vector<DetectionInfo> getDetections(const std::string& camera_name, ImageCaptureBase::ImageType image_type,
+                                                         const std::string& vehicle_name = "", bool external = false) = 0;
     };
 }
 } //namespace

--- a/AirLib/include/api/WorldSimApiBase.hpp
+++ b/AirLib/include/api/WorldSimApiBase.hpp
@@ -99,6 +99,11 @@ namespace airlib
                                         const std::string& vehicle_name = "", bool external = false) = 0;
         virtual std::vector<float> getDistortionParams(const std::string& camera_name, const std::string& vehicle_name = "",
                                                        bool external = false) const = 0;
+
+        virtual std::vector<ImageCaptureBase::ImageResponse> getImages(const std::vector<ImageCaptureBase::ImageRequest>& requests,
+                                                                       const std::string& vehicle_name = "", bool external = false) const = 0;
+        virtual std::vector<uint8_t> getImage(const std::string& camera_name, ImageCaptureBase::ImageType image_type,
+                                              const std::string& vehicle_name = "", bool external = false) const = 0;
     };
 }
 } //namespace

--- a/AirLib/include/api/WorldSimApiBase.hpp
+++ b/AirLib/include/api/WorldSimApiBase.hpp
@@ -97,9 +97,8 @@ namespace airlib
         virtual std::vector<float> getDistortionParams(const CameraDetails& camera_details) const = 0;
 
         virtual std::vector<ImageCaptureBase::ImageResponse> getImages(const std::vector<ImageCaptureBase::ImageRequest>& requests,
-                                                                       const std::string& vehicle_name = "", bool external = false) const = 0;
-        virtual std::vector<uint8_t> getImage(const std::string& camera_name, ImageCaptureBase::ImageType image_type,
-                                              const std::string& vehicle_name = "", bool external = false) const = 0;
+                                                                       const std::string& vehicle_name, bool external) const = 0;
+        virtual std::vector<uint8_t> getImage(ImageCaptureBase::ImageType image_type, const CameraDetails& camera_details) const = 0;
 
         virtual void addDetectionFilterMeshName(ImageCaptureBase::ImageType image_type, const std::string& mesh_name, const CameraDetails& camera_details) = 0;
         virtual void setDetectionFilterRadius(ImageCaptureBase::ImageType image_type, float radius_cm, const CameraDetails& camera_details) = 0;

--- a/AirLib/include/api/WorldSimApiBase.hpp
+++ b/AirLib/include/api/WorldSimApiBase.hpp
@@ -90,29 +90,21 @@ namespace airlib
         virtual vector<msr::airlib::GeoPoint> getWorldExtents() const = 0;
 
         // Camera APIs
-        virtual CameraInfo getCameraInfo(const std::string& camera_name, const std::string& vehicle_name = "", bool external = false) const = 0;
-        virtual void setCameraPose(const std::string& camera_name, const msr::airlib::Pose& pose,
-                                   const std::string& vehicle_name = "", bool external = false) = 0;
-        virtual void setCameraFoV(const std::string& camera_name, float fov_degrees,
-                                  const std::string& vehicle_name = "", bool external = false) = 0;
-        virtual void setDistortionParam(const std::string& camera_name, const std::string& param_name, float value,
-                                        const std::string& vehicle_name = "", bool external = false) = 0;
-        virtual std::vector<float> getDistortionParams(const std::string& camera_name,
-                                                       const std::string& vehicle_name = "", bool external = false) const = 0;
+        virtual CameraInfo getCameraInfo(const CameraDetails& camera_details) const = 0;
+        virtual void setCameraPose(const msr::airlib::Pose& pose, const CameraDetails& camera_details) = 0;
+        virtual void setCameraFoV(float fov_degrees, const CameraDetails& camera_details) = 0;
+        virtual void setDistortionParam(const std::string& param_name, float value, const CameraDetails& camera_details) = 0;
+        virtual std::vector<float> getDistortionParams(const CameraDetails& camera_details) const = 0;
 
         virtual std::vector<ImageCaptureBase::ImageResponse> getImages(const std::vector<ImageCaptureBase::ImageRequest>& requests,
                                                                        const std::string& vehicle_name = "", bool external = false) const = 0;
         virtual std::vector<uint8_t> getImage(const std::string& camera_name, ImageCaptureBase::ImageType image_type,
                                               const std::string& vehicle_name = "", bool external = false) const = 0;
 
-        virtual void addDetectionFilterMeshName(const std::string& camera_name, ImageCaptureBase::ImageType image_type, const std::string& mesh_name,
-                                                const std::string& vehicle_name = "", bool external = false) = 0;
-        virtual void setDetectionFilterRadius(const std::string& camera_name, ImageCaptureBase::ImageType image_type, float radius_cm,
-                                              const std::string& vehicle_name = "", bool external = false) = 0;
-        virtual void clearDetectionMeshNames(const std::string& camera_name, ImageCaptureBase::ImageType image_type,
-                                             const std::string& vehicle_name = "", bool external = false) = 0;
-        virtual std::vector<DetectionInfo> getDetections(const std::string& camera_name, ImageCaptureBase::ImageType image_type,
-                                                         const std::string& vehicle_name = "", bool external = false) = 0;
+        virtual void addDetectionFilterMeshName(ImageCaptureBase::ImageType image_type, const std::string& mesh_name, const CameraDetails& camera_details) = 0;
+        virtual void setDetectionFilterRadius(ImageCaptureBase::ImageType image_type, float radius_cm, const CameraDetails& camera_details) = 0;
+        virtual void clearDetectionMeshNames(ImageCaptureBase::ImageType image_type, const CameraDetails& camera_details) = 0;
+        virtual std::vector<DetectionInfo> getDetections(ImageCaptureBase::ImageType image_type, const CameraDetails& camera_details) = 0;
     };
 }
 } //namespace

--- a/AirLib/include/common/AirSimSettings.hpp
+++ b/AirLib/include/common/AirSimSettings.hpp
@@ -53,9 +53,13 @@ namespace airlib
             bool external;
 
             SubwindowSetting(int window_index_val = 0, ImageType image_type_val = ImageType::Scene, bool visible_val = false,
-                const std::string& camera_name_val = "", const std::string& vehicle_name_val = "", bool external_val = false)
-                : window_index(window_index_val), image_type(image_type_val), visible(visible_val),
-                  camera_name(camera_name_val), vehicle_name(vehicle_name_val), external(external_val)
+                             const std::string& camera_name_val = "", const std::string& vehicle_name_val = "", bool external_val = false)
+                : window_index(window_index_val)
+                , image_type(image_type_val)
+                , visible(visible_val)
+                , camera_name(camera_name_val)
+                , vehicle_name(vehicle_name_val)
+                , external(external_val)
             {
             }
         };
@@ -1348,7 +1352,6 @@ namespace airlib
                 }
             }
         }
-
     };
 }
 } //namespace

--- a/AirLib/include/common/AirSimSettings.hpp
+++ b/AirLib/include/common/AirSimSettings.hpp
@@ -393,6 +393,7 @@ namespace airlib
         std::string speed_unit_label = "m\\s";
         std::map<std::string, std::shared_ptr<SensorSetting>> sensor_defaults;
         Vector3r wind = Vector3r::Zero();
+        std::map<std::string, CameraSetting> external_cameras;
 
         std::string settings_text_ = "";
 
@@ -1327,7 +1328,26 @@ namespace airlib
             else
                 createDefaultSensorSettings(simmode_name, sensors);
         }
+
+        static void loadExternalCameraSettings(const Settings& settings_json, std::map<std::string, CameraSetting>& external_cameras)
+        {
+            external_cameras.clear();
+
+            Settings json_parent;
+            if (settings_json.getChild("ExternalCameras", json_parent)) {
+                std::vector<std::string> keys;
+                json_parent.getChildNames(keys);
+
+                for (const auto& key : keys) {
+                    Settings child;
+                    json_parent.getChild(key, child);
+                    external_cameras[key] = createCameraSetting(child);
+                }
+            }
+        }
+
     };
 }
 } //namespace
+
 #endif

--- a/AirLib/include/common/AirSimSettings.hpp
+++ b/AirLib/include/common/AirSimSettings.hpp
@@ -50,10 +50,12 @@ namespace airlib
             bool visible;
             std::string camera_name;
             std::string vehicle_name;
+            bool external;
 
-            SubwindowSetting(int window_index_val = 0, ImageType image_type_val = ImageType::Scene,
-                             bool visible_val = false, const std::string& camera_name_val = "", const std::string& vehicle_name_val = "")
-                : window_index(window_index_val), image_type(image_type_val), visible(visible_val), camera_name(camera_name_val), vehicle_name(vehicle_name_val)
+            SubwindowSetting(int window_index_val = 0, ImageType image_type_val = ImageType::Scene, bool visible_val = false,
+                const std::string& camera_name_val = "", const std::string& vehicle_name_val = "", bool external_val = false)
+                : window_index(window_index_val), image_type(image_type_val), visible(visible_val),
+                  camera_name(camera_name_val), vehicle_name(vehicle_name_val), external(external_val)
             {
             }
         };
@@ -1089,6 +1091,7 @@ namespace airlib
                         subwindow_setting.visible = json_settings_child.getBool("Visible", false);
                         subwindow_setting.camera_name = getCameraName(json_settings_child);
                         subwindow_setting.vehicle_name = json_settings_child.getString("VehicleName", "");
+                        subwindow_setting.external = json_settings_child.getBool("External", false);
                     }
                 }
             }
@@ -1097,9 +1100,9 @@ namespace airlib
         static void initializeSubwindowSettings(std::vector<SubwindowSetting>& subwindow_settings)
         {
             subwindow_settings.clear();
-            subwindow_settings.push_back(SubwindowSetting(0, ImageType::DepthVis, false, "", "")); //depth
-            subwindow_settings.push_back(SubwindowSetting(1, ImageType::Segmentation, false, "", "")); //seg
-            subwindow_settings.push_back(SubwindowSetting(2, ImageType::Scene, false, "", "")); //vis
+            subwindow_settings.push_back(SubwindowSetting(0, ImageType::DepthVis, false, "", "", false)); //depth
+            subwindow_settings.push_back(SubwindowSetting(1, ImageType::Segmentation, false, "", "", false)); //seg
+            subwindow_settings.push_back(SubwindowSetting(2, ImageType::Scene, false, "", "", false)); //vis
         }
 
         void loadOtherSettings(const Settings& settings_json)

--- a/AirLib/include/common/AirSimSettings.hpp
+++ b/AirLib/include/common/AirSimSettings.hpp
@@ -435,6 +435,7 @@ namespace airlib
             loadOtherSettings(settings_json);
             loadDefaultSensorSettings(simmode_name, settings_json, sensor_defaults);
             loadVehicleSettings(simmode_name, settings_json, vehicles, sensor_defaults);
+            loadExternalCameraSettings(settings_json, external_cameras);
 
             //this should be done last because it depends on vehicles (and/or their type) we have
             loadRecordingSetting(settings_json);

--- a/AirLib/include/common/CommonStructs.hpp
+++ b/AirLib/include/common/CommonStructs.hpp
@@ -434,6 +434,14 @@ namespace airlib
             : camera_name(camera_name_val), vehicle_name(vehicle_name_val), external(external_val)
         {
         }
+
+        std::string to_string() const
+        {
+            return Utils::stringf("CameraDetails: camera_name=%s, vehicle_name=%s, external=%d",
+                                  camera_name.c_str(),
+                                  vehicle_name.c_str(),
+                                  external);
+        }
     };
 }
 } //namespace

--- a/AirLib/include/common/CommonStructs.hpp
+++ b/AirLib/include/common/CommonStructs.hpp
@@ -421,6 +421,20 @@ namespace airlib
         std::vector<uint32_t> indices;
         std::string name;
     };
+
+    // This is a small helper struct to keep camera details together
+    // Not currently exposed to the client, just for cleaner codebase internally
+    struct CameraDetails
+    {
+        std::string camera_name;
+        std::string vehicle_name;
+        bool external;
+
+        CameraDetails(const std::string& camera_name_val, const std::string& vehicle_name_val, bool external_val)
+            : camera_name(camera_name_val), vehicle_name(vehicle_name_val), external(external_val)
+        {
+        }
+    };
 }
 } //namespace
 #endif

--- a/AirLib/src/api/RpcLibClientBase.cpp
+++ b/AirLib/src/api/RpcLibClientBase.cpp
@@ -440,31 +440,31 @@ __pragma(warning(disable : 4239))
             return pimpl_->client.call("simGetCameraInfo", camera_name, vehicle_name, external).as<RpcLibAdaptorsBase::CameraInfo>().to();
         }
 
-        void RpcLibClientBase::simSetCameraPose(const std::string& camera_name, const Pose& pose, const std::string& vehicle_name)
+        void RpcLibClientBase::simSetCameraPose(const std::string& camera_name, const Pose& pose, const std::string& vehicle_name, bool external)
         {
-            pimpl_->client.call("simSetCameraPose", camera_name, RpcLibAdaptorsBase::Pose(pose), vehicle_name);
+            pimpl_->client.call("simSetCameraPose", camera_name, RpcLibAdaptorsBase::Pose(pose), vehicle_name, external);
         }
 
-        void RpcLibClientBase::simSetCameraOrientation(const std::string& camera_name, const Quaternionr& orientation, const std::string& vehicle_name)
+        void RpcLibClientBase::simSetCameraOrientation(const std::string& camera_name, const Quaternionr& orientation, const std::string& vehicle_name, bool external)
         {
             std::cout << "`simSetCameraOrientation` API has been upgraded to `simSetCameraPose`. Please update your code." << std::endl;
             Pose pose{ Vector3r::Zero(), orientation };
-            RpcLibClientBase::simSetCameraPose(camera_name, pose, vehicle_name);
+            RpcLibClientBase::simSetCameraPose(camera_name, pose, vehicle_name, external);
         }
 
-        void RpcLibClientBase::simSetCameraFov(const std::string& camera_name, float fov_degrees, const std::string& vehicle_name)
+        void RpcLibClientBase::simSetCameraFov(const std::string& camera_name, float fov_degrees, const std::string& vehicle_name, bool external)
         {
-            pimpl_->client.call("simSetCameraFov", camera_name, fov_degrees, vehicle_name);
+            pimpl_->client.call("simSetCameraFov", camera_name, fov_degrees, vehicle_name, external);
         }
 
-        void RpcLibClientBase::simSetDistortionParam(const std::string& camera_name, const std::string& param_name, float value, const std::string& vehicle_name)
+        void RpcLibClientBase::simSetDistortionParam(const std::string& camera_name, const std::string& param_name, float value, const std::string& vehicle_name, bool external)
         {
-            pimpl_->client.call("simSetDistortionParam", camera_name, param_name, value, vehicle_name);
+            pimpl_->client.call("simSetDistortionParam", camera_name, param_name, value, vehicle_name, external);
         }
 
-        std::vector<float> RpcLibClientBase::simGetDistortionParams(const std::string& camera_name, const std::string& vehicle_name)
+        std::vector<float> RpcLibClientBase::simGetDistortionParams(const std::string& camera_name, const std::string& vehicle_name, bool external)
         {
-            return pimpl_->client.call("simGetDistortionParams", camera_name, vehicle_name).as<std::vector<float>>();
+            return pimpl_->client.call("simGetDistortionParams", camera_name, vehicle_name, external).as<std::vector<float>>();
         }
 
         msr::airlib::Kinematics::State RpcLibClientBase::simGetGroundTruthKinematics(const std::string& vehicle_name) const

--- a/AirLib/src/api/RpcLibClientBase.cpp
+++ b/AirLib/src/api/RpcLibClientBase.cpp
@@ -435,9 +435,9 @@ __pragma(warning(disable : 4239))
             return pimpl_->client.call("simSetObjectScale", object_name, RpcLibAdaptorsBase::Vector3r(scale)).as<bool>();
         }
 
-        CameraInfo RpcLibClientBase::simGetCameraInfo(const std::string& camera_name, const std::string& vehicle_name) const
+        CameraInfo RpcLibClientBase::simGetCameraInfo(const std::string& camera_name, const std::string& vehicle_name, bool external) const
         {
-            return pimpl_->client.call("simGetCameraInfo", camera_name, vehicle_name).as<RpcLibAdaptorsBase::CameraInfo>().to();
+            return pimpl_->client.call("simGetCameraInfo", camera_name, vehicle_name, external).as<RpcLibAdaptorsBase::CameraInfo>().to();
         }
 
         void RpcLibClientBase::simSetCameraPose(const std::string& camera_name, const Pose& pose, const std::string& vehicle_name)

--- a/AirLib/src/api/RpcLibClientBase.cpp
+++ b/AirLib/src/api/RpcLibClientBase.cpp
@@ -251,18 +251,19 @@ __pragma(warning(disable : 4239))
             pimpl_->client.call("simSetTraceLine", color_rgba, thickness, vehicle_name);
         }
 
-        vector<ImageCaptureBase::ImageResponse> RpcLibClientBase::simGetImages(vector<ImageCaptureBase::ImageRequest> request, const std::string& vehicle_name)
+        vector<ImageCaptureBase::ImageResponse> RpcLibClientBase::simGetImages(vector<ImageCaptureBase::ImageRequest> request, const std::string& vehicle_name, bool external)
         {
             const auto& response_adaptor = pimpl_->client.call("simGetImages",
                                                                RpcLibAdaptorsBase::ImageRequest::from(request),
-                                                               vehicle_name)
+                                                               vehicle_name,
+                                                               external)
                                                .as<vector<RpcLibAdaptorsBase::ImageResponse>>();
 
             return RpcLibAdaptorsBase::ImageResponse::to(response_adaptor);
         }
-        vector<uint8_t> RpcLibClientBase::simGetImage(const std::string& camera_name, ImageCaptureBase::ImageType type, const std::string& vehicle_name)
+        vector<uint8_t> RpcLibClientBase::simGetImage(const std::string& camera_name, ImageCaptureBase::ImageType type, const std::string& vehicle_name, bool external)
         {
-            vector<uint8_t> result = pimpl_->client.call("simGetImage", camera_name, type, vehicle_name).as<vector<uint8_t>>();
+            vector<uint8_t> result = pimpl_->client.call("simGetImage", camera_name, type, vehicle_name, external).as<vector<uint8_t>>();
             if (result.size() == 1) {
                 // rpclib has a bug with serializing empty vectors, so we return a 1 byte vector instead.
                 result.clear();

--- a/AirLib/src/api/RpcLibClientBase.cpp
+++ b/AirLib/src/api/RpcLibClientBase.cpp
@@ -445,13 +445,6 @@ __pragma(warning(disable : 4239))
             pimpl_->client.call("simSetCameraPose", camera_name, RpcLibAdaptorsBase::Pose(pose), vehicle_name, external);
         }
 
-        void RpcLibClientBase::simSetCameraOrientation(const std::string& camera_name, const Quaternionr& orientation, const std::string& vehicle_name, bool external)
-        {
-            std::cout << "`simSetCameraOrientation` API has been upgraded to `simSetCameraPose`. Please update your code." << std::endl;
-            Pose pose{ Vector3r::Zero(), orientation };
-            RpcLibClientBase::simSetCameraPose(camera_name, pose, vehicle_name, external);
-        }
-
         void RpcLibClientBase::simSetCameraFov(const std::string& camera_name, float fov_degrees, const std::string& vehicle_name, bool external)
         {
             pimpl_->client.call("simSetCameraFov", camera_name, fov_degrees, vehicle_name, external);

--- a/AirLib/src/api/RpcLibClientBase.cpp
+++ b/AirLib/src/api/RpcLibClientBase.cpp
@@ -213,21 +213,21 @@ __pragma(warning(disable : 4239))
             return pimpl_->client.call("simGetSegmentationObjectID", mesh_name).as<int>();
         }
 
-        void RpcLibClientBase::simAddDetectionFilterMeshName(const std::string& camera_name, const std::string& mesh_name, const std::string& vehicle_name)
+        void RpcLibClientBase::simAddDetectionFilterMeshName(const std::string& camera_name, const std::string& mesh_name, const std::string& vehicle_name, bool external)
         {
-            pimpl_->client.call("simAddDetectionFilterMeshName", camera_name, mesh_name, vehicle_name);
+            pimpl_->client.call("simAddDetectionFilterMeshName", camera_name, mesh_name, vehicle_name, external);
         }
-        void RpcLibClientBase::simSetDetectionFilterRadius(const std::string& camera_name, const float radius_cm, const std::string& vehicle_name)
+        void RpcLibClientBase::simSetDetectionFilterRadius(const std::string& camera_name, const float radius_cm, const std::string& vehicle_name, bool external)
         {
-            pimpl_->client.call("simSetDetectionFilterRadius", camera_name, radius_cm, vehicle_name);
+            pimpl_->client.call("simSetDetectionFilterRadius", camera_name, radius_cm, vehicle_name, external);
         }
-        void RpcLibClientBase::simClearDetectionMeshNames(const std::string& camera_name, const std::string& vehicle_name)
+        void RpcLibClientBase::simClearDetectionMeshNames(const std::string& camera_name, const std::string& vehicle_name, bool external)
         {
-            pimpl_->client.call("simClearDetectionMeshNames", camera_name, vehicle_name);
+            pimpl_->client.call("simClearDetectionMeshNames", camera_name, vehicle_name, external);
         }
-        vector<DetectionInfo> RpcLibClientBase::simGetDetections(const std::string& camera_name, ImageCaptureBase::ImageType image_type, const std::string& vehicle_name)
+        vector<DetectionInfo> RpcLibClientBase::simGetDetections(const std::string& camera_name, ImageCaptureBase::ImageType image_type, const std::string& vehicle_name, bool external)
         {
-            const auto& result = pimpl_->client.call("simGetDetections", camera_name, image_type, vehicle_name).as<vector<RpcLibAdaptorsBase::DetectionInfo>>();
+            const auto& result = pimpl_->client.call("simGetDetections", camera_name, image_type, vehicle_name, external).as<vector<RpcLibAdaptorsBase::DetectionInfo>>();
             return RpcLibAdaptorsBase::DetectionInfo::to(result);
         }
 

--- a/AirLib/src/api/RpcLibServerBase.cpp
+++ b/AirLib/src/api/RpcLibServerBase.cpp
@@ -199,16 +199,16 @@ namespace airlib
         });
 
         pimpl_->server.bind("simAddDetectionFilterMeshName", [&](const std::string& camera_name, ImageCaptureBase::ImageType type, const std::string& mesh_name, const std::string& vehicle_name, bool external) -> void {
-            getWorldSimApi()->addDetectionFilterMeshName(camera_name, type, mesh_name, vehicle_name, external);
+            getWorldSimApi()->addDetectionFilterMeshName(type, mesh_name, CameraDetails(camera_name, vehicle_name, external));
         });
         pimpl_->server.bind("simSetDetectionFilterRadius", [&](const std::string& camera_name, ImageCaptureBase::ImageType type, const float radius_cm, const std::string& vehicle_name, bool external) -> void {
-            getWorldSimApi()->setDetectionFilterRadius(camera_name, type, radius_cm, vehicle_name, external);
+            getWorldSimApi()->setDetectionFilterRadius(type, radius_cm, CameraDetails(camera_name, vehicle_name, external));
         });
         pimpl_->server.bind("simClearDetectionMeshNames", [&](const std::string& camera_name, ImageCaptureBase::ImageType type, const std::string& vehicle_name, bool external) -> void {
-            getWorldSimApi()->clearDetectionMeshNames(camera_name, type, vehicle_name, external);
+            getWorldSimApi()->clearDetectionMeshNames(type, CameraDetails(camera_name, vehicle_name, external));
         });
         pimpl_->server.bind("simGetDetections", [&](const std::string& camera_name, ImageCaptureBase::ImageType type, const std::string& vehicle_name, bool external) -> vector<RpcLibAdaptorsBase::DetectionInfo> {
-            const auto& response = getWorldSimApi()->getDetections(camera_name, type, vehicle_name, external);
+            const auto& response = getWorldSimApi()->getDetections(type, CameraDetails(camera_name, vehicle_name, external));
             return RpcLibAdaptorsBase::DetectionInfo::from(response);
         });
 
@@ -269,24 +269,24 @@ namespace airlib
         });
 
         pimpl_->server.bind("simGetCameraInfo", [&](const std::string& camera_name, const std::string& vehicle_name, bool external) -> RpcLibAdaptorsBase::CameraInfo {
-            const auto& camera_info = getWorldSimApi()->getCameraInfo(camera_name, vehicle_name, external);
+            const auto& camera_info = getWorldSimApi()->getCameraInfo(CameraDetails(camera_name, vehicle_name, external));
             return RpcLibAdaptorsBase::CameraInfo(camera_info);
         });
 
         pimpl_->server.bind("simSetDistortionParam", [&](const std::string& camera_name, const std::string& param_name, float value, const std::string& vehicle_name, bool external) -> void {
-            getWorldSimApi()->setDistortionParam(camera_name, param_name, value, vehicle_name, external);
+            getWorldSimApi()->setDistortionParam(param_name, value, CameraDetails(camera_name, vehicle_name, external));
         });
 
         pimpl_->server.bind("simGetDistortionParams", [&](const std::string& camera_name, const std::string& vehicle_name, bool external) -> std::vector<float> {
-            return getWorldSimApi()->getDistortionParams(camera_name, vehicle_name, external);
+            return getWorldSimApi()->getDistortionParams(CameraDetails(camera_name, vehicle_name, external));
         });
 
         pimpl_->server.bind("simSetCameraPose", [&](const std::string& camera_name, const RpcLibAdaptorsBase::Pose& pose, const std::string& vehicle_name, bool external) -> void {
-            getWorldSimApi()->setCameraPose(camera_name, pose.to(), vehicle_name, external);
+            getWorldSimApi()->setCameraPose(pose.to(), CameraDetails(camera_name, vehicle_name, external));
         });
 
         pimpl_->server.bind("simSetCameraFov", [&](const std::string& camera_name, float fov_degrees, const std::string& vehicle_name, bool external) -> void {
-            getWorldSimApi()->setCameraFoV(camera_name, fov_degrees, vehicle_name, external);
+            getWorldSimApi()->setCameraFoV(fov_degrees, CameraDetails(camera_name, vehicle_name, external));
         });
 
         pimpl_->server.bind("simGetCollisionInfo", [&](const std::string& vehicle_name) -> RpcLibAdaptorsBase::CollisionInfo {

--- a/AirLib/src/api/RpcLibServerBase.cpp
+++ b/AirLib/src/api/RpcLibServerBase.cpp
@@ -286,7 +286,7 @@ namespace airlib
 
         pimpl_->server.bind("simSetCameraPose", [&](const std::string& camera_name, const RpcLibAdaptorsBase::Pose& pose,
             const std::string& vehicle_name, bool external) -> void {
-            getWorldSimApi()->setCameraPose(camera_name, pose.to(), external);
+            getWorldSimApi()->setCameraPose(camera_name, pose.to(), vehicle_name, external);
         });
 
         pimpl_->server.bind("simSetCameraFov", [&](const std::string& camera_name, float fov_degrees,

--- a/AirLib/src/api/RpcLibServerBase.cpp
+++ b/AirLib/src/api/RpcLibServerBase.cpp
@@ -147,6 +147,7 @@ namespace airlib
         pimpl_->server.bind("simGetImages", [&](const std::vector<RpcLibAdaptorsBase::ImageRequest>& request_adapter, const std::string& vehicle_name) -> vector<RpcLibAdaptorsBase::ImageResponse> {
             const auto& response = getVehicleSimApi(vehicle_name)->getImages(RpcLibAdaptorsBase::ImageRequest::to(request_adapter));
             return RpcLibAdaptorsBase::ImageResponse::from(response);
+<<<<<<< HEAD
         });
 
         pimpl_->server.bind("simGetImage", [&](const std::string& camera_name, ImageCaptureBase::ImageType type, const std::string& vehicle_name) -> vector<uint8_t> {
@@ -273,20 +274,24 @@ namespace airlib
             return RpcLibAdaptorsBase::CameraInfo(camera_info);
         });
 
-        pimpl_->server.bind("simSetDistortionParam", [&](const std::string& camera_name, const std::string& param_name, float value, const std::string& vehicle_name) -> void {
-            getVehicleSimApi(vehicle_name)->setDistortionParam(camera_name, param_name, value);
+        pimpl_->server.bind("simSetDistortionParam", [&](const std::string& camera_name, const std::string& param_name, float value,
+            const std::string& vehicle_name, bool external) -> void {
+            getWorldSimApi()->setDistortionParam(camera_name, param_name, value, vehicle_name, external);
         });
 
-        pimpl_->server.bind("simGetDistortionParams", [&](const std::string& camera_name, const std::string& vehicle_name) -> std::vector<float> {
-            return getVehicleSimApi(vehicle_name)->getDistortionParams(camera_name);
+        pimpl_->server.bind("simGetDistortionParams", [&](const std::string& camera_name, const std::string& vehicle_name,
+            bool external) -> std::vector<float> {
+            return getWorldSimApi()->getDistortionParams(camera_name, vehicle_name, external);
         });
 
-        pimpl_->server.bind("simSetCameraPose", [&](const std::string& camera_name, const RpcLibAdaptorsBase::Pose& pose, const std::string& vehicle_name) -> void {
-            getVehicleSimApi(vehicle_name)->setCameraPose(camera_name, pose.to());
+        pimpl_->server.bind("simSetCameraPose", [&](const std::string& camera_name, const RpcLibAdaptorsBase::Pose& pose,
+            const std::string& vehicle_name, bool external) -> void {
+            getWorldSimApi()->setCameraPose(camera_name, pose.to(), external);
         });
 
-        pimpl_->server.bind("simSetCameraFov", [&](const std::string& camera_name, float fov_degrees, const std::string& vehicle_name) -> void {
-            getVehicleSimApi(vehicle_name)->setCameraFoV(camera_name, fov_degrees);
+        pimpl_->server.bind("simSetCameraFov", [&](const std::string& camera_name, float fov_degrees,
+            const std::string& vehicle_name, bool external) -> void {
+            getWorldSimApi()->setCameraFoV(camera_name, fov_degrees, vehicle_name, external);
         });
 
         pimpl_->server.bind("simGetCollisionInfo", [&](const std::string& vehicle_name) -> RpcLibAdaptorsBase::CollisionInfo {

--- a/AirLib/src/api/RpcLibServerBase.cpp
+++ b/AirLib/src/api/RpcLibServerBase.cpp
@@ -144,10 +144,9 @@ namespace airlib
             return getWorldSimApi()->runConsoleCommand(command);
         });
 
-        pimpl_->server.bind("simGetImages", [&](const std::vector<RpcLibAdaptorsBase::ImageRequest>& request_adapter, const std::string& vehicle_name, bool external) ->
-            vector<RpcLibAdaptorsBase::ImageResponse> {
-                const auto& response = getWorldSimApi()->getImages(RpcLibAdaptorsBase::ImageRequest::to(request_adapter), vehicle_name, external);
-                return RpcLibAdaptorsBase::ImageResponse::from(response);
+        pimpl_->server.bind("simGetImages", [&](const std::vector<RpcLibAdaptorsBase::ImageRequest>& request_adapter, const std::string& vehicle_name, bool external) -> vector<RpcLibAdaptorsBase::ImageResponse> {
+            const auto& response = getWorldSimApi()->getImages(RpcLibAdaptorsBase::ImageRequest::to(request_adapter), vehicle_name, external);
+            return RpcLibAdaptorsBase::ImageResponse::from(response);
         });
 
         pimpl_->server.bind("simGetImage", [&](const std::string& camera_name, ImageCaptureBase::ImageType type, const std::string& vehicle_name, bool external) -> vector<uint8_t> {
@@ -274,23 +273,19 @@ namespace airlib
             return RpcLibAdaptorsBase::CameraInfo(camera_info);
         });
 
-        pimpl_->server.bind("simSetDistortionParam", [&](const std::string& camera_name, const std::string& param_name, float value,
-            const std::string& vehicle_name, bool external) -> void {
+        pimpl_->server.bind("simSetDistortionParam", [&](const std::string& camera_name, const std::string& param_name, float value, const std::string& vehicle_name, bool external) -> void {
             getWorldSimApi()->setDistortionParam(camera_name, param_name, value, vehicle_name, external);
         });
 
-        pimpl_->server.bind("simGetDistortionParams", [&](const std::string& camera_name, const std::string& vehicle_name,
-            bool external) -> std::vector<float> {
+        pimpl_->server.bind("simGetDistortionParams", [&](const std::string& camera_name, const std::string& vehicle_name, bool external) -> std::vector<float> {
             return getWorldSimApi()->getDistortionParams(camera_name, vehicle_name, external);
         });
 
-        pimpl_->server.bind("simSetCameraPose", [&](const std::string& camera_name, const RpcLibAdaptorsBase::Pose& pose,
-            const std::string& vehicle_name, bool external) -> void {
+        pimpl_->server.bind("simSetCameraPose", [&](const std::string& camera_name, const RpcLibAdaptorsBase::Pose& pose, const std::string& vehicle_name, bool external) -> void {
             getWorldSimApi()->setCameraPose(camera_name, pose.to(), vehicle_name, external);
         });
 
-        pimpl_->server.bind("simSetCameraFov", [&](const std::string& camera_name, float fov_degrees,
-            const std::string& vehicle_name, bool external) -> void {
+        pimpl_->server.bind("simSetCameraFov", [&](const std::string& camera_name, float fov_degrees, const std::string& vehicle_name, bool external) -> void {
             getWorldSimApi()->setCameraFoV(camera_name, fov_degrees, vehicle_name, external);
         });
 

--- a/AirLib/src/api/RpcLibServerBase.cpp
+++ b/AirLib/src/api/RpcLibServerBase.cpp
@@ -150,7 +150,7 @@ namespace airlib
         });
 
         pimpl_->server.bind("simGetImage", [&](const std::string& camera_name, ImageCaptureBase::ImageType type, const std::string& vehicle_name, bool external) -> vector<uint8_t> {
-            return getWorldSimApi()->getImage(camera_name, type, vehicle_name, external);
+            return getWorldSimApi()->getImage(type, CameraDetails(camera_name, vehicle_name, external));
         });
 
         pimpl_->server.bind("simTestLineOfSightToPoint", [&](const RpcLibAdaptorsBase::GeoPoint& point, const std::string& vehicle_name) -> bool {

--- a/AirLib/src/api/RpcLibServerBase.cpp
+++ b/AirLib/src/api/RpcLibServerBase.cpp
@@ -144,14 +144,14 @@ namespace airlib
             return getWorldSimApi()->runConsoleCommand(command);
         });
 
-        pimpl_->server.bind("simGetImages", [&](const std::vector<RpcLibAdaptorsBase::ImageRequest>& request_adapter, const std::string& vehicle_name) -> vector<RpcLibAdaptorsBase::ImageResponse> {
-            const auto& response = getVehicleSimApi(vehicle_name)->getImages(RpcLibAdaptorsBase::ImageRequest::to(request_adapter));
-            return RpcLibAdaptorsBase::ImageResponse::from(response);
-<<<<<<< HEAD
+        pimpl_->server.bind("simGetImages", [&](const std::vector<RpcLibAdaptorsBase::ImageRequest>& request_adapter, const std::string& vehicle_name, bool external) ->
+            vector<RpcLibAdaptorsBase::ImageResponse> {
+                const auto& response = getWorldSimApi()->getImages(RpcLibAdaptorsBase::ImageRequest::to(request_adapter), vehicle_name, external);
+                return RpcLibAdaptorsBase::ImageResponse::from(response);
         });
 
-        pimpl_->server.bind("simGetImage", [&](const std::string& camera_name, ImageCaptureBase::ImageType type, const std::string& vehicle_name) -> vector<uint8_t> {
-            return getVehicleSimApi(vehicle_name)->getImage(camera_name, type);
+        pimpl_->server.bind("simGetImage", [&](const std::string& camera_name, ImageCaptureBase::ImageType type, const std::string& vehicle_name, bool external) -> vector<uint8_t> {
+            return getWorldSimApi()->getImage(camera_name, type, vehicle_name, external);
         });
 
         pimpl_->server.bind("simTestLineOfSightToPoint", [&](const RpcLibAdaptorsBase::GeoPoint& point, const std::string& vehicle_name) -> bool {

--- a/AirLib/src/api/RpcLibServerBase.cpp
+++ b/AirLib/src/api/RpcLibServerBase.cpp
@@ -268,8 +268,8 @@ namespace airlib
             return RpcLibAdaptorsBase::DistanceSensorData(distance_sensor_data);
         });
 
-        pimpl_->server.bind("simGetCameraInfo", [&](const std::string& camera_name, const std::string& vehicle_name) -> RpcLibAdaptorsBase::CameraInfo {
-            const auto& camera_info = getVehicleSimApi(vehicle_name)->getCameraInfo(camera_name);
+        pimpl_->server.bind("simGetCameraInfo", [&](const std::string& camera_name, const std::string& vehicle_name, bool external) -> RpcLibAdaptorsBase::CameraInfo {
+            const auto& camera_info = getWorldSimApi()->getCameraInfo(camera_name, vehicle_name, external);
             return RpcLibAdaptorsBase::CameraInfo(camera_info);
         });
 

--- a/AirLib/src/api/RpcLibServerBase.cpp
+++ b/AirLib/src/api/RpcLibServerBase.cpp
@@ -198,17 +198,17 @@ namespace airlib
             return getWorldSimApi()->getSegmentationObjectID(mesh_name);
         });
 
-        pimpl_->server.bind("simAddDetectionFilterMeshName", [&](const std::string& camera_name, ImageCaptureBase::ImageType type, const std::string& mesh_name, const std::string& vehicle_name) -> void {
-            getVehicleSimApi(vehicle_name)->addDetectionFilterMeshName(camera_name, type, mesh_name);
+        pimpl_->server.bind("simAddDetectionFilterMeshName", [&](const std::string& camera_name, ImageCaptureBase::ImageType type, const std::string& mesh_name, const std::string& vehicle_name, bool external) -> void {
+            getWorldSimApi()->addDetectionFilterMeshName(camera_name, type, mesh_name, vehicle_name, external);
         });
-        pimpl_->server.bind("simSetDetectionFilterRadius", [&](const std::string& camera_name, ImageCaptureBase::ImageType type, const float radius_cm, const std::string& vehicle_name) -> void {
-            getVehicleSimApi(vehicle_name)->setDetectionFilterRadius(camera_name, type, radius_cm);
+        pimpl_->server.bind("simSetDetectionFilterRadius", [&](const std::string& camera_name, ImageCaptureBase::ImageType type, const float radius_cm, const std::string& vehicle_name, bool external) -> void {
+            getWorldSimApi()->setDetectionFilterRadius(camera_name, type, radius_cm, vehicle_name, external);
         });
-        pimpl_->server.bind("simClearDetectionMeshNames", [&](const std::string& camera_name, ImageCaptureBase::ImageType type, const std::string& vehicle_name) -> void {
-            getVehicleSimApi(vehicle_name)->clearDetectionMeshNames(camera_name, type);
+        pimpl_->server.bind("simClearDetectionMeshNames", [&](const std::string& camera_name, ImageCaptureBase::ImageType type, const std::string& vehicle_name, bool external) -> void {
+            getWorldSimApi()->clearDetectionMeshNames(camera_name, type, vehicle_name, external);
         });
-        pimpl_->server.bind("simGetDetections", [&](const std::string& camera_name, ImageCaptureBase::ImageType type, const std::string& vehicle_name) -> vector<RpcLibAdaptorsBase::DetectionInfo> {
-            const auto& response = getVehicleSimApi(vehicle_name)->getDetections(camera_name, type);
+        pimpl_->server.bind("simGetDetections", [&](const std::string& camera_name, ImageCaptureBase::ImageType type, const std::string& vehicle_name, bool external) -> vector<RpcLibAdaptorsBase::DetectionInfo> {
+            const auto& response = getWorldSimApi()->getDetections(camera_name, type, vehicle_name, external);
             return RpcLibAdaptorsBase::DetectionInfo::from(response);
         });
 

--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -593,7 +593,7 @@ class VehicleClient:
         # TODO: below str() conversion is only needed for legacy reason and should be removed in future
         return CameraInfo.from_msgpack(self.client.call('simGetCameraInfo', str(camera_name), vehicle_name, external))
 
-    def simGetDistortionParams(self, camera_name, vehicle_name = ''):
+    def simGetDistortionParams(self, camera_name, vehicle_name = '', external = False):
         """
         Get camera distortion parameters
 
@@ -605,9 +605,9 @@ class VehicleClient:
             List (float): List of distortion parameter values corresponding to K1, K2, K3, P1, P2 respectively.
         """
     
-        return self.client.call('simGetDistortionParams', str(camera_name), vehicle_name)
+        return self.client.call('simGetDistortionParams', str(camera_name), vehicle_name, external)
 
-    def simSetDistortionParams(self, camera_name, distortion_params, vehicle_name = ''):
+    def simSetDistortionParams(self, camera_name, distortion_params, vehicle_name = '', external = False):
         """
         Set camera distortion parameters
 
@@ -619,9 +619,10 @@ class VehicleClient:
         """
 
         for param_name, value in distortion_params.items():
-            self.client.call('simSetDistortionParam', str(camera_name), param_name, value, vehicle_name)
+            # self.client.call('simSetDistortionParam', str(camera_name), param_name, value, vehicle_name, external)
+            self.simSetDistortionParam(camera_name, param_name, value, vehicle_name, external)
 
-    def simSetDistortionParam(self, camera_name, param_name, value, vehicle_name = ''):
+    def simSetDistortionParam(self, camera_name, param_name, value, vehicle_name = '', external = False):
         """
         Set single camera distortion parameter
 
@@ -631,9 +632,9 @@ class VehicleClient:
             value (float): Value of distortion parameter
             vehicle_name (str, optional): Vehicle which the camera is associated with
         """
-        self.client.call('simSetDistortionParam', str(camera_name), param_name, value, vehicle_name)
+        self.client.call('simSetDistortionParam', str(camera_name), param_name, value, vehicle_name, external)
 
-    def simSetCameraPose(self, camera_name, pose, vehicle_name = ''):
+    def simSetCameraPose(self, camera_name, pose, vehicle_name = '', external = False):
         """
         - Control the pose of a selected camera
 
@@ -643,9 +644,9 @@ class VehicleClient:
             vehicle_name (str, optional): Name of vehicle which the camera corresponds to
         """
         # TODO: below str() conversion is only needed for legacy reason and should be removed in future
-        self.client.call('simSetCameraPose', str(camera_name), pose, vehicle_name)
+        self.client.call('simSetCameraPose', str(camera_name), pose, vehicle_name, external)
 
-    def simSetCameraOrientation(self, camera_name, orientation, vehicle_name = ''):
+    def simSetCameraOrientation(self, camera_name, orientation, vehicle_name = '', external = False):
         """
         .. note::
 
@@ -660,9 +661,9 @@ class VehicleClient:
         """
         logging.warning("`simSetCameraOrientation` API has been upgraded to `simSetCameraPose`. Please update your code.")
         pose = Pose(orientation_val=orientation)
-        self.simSetCameraPose(camera_name, pose, vehicle_name)
+        self.simSetCameraPose(camera_name, pose, vehicle_name, external)
 
-    def simSetCameraFov(self, camera_name, fov_degrees, vehicle_name = ''):
+    def simSetCameraFov(self, camera_name, fov_degrees, vehicle_name = '', external = False):
         """
         - Control the field of view of a selected camera
 
@@ -672,7 +673,7 @@ class VehicleClient:
             vehicle_name (str, optional): Name of vehicle which the camera corresponds to
         """
         # TODO: below str() conversion is only needed for legacy reason and should be removed in future
-        self.client.call('simSetCameraFov', str(camera_name), fov_degrees, vehicle_name)
+        self.client.call('simSetCameraFov', str(camera_name), fov_degrees, vehicle_name, external)
 
     def simGetGroundTruthKinematics(self, vehicle_name = ''):
         """

--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -220,7 +220,7 @@ class VehicleClient:
     # camera control
     # simGetImage returns compressed png in array of bytes
     # image_type uses one of the ImageType members
-    def simGetImage(self, camera_name, image_type, vehicle_name = ''):
+    def simGetImage(self, camera_name, image_type, vehicle_name = '', external = False):
         """
         Get a single image
 
@@ -240,7 +240,7 @@ class VehicleClient:
         camera_name = str(camera_name)
 
         # because this method returns std::vector<uint8>, msgpack decides to encode it as a string unfortunately.
-        result = self.client.call('simGetImage', camera_name, image_type, vehicle_name)
+        result = self.client.call('simGetImage', camera_name, image_type, vehicle_name, external)
         if (result == "" or result == "\0"):
             return None
         return result
@@ -248,7 +248,7 @@ class VehicleClient:
     # camera control
     # simGetImage returns compressed png in array of bytes
     # image_type uses one of the ImageType members
-    def simGetImages(self, requests, vehicle_name = ''):
+    def simGetImages(self, requests, vehicle_name = '', external = False):
         """
         Get multiple images
 
@@ -261,7 +261,7 @@ class VehicleClient:
         Returns:
             list[ImageResponse]:
         """
-        responses_raw = self.client.call('simGetImages', requests, vehicle_name)
+        responses_raw = self.client.call('simGetImages', requests, vehicle_name, external)
         return [ImageResponse.from_msgpack(response_raw) for response_raw in responses_raw]
         
     def simTestLineOfSightToPoint(self, point, vehicle_name = ''):

--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -579,7 +579,7 @@ class VehicleClient:
         """
         self.client.call('simPrintLogMessage', message, message_param, severity)
 
-    def simGetCameraInfo(self, camera_name, vehicle_name = ''):
+    def simGetCameraInfo(self, camera_name, vehicle_name = '', external=False):
         """
         Get details about the camera
 
@@ -591,7 +591,7 @@ class VehicleClient:
             CameraInfo:
         """
         # TODO: below str() conversion is only needed for legacy reason and should be removed in future
-        return CameraInfo.from_msgpack(self.client.call('simGetCameraInfo', str(camera_name), vehicle_name))
+        return CameraInfo.from_msgpack(self.client.call('simGetCameraInfo', str(camera_name), vehicle_name, external))
 
     def simGetDistortionParams(self, camera_name, vehicle_name = ''):
         """

--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -232,6 +232,7 @@ class VehicleClient:
             camera_name (str): Name of the camera, for backwards compatibility, ID numbers such as 0,1,etc. can also be used
             image_type (ImageType): Type of image required
             vehicle_name (str, optional): Name of the vehicle with the camera
+            external (bool, optional): Whether the camera is an External Camera
 
         Returns:
             Binary string literal of compressed png image
@@ -257,6 +258,7 @@ class VehicleClient:
         Args:
             requests (list[ImageRequest]): Images required
             vehicle_name (str, optional): Name of vehicle associated with the camera
+            external (bool, optional): Whether the camera is an External Camera
 
         Returns:
             list[ImageResponse]:
@@ -586,6 +588,7 @@ class VehicleClient:
         Args:
             camera_name (str): Name of the camera, for backwards compatibility, ID numbers such as 0,1,etc. can also be used
             vehicle_name (str, optional): Vehicle which the camera is associated with
+            external (bool, optional): Whether the camera is an External Camera
 
         Returns:
             CameraInfo:
@@ -600,6 +603,7 @@ class VehicleClient:
         Args:
             camera_name (str): Name of the camera, for backwards compatibility, ID numbers such as 0,1,etc. can also be used
             vehicle_name (str, optional): Vehicle which the camera is associated with
+            external (bool, optional): Whether the camera is an External Camera
 
         Returns:
             List (float): List of distortion parameter values corresponding to K1, K2, K3, P1, P2 respectively.
@@ -616,6 +620,7 @@ class VehicleClient:
             distortion_params (dict): Dictionary of distortion param names and corresponding values
                                         {"K1": 0.0, "K2": 0.0, "K3": 0.0, "P1": 0.0, "P2": 0.0}
             vehicle_name (str, optional): Vehicle which the camera is associated with
+            external (bool, optional): Whether the camera is an External Camera
         """
 
         for param_name, value in distortion_params.items():
@@ -631,6 +636,7 @@ class VehicleClient:
             param_name (str): Name of distortion parameter
             value (float): Value of distortion parameter
             vehicle_name (str, optional): Vehicle which the camera is associated with
+            external (bool, optional): Whether the camera is an External Camera
         """
         self.client.call('simSetDistortionParam', str(camera_name), param_name, value, vehicle_name, external)
 
@@ -642,6 +648,7 @@ class VehicleClient:
             camera_name (str): Name of the camera to be controlled
             pose (Pose): Pose representing the desired position and orientation of the camera
             vehicle_name (str, optional): Name of vehicle which the camera corresponds to
+            external (bool, optional): Whether the camera is an External Camera
         """
         # TODO: below str() conversion is only needed for legacy reason and should be removed in future
         self.client.call('simSetCameraPose', str(camera_name), pose, vehicle_name, external)
@@ -658,6 +665,7 @@ class VehicleClient:
             camera_name (str): Name of the camera to be controlled
             orientation (Quaternionr): Quaternion representing the desired orientation of the camera
             vehicle_name (str, optional): Name of vehicle which the camera corresponds to
+            external (bool, optional): Whether the camera is an External Camera
         """
         logging.warning("`simSetCameraOrientation` API has been upgraded to `simSetCameraPose`. Please update your code.")
         pose = Pose(orientation_val=orientation)
@@ -671,6 +679,7 @@ class VehicleClient:
             camera_name (str): Name of the camera to be controlled
             fov_degrees (float): Value of field of view in degrees
             vehicle_name (str, optional): Name of vehicle which the camera corresponds to
+            external (bool, optional): Whether the camera is an External Camera
         """
         # TODO: below str() conversion is only needed for legacy reason and should be removed in future
         self.client.call('simSetCameraFov', str(camera_name), fov_degrees, vehicle_name, external)

--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -652,24 +652,6 @@ class VehicleClient:
         # TODO: below str() conversion is only needed for legacy reason and should be removed in future
         self.client.call('simSetCameraPose', str(camera_name), pose, vehicle_name, external)
 
-    def simSetCameraOrientation(self, camera_name, orientation, vehicle_name = '', external = False):
-        """
-        .. note::
-
-            This API has been upgraded to `simSetCameraPose`
-
-        - Control the Orientation of a selected camera
-
-        Args:
-            camera_name (str): Name of the camera to be controlled
-            orientation (Quaternionr): Quaternion representing the desired orientation of the camera
-            vehicle_name (str, optional): Name of vehicle which the camera corresponds to
-            external (bool, optional): Whether the camera is an External Camera
-        """
-        logging.warning("`simSetCameraOrientation` API has been upgraded to `simSetCameraPose`. Please update your code.")
-        pose = Pose(orientation_val=orientation)
-        self.simSetCameraPose(camera_name, pose, vehicle_name, external)
-
     def simSetCameraFov(self, camera_name, fov_degrees, vehicle_name = '', external = False):
         """
         - Control the field of view of a selected camera

--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -510,7 +510,7 @@ class VehicleClient:
         """
         return self.client.call('simGetSegmentationObjectID', mesh_name)
 
-    def simAddDetectionFilterMeshName(self, camera_name, image_type, mesh_name, vehicle_name = ''):
+    def simAddDetectionFilterMeshName(self, camera_name, image_type, mesh_name, vehicle_name = '', external = False):
         """
         Add mesh name to detect in wild card format
 
@@ -521,11 +521,12 @@ class VehicleClient:
             image_type (ImageType): Type of image required
             mesh_name (str): mesh name in wild card format
             vehicle_name (str, optional): Vehicle which the camera is associated with
+            external (bool, optional): Whether the camera is an External Camera
 
         """
-        self.client.call('simAddDetectionFilterMeshName', camera_name, image_type, mesh_name, vehicle_name)
+        self.client.call('simAddDetectionFilterMeshName', camera_name, image_type, mesh_name, vehicle_name, external)
     
-    def simSetDetectionFilterRadius(self, camera_name, image_type, radius_cm, vehicle_name = ''):
+    def simSetDetectionFilterRadius(self, camera_name, image_type, radius_cm, vehicle_name = '', external = False):
         """
         Set detection radius for all cameras
 
@@ -534,10 +535,11 @@ class VehicleClient:
             image_type (ImageType): Type of image required
             radius_cm (int): Radius in [cm]
             vehicle_name (str, optional): Vehicle which the camera is associated with
+            external (bool, optional): Whether the camera is an External Camera
         """
-        self.client.call('simSetDetectionFilterRadius', camera_name, image_type, radius_cm, vehicle_name)
+        self.client.call('simSetDetectionFilterRadius', camera_name, image_type, radius_cm, vehicle_name, external)
      
-    def simClearDetectionMeshNames(self, camera_name, image_type, vehicle_name = ''):
+    def simClearDetectionMeshNames(self, camera_name, image_type, vehicle_name = '', external = False):
         """
         Clear all mesh names from detection filter
 
@@ -545,11 +547,12 @@ class VehicleClient:
             camera_name (str): Name of the camera, for backwards compatibility, ID numbers such as 0,1,etc. can also be used
             image_type (ImageType): Type of image required
             vehicle_name (str, optional): Vehicle which the camera is associated with
+            external (bool, optional): Whether the camera is an External Camera
 
         """
-        self.client.call('simClearDetectionMeshNames', camera_name, image_type, vehicle_name)
+        self.client.call('simClearDetectionMeshNames', camera_name, image_type, vehicle_name, external)
 
-    def simGetDetections(self, camera_name, image_type, vehicle_name = ''):
+    def simGetDetections(self, camera_name, image_type, vehicle_name = '', external = False):
         """
         Get current detections
 
@@ -557,11 +560,12 @@ class VehicleClient:
             camera_name (str): Name of the camera, for backwards compatibility, ID numbers such as 0,1,etc. can also be used
             image_type (ImageType): Type of image required
             vehicle_name (str, optional): Vehicle which the camera is associated with
+            external (bool, optional): Whether the camera is an External Camera
 
         Returns:
             DetectionInfo array
         """
-        responses_raw = self.client.call('simGetDetections', camera_name, image_type, vehicle_name)
+        responses_raw = self.client.call('simGetDetections', camera_name, image_type, vehicle_name, external)
         return [DetectionInfo.from_msgpack(response_raw) for response_raw in responses_raw]
 
     def simPrintLogMessage(self, message, message_param = "", severity = 0):

--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -624,7 +624,6 @@ class VehicleClient:
         """
 
         for param_name, value in distortion_params.items():
-            # self.client.call('simSetDistortionParam', str(camera_name), param_name, value, vehicle_name, external)
             self.simSetDistortionParam(camera_name, param_name, value, vehicle_name, external)
 
     def simSetDistortionParam(self, camera_name, param_name, value, vehicle_name = '', external = False):

--- a/PythonClient/computer_vision/external_camera.py
+++ b/PythonClient/computer_vision/external_camera.py
@@ -1,0 +1,101 @@
+import airsim
+import os
+import tempfile
+
+"""
+A simple script to test all the camera APIs. Change the cmaera name and whether it's an external camera
+
+Example Settings for external camera -
+
+{
+    "SettingsVersion": 1.2,
+    "SimMode": "Car",
+    "ExternalCameras": {
+        "fixed1": {
+            "X": 0, "Y": 0, "Z": -5,
+            "Pitch": -90, "Roll": 0, "Yaw": 0
+        }
+    }
+}
+"""
+
+# Just change the below to test different cameras easily!
+CAM_NAME = "fixed1"
+IS_EXTERNAL_CAM = True
+
+
+client = airsim.VehicleClient()
+client.confirmConnection()
+
+tmp_dir = os.path.join(tempfile.gettempdir(), "airsim_cv_mode")
+print ("Saving images to %s" % tmp_dir)
+try:
+    os.makedirs(tmp_dir)
+except OSError:
+    if not os.path.isdir(tmp_dir):
+        raise
+
+print(f"Camera: {CAM_NAME}, External = {IS_EXTERNAL_CAM}")
+
+# Test Camera info
+cam_info = client.simGetCameraInfo(CAM_NAME, external=IS_EXTERNAL_CAM)
+print(cam_info)
+
+# Test Image APIs
+airsim.wait_key('Press any key to get images')
+
+requests = [airsim.ImageRequest(CAM_NAME, airsim.ImageType.Scene),
+            airsim.ImageRequest(CAM_NAME, airsim.ImageType.DepthPlanner),
+            airsim.ImageRequest(CAM_NAME, airsim.ImageType.DepthVis),
+            airsim.ImageRequest(CAM_NAME, airsim.ImageType.Segmentation),
+            airsim.ImageRequest(CAM_NAME, airsim.ImageType.SurfaceNormals)]
+
+def save_images(responses, prefix = ""):
+    for i, response in enumerate(responses):
+        filename = os.path.join(tmp_dir, prefix + "_" + str(i))
+
+        if response.pixels_as_float:
+            print(f"Type {response.image_type}, size {len(response.image_data_float)}, pos {response.camera_position}")
+            airsim.write_pfm(os.path.normpath(filename + '.pfm'), airsim.get_pfm_array(response))
+        else:
+            print(f"Type {response.image_type}, size {len(response.image_data_uint8)}, pos {response.camera_position}")
+            airsim.write_file(os.path.normpath(filename + '.png'), response.image_data_uint8)
+
+
+responses = client.simGetImages(requests, external=IS_EXTERNAL_CAM)
+save_images(responses, "old_fov")
+
+
+# Test FoV API
+airsim.wait_key('Press any key to change FoV and get images')
+
+client.simSetCameraFov(CAM_NAME, 120, external=IS_EXTERNAL_CAM)
+
+responses = client.simGetImages(requests, external = IS_EXTERNAL_CAM)
+save_images(responses, "new_fov")
+
+new_cam_info = client.simGetCameraInfo(CAM_NAME, external=IS_EXTERNAL_CAM)
+print(f"Old FOV: {cam_info.fov}, New FOV: {new_cam_info.fov}")
+
+
+# Test Pose APIs
+new_pose = airsim.Pose(airsim.Vector3r(-10, -5, -5), airsim.to_quaternion(0.1, 0, 0.1))
+client.simSetCameraPose(CAM_NAME, new_pose, external=IS_EXTERNAL_CAM)
+
+responses = client.simGetImages(requests, external=IS_EXTERNAL_CAM)
+save_images(responses, "new_pose")
+
+new_cam_info = client.simGetCameraInfo(CAM_NAME, external=IS_EXTERNAL_CAM)
+print(f"Old Pose: {cam_info.pose}, New Pose: {new_cam_info.pose}")
+
+
+# Test Distortion params APIs
+dist_params = client.simGetDistortionParams(CAM_NAME, external=IS_EXTERNAL_CAM)
+print(f"Distortion Params: {dist_params}")
+
+new_params_dict = {"K1": 0.1, "K2": 0.01, "K3": 0.0, "P1": 0.0, "P2": 0.0}
+print(f"Setting distortion params as {new_params_dict}")
+client.simSetDistortionParams(CAM_NAME, new_params_dict, external=IS_EXTERNAL_CAM)
+
+dist_params = client.simGetDistortionParams(CAM_NAME, external=IS_EXTERNAL_CAM)
+print(f"Updated Distortion Params: {dist_params}")

--- a/PythonClient/computer_vision/external_camera.py
+++ b/PythonClient/computer_vision/external_camera.py
@@ -1,9 +1,10 @@
+import setup_path
 import airsim
 import os
 import tempfile
 
 """
-A simple script to test all the camera APIs. Change the cmaera name and whether it's an external camera
+A simple script to test all the camera APIs. Change the camera name and whether it's an external camera
 
 Example Settings for external camera -
 
@@ -45,7 +46,7 @@ print(cam_info)
 airsim.wait_key('Press any key to get images')
 
 requests = [airsim.ImageRequest(CAM_NAME, airsim.ImageType.Scene),
-            airsim.ImageRequest(CAM_NAME, airsim.ImageType.DepthPlanner),
+            airsim.ImageRequest(CAM_NAME, airsim.ImageType.DepthPlanar),
             airsim.ImageRequest(CAM_NAME, airsim.ImageType.DepthVis),
             airsim.ImageRequest(CAM_NAME, airsim.ImageType.Segmentation),
             airsim.ImageRequest(CAM_NAME, airsim.ImageType.SurfaceNormals)]

--- a/PythonClient/detection/detection.py
+++ b/PythonClient/detection/detection.py
@@ -5,7 +5,7 @@ import numpy as np
 import pprint
 
 # connect to the AirSim simulator
-client = airsim.MultirotorClient()
+client = airsim.VehicleClient()
 client.confirmConnection()
 
 # set camera name and image type to request images and detections

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/PawnSimApi.cpp
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/PawnSimApi.cpp
@@ -279,7 +279,7 @@ void PawnSimApi::setDistortionParam(const std::string& camera_name, const std::s
     // not implemented
 }
 
-std::vector<float> PawnSimApi::getDistortionParams(const std::string& camera_name)
+std::vector<float> PawnSimApi::getDistortionParams(const std::string& camera_name) const
 {
     // not implemented
     std::vector<float> params(5, 0.0);

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/PawnSimApi.cpp
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/PawnSimApi.cpp
@@ -135,7 +135,6 @@ const NedTransform& PawnSimApi::getNedTransform() const
     return ned_transform_;
 }
 
-
 msr::airlib::RCData PawnSimApi::getRCData() const
 {
     AirSimRCData rcDataFromUnity = GetRCData(getVehicleName().c_str());
@@ -230,7 +229,6 @@ void PawnSimApi::allowPassthroughToggleInput()
     state_.passthrough_enabled = !state_.passthrough_enabled;
     PrintLogMessage("enable_passthrough_on_collisions: ", state_.passthrough_enabled ? "true" : "false", params_.vehicle_name.c_str(), ErrorLogSeverity::Information);
 }
-
 
 //parameters in NED frame
 PawnSimApi::Pose PawnSimApi::getPose() const

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/PawnSimApi.cpp
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/PawnSimApi.cpp
@@ -59,50 +59,6 @@ void PawnSimApi::pawnTick(float dt)
     updateRendering(dt);
 }
 
-void PawnSimApi::addDetectionFilterMeshName(const std::string& camera_name, ImageCaptureBase::ImageType image_type, const std::string& mesh_name)
-{
-    unused(camera_name);
-    unused(image_type);
-    unused(mesh_name);
-
-    throw std::invalid_argument(common_utils::Utils::stringf(
-                                    "addDetectionFilterMeshName is not supported on unity")
-                                    .c_str());
-}
-
-void PawnSimApi::setDetectionFilterRadius(const std::string& camera_name, ImageCaptureBase::ImageType image_type, const float radius_cm)
-{
-    unused(camera_name);
-    unused(image_type);
-    unused(radius_cm);
-
-    throw std::invalid_argument(common_utils::Utils::stringf(
-                                    "setDetectionFilterRadius is not supported on unity")
-                                    .c_str());
-}
-
-void PawnSimApi::clearDetectionMeshNames(const std::string& camera_name, ImageCaptureBase::ImageType image_type)
-{
-    unused(camera_name);
-    unused(image_type);
-
-    throw std::invalid_argument(common_utils::Utils::stringf(
-                                    "clearDetectionMeshNames is not supported on unity")
-                                    .c_str());
-}
-
-std::vector<PawnSimApi::DetectionInfo> PawnSimApi::getDetections(const std::string& camera_name, ImageCaptureBase::ImageType image_type) const
-{
-    unused(camera_name);
-    unused(image_type);
-
-    throw std::invalid_argument(common_utils::Utils::stringf(
-                                    "getDetections is not supported on unity")
-                                    .c_str());
-
-    return std::vector<DetectionInfo>();
-}
-
 bool PawnSimApi::testLineOfSightToPoint(const msr::airlib::GeoPoint& point) const
 {
     unused(point);

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/PawnSimApi.cpp
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/PawnSimApi.cpp
@@ -135,24 +135,6 @@ const NedTransform& PawnSimApi::getNedTransform() const
     return ned_transform_;
 }
 
-std::vector<PawnSimApi::ImageCaptureBase::ImageResponse> PawnSimApi::getImages(
-    const std::vector<ImageCaptureBase::ImageRequest>& requests) const
-{
-    std::vector<ImageCaptureBase::ImageResponse> responses;
-    const ImageCaptureBase* camera = getImageCapture();
-    camera->getImages(requests, responses);
-    return responses;
-}
-
-std::vector<uint8_t> PawnSimApi::getImage(const std::string& camera_name, ImageCaptureBase::ImageType image_type) const
-{
-    std::vector<ImageCaptureBase::ImageRequest> request = { ImageCaptureBase::ImageRequest(camera_name, image_type) };
-    const std::vector<ImageCaptureBase::ImageResponse>& response = getImages(request);
-    if (response.size() > 0)
-        return response.at(0).image_data_uint8;
-    else
-        return std::vector<uint8_t>();
-}
 
 msr::airlib::RCData PawnSimApi::getRCData() const
 {
@@ -249,42 +231,6 @@ void PawnSimApi::allowPassthroughToggleInput()
     PrintLogMessage("enable_passthrough_on_collisions: ", state_.passthrough_enabled ? "true" : "false", params_.vehicle_name.c_str(), ErrorLogSeverity::Information);
 }
 
-msr::airlib::CameraInfo PawnSimApi::getCameraInfo(const std::string& camera_name) const
-{
-    AirSimCameraInfo airsim_camera_info = GetCameraInfo(camera_name.c_str(), params_.vehicle_name.c_str()); // Into Unity
-    msr::airlib::CameraInfo camera_info;
-    camera_info.pose.position.x() = airsim_camera_info.pose.position.x;
-    camera_info.pose.position.y() = airsim_camera_info.pose.position.y;
-    camera_info.pose.position.z() = airsim_camera_info.pose.position.z;
-    camera_info.pose.orientation.x() = airsim_camera_info.pose.orientation.x;
-    camera_info.pose.orientation.y() = airsim_camera_info.pose.orientation.y;
-    camera_info.pose.orientation.z() = airsim_camera_info.pose.orientation.z;
-    camera_info.pose.orientation.w() = airsim_camera_info.pose.orientation.w;
-    camera_info.fov = airsim_camera_info.fov;
-    return camera_info;
-}
-
-void PawnSimApi::setCameraPose(const std::string& camera_name, const msr::airlib::Pose& pose)
-{
-    SetCameraPose(camera_name.c_str(), UnityUtilities::Convert_to_AirSimPose(pose), params_.vehicle_name.c_str());
-}
-
-void PawnSimApi::setCameraFoV(const std::string& camera_name, float fov_degrees)
-{
-    SetCameraFoV(camera_name.c_str(), fov_degrees, params_.vehicle_name.c_str());
-}
-
-void PawnSimApi::setDistortionParam(const std::string& camera_name, const std::string& param_name, float value)
-{
-    // not implemented
-}
-
-std::vector<float> PawnSimApi::getDistortionParams(const std::string& camera_name) const
-{
-    // not implemented
-    std::vector<float> params(5, 0.0);
-    return params;
-}
 
 //parameters in NED frame
 PawnSimApi::Pose PawnSimApi::getPose() const

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/PawnSimApi.h
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/PawnSimApi.h
@@ -78,7 +78,7 @@ public:
     virtual void setCameraPose(const std::string& camera_name, const Pose& pose) override;
     virtual void setCameraFoV(const std::string& camera_name, float fov_degrees) override;
     virtual void setDistortionParam(const std::string& camera_name, const std::string& param_name, float value) override;
-    virtual std::vector<float> getDistortionParams(const std::string& camera_name) override;
+    virtual std::vector<float> getDistortionParams(const std::string& camera_name) const override;
     virtual CollisionInfo getCollisionInfo() const override;
     virtual int getRemoteControlID() const override;
     virtual msr::airlib::RCData getRCData() const override;

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/PawnSimApi.h
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/PawnSimApi.h
@@ -29,7 +29,6 @@ public:
     typedef msr::airlib::Utils Utils;
     typedef msr::airlib::AirSimSettings::VehicleSetting VehicleSetting;
     typedef msr::airlib::ImageCaptureBase ImageCaptureBase;
-    typedef msr::airlib::DetectionInfo DetectionInfo;
 
 public:
     struct Params
@@ -92,11 +91,6 @@ public:
     void OnCollision(msr::airlib::CollisionInfo collisionInfo);
     const NedTransform& getNedTransform() const;
     virtual void pawnTick(float dt);
-
-    virtual void addDetectionFilterMeshName(const std::string& camera_name, ImageCaptureBase::ImageType image_type, const std::string& mesh_name) override;
-    virtual void setDetectionFilterRadius(const std::string& camera_name, ImageCaptureBase::ImageType image_type, const float radius_cm) override;
-    virtual void clearDetectionMeshNames(const std::string& camera_name, ImageCaptureBase::ImageType image_type) override;
-    virtual std::vector<DetectionInfo> getDetections(const std::string& camera_name, ImageCaptureBase::ImageType image_type) const override;
 
     virtual bool testLineOfSightToPoint(const msr::airlib::GeoPoint& point) const override;
 

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/PawnSimApi.h
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/PawnSimApi.h
@@ -70,15 +70,10 @@ public:
     virtual void resetImplementation() override;
     virtual void update() override;
     virtual const UnityImageCapture* getImageCapture() const override;
-    virtual std::vector<ImageCaptureBase::ImageResponse> getImages(const std::vector<ImageCaptureBase::ImageRequest>& request) const override;
-    virtual std::vector<uint8_t> getImage(const std::string& camera_name, ImageCaptureBase::ImageType image_type) const override;
+
     virtual Pose getPose() const override;
     virtual void setPose(const Pose& pose, bool ignore_collision) override;
-    virtual msr::airlib::CameraInfo getCameraInfo(const std::string& camera_name) const override;
-    virtual void setCameraPose(const std::string& camera_name, const Pose& pose) override;
-    virtual void setCameraFoV(const std::string& camera_name, float fov_degrees) override;
-    virtual void setDistortionParam(const std::string& camera_name, const std::string& param_name, float value) override;
-    virtual std::vector<float> getDistortionParams(const std::string& camera_name) const override;
+
     virtual CollisionInfo getCollisionInfo() const override;
     virtual int getRemoteControlID() const override;
     virtual msr::airlib::RCData getRCData() const override;

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.cpp
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.cpp
@@ -330,4 +330,55 @@ std::vector<uint8_t> WorldSimApi::getImage(const std::string& camera_name, Image
         return std::vector<uint8_t>();
 }
 
+void WorldSimApi::addDetectionFilterMeshName(const std::string& camera_name, ImageCaptureBase::ImageType image_type, const std::string& mesh_name,
+                                             const std::string& vehicle_name, bool external)
+{
+    unused(camera_name);
+    unused(image_type);
+    unused(mesh_name);
+
+    throw std::invalid_argument(common_utils::Utils::stringf(
+                                    "addDetectionFilterMeshName is not supported on unity")
+                                    .c_str());
+}
+
+void WorldSimApi::setDetectionFilterRadius(const std::string& camera_name, ImageCaptureBase::ImageType image_type, float radius_cm,
+                                           const std::string& vehicle_name, bool external)
+{
+    unused(camera_name);
+    unused(image_type);
+    unused(radius_cm);
+    unused(external);
+
+    throw std::invalid_argument(common_utils::Utils::stringf(
+                                    "setDetectionFilterRadius is not supported on unity")
+                                    .c_str());
+}
+
+void WorldSimApi::clearDetectionMeshNames(const std::string& camera_name, ImageCaptureBase::ImageType image_type,
+                                          const std::string& vehicle_name, bool external)
+{
+    unused(camera_name);
+    unused(image_type);
+    unused(external);
+
+    throw std::invalid_argument(common_utils::Utils::stringf(
+                                    "clearDetectionMeshNames is not supported on unity")
+                                    .c_str());
+}
+
+std::vector<msr::airlib::DetectionInfo> WorldSimApi::getDetections(const std::string& camera_name, ImageCaptureBase::ImageType image_type,
+                                                                   const std::string& vehicle_name, bool external)
+{
+    unused(camera_name);
+    unused(image_type);
+    unused(external);
+
+    throw std::invalid_argument(common_utils::Utils::stringf(
+                                    "getDetections is not supported on unity")
+                                    .c_str());
+
+    return std::vector<msr::airlib::DetectionInfo>();
+}
+
 #pragma endregion

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.cpp
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.cpp
@@ -266,43 +266,40 @@ std::vector<msr::airlib::GeoPoint> WorldSimApi::getWorldExtents() const
     return result;
 }
 
-msr::airlib::CameraInfo WorldSimApi::getCameraInfo(const std::string& camera_name, const std::string& vehicle_name, bool external) const
+msr::airlib::CameraInfo WorldSimApi::getCameraInfo(const CameraDetails& camera_details) const
 {
-    if (external)
+    if (camera_details.external)
         throw std::invalid_argument(common_utils::Utils::stringf("external field is not supported on Unity Image APIs").c_str());
 
-    AirSimCameraInfo airsim_camera_info = GetCameraInfo(camera_name.c_str(), vehicle_name.c_str()); // Into Unity
+    AirSimCameraInfo airsim_camera_info = GetCameraInfo(camera_details.camera_name.c_str(), camera_details.vehicle_name.c_str()); // Into Unity
     msr::airlib::CameraInfo camera_info;
     camera_info.pose = UnityUtilities::Convert_to_Pose(airsim_camera_info.pose);
     camera_info.fov = airsim_camera_info.fov;
     return camera_info;
 }
 
-void WorldSimApi::setCameraPose(const std::string& camera_name, const msr::airlib::Pose& pose,
-                                const std::string& vehicle_name, bool external)
+void WorldSimApi::setCameraPose(const msr::airlib::Pose& pose, const CameraDetails& camera_details)
 {
-    if (external)
+    if (camera_details.external)
         throw std::invalid_argument(common_utils::Utils::stringf("external field is not supported on Unity Image APIs").c_str());
 
-    SetCameraPose(camera_name.c_str(), UnityUtilities::Convert_to_AirSimPose(pose), vehicle_name.c_str());
+    SetCameraPose(camera_details.camera_name.c_str(), UnityUtilities::Convert_to_AirSimPose(pose), camera_details.vehicle_name.c_str());
 }
 
-void WorldSimApi::setCameraFoV(const std::string& camera_name, float fov_degrees,
-                               const std::string& vehicle_name, bool external)
+void WorldSimApi::setCameraFoV(float fov_degrees, const CameraDetails& camera_details)
 {
-    if (external)
+    if (camera_details.external)
         throw std::invalid_argument(common_utils::Utils::stringf("external field is not supported on Unity Image APIs").c_str());
 
-    SetCameraFoV(camera_name.c_str(), fov_degrees, vehicle_name.c_str());
+    SetCameraFoV(camera_details.camera_name.c_str(), fov_degrees, camera_details.vehicle_name.c_str());
 }
 
-void WorldSimApi::setDistortionParam(const std::string& camera_name, const std::string& param_name, float value,
-                                     const std::string& vehicle_name, bool external)
+void WorldSimApi::setDistortionParam(const std::string& param_name, float value, const CameraDetails& camera_details)
 {
     throw std::invalid_argument(common_utils::Utils::stringf("setDistortionParam is not supported on unity").c_str());
 }
 
-std::vector<float> WorldSimApi::getDistortionParams(const std::string& camera_name, const std::string& vehicle_name, bool external) const
+std::vector<float> WorldSimApi::getDistortionParams(const CameraDetails& camera_details) const
 {
     throw std::invalid_argument(common_utils::Utils::stringf("getDistortionParams is not supported on unity").c_str());
 
@@ -330,10 +327,9 @@ std::vector<uint8_t> WorldSimApi::getImage(const std::string& camera_name, Image
         return std::vector<uint8_t>();
 }
 
-void WorldSimApi::addDetectionFilterMeshName(const std::string& camera_name, ImageCaptureBase::ImageType image_type, const std::string& mesh_name,
-                                             const std::string& vehicle_name, bool external)
+void WorldSimApi::addDetectionFilterMeshName(ImageCaptureBase::ImageType image_type, const std::string& mesh_name, const CameraDetails& camera_details)
 {
-    unused(camera_name);
+    unused(camera_details);
     unused(image_type);
     unused(mesh_name);
 
@@ -342,37 +338,31 @@ void WorldSimApi::addDetectionFilterMeshName(const std::string& camera_name, Ima
                                     .c_str());
 }
 
-void WorldSimApi::setDetectionFilterRadius(const std::string& camera_name, ImageCaptureBase::ImageType image_type, float radius_cm,
-                                           const std::string& vehicle_name, bool external)
+void WorldSimApi::setDetectionFilterRadius(ImageCaptureBase::ImageType image_type, float radius_cm, const CameraDetails& camera_details)
 {
-    unused(camera_name);
+    unused(camera_details);
     unused(image_type);
     unused(radius_cm);
-    unused(external);
 
     throw std::invalid_argument(common_utils::Utils::stringf(
                                     "setDetectionFilterRadius is not supported on unity")
                                     .c_str());
 }
 
-void WorldSimApi::clearDetectionMeshNames(const std::string& camera_name, ImageCaptureBase::ImageType image_type,
-                                          const std::string& vehicle_name, bool external)
+void WorldSimApi::clearDetectionMeshNames(ImageCaptureBase::ImageType image_type, const CameraDetails& camera_details)
 {
-    unused(camera_name);
+    unused(camera_details);
     unused(image_type);
-    unused(external);
 
     throw std::invalid_argument(common_utils::Utils::stringf(
                                     "clearDetectionMeshNames is not supported on unity")
                                     .c_str());
 }
 
-std::vector<msr::airlib::DetectionInfo> WorldSimApi::getDetections(const std::string& camera_name, ImageCaptureBase::ImageType image_type,
-                                                                   const std::string& vehicle_name, bool external)
+std::vector<msr::airlib::DetectionInfo> WorldSimApi::getDetections(ImageCaptureBase::ImageType image_type, const CameraDetails& camera_details)
 {
-    unused(camera_name);
+    unused(camera_details);
     unused(image_type);
-    unused(external);
 
     throw std::invalid_argument(common_utils::Utils::stringf(
                                     "getDetections is not supported on unity")

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.cpp
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.cpp
@@ -316,11 +316,13 @@ std::vector<WorldSimApi::ImageCaptureBase::ImageResponse> WorldSimApi::getImages
     return responses;
 }
 
-std::vector<uint8_t> WorldSimApi::getImage(const std::string& camera_name, ImageCaptureBase::ImageType image_type,
-                                           const std::string& vehicle_name, bool external) const
+std::vector<uint8_t> WorldSimApi::getImage(ImageCaptureBase::ImageType image_type, const CameraDetails& camera_details) const
 {
-    std::vector<ImageCaptureBase::ImageRequest> request{ ImageCaptureBase::ImageRequest(camera_name, image_type) };
-    const auto& response = getImages(request);
+    std::vector<ImageCaptureBase::ImageRequest> request{
+        ImageCaptureBase::ImageRequest(camera_details.camera_name, image_type)
+    };
+
+    const auto& response = getImages(request, camera_details.vehicle_name, camera_details.external);
     if (response.size() > 0)
         return response.at(0).image_data_uint8;
     else

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.h
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "api/WorldSimApiBase.hpp"
-#include "./SimMode/SimModeBase.h"
+#include "SimMode/SimModeBase.h"
 #include "AirSimStructs.hpp"
 
 class WorldSimApi : public msr::airlib::WorldSimApiBase
@@ -10,6 +10,7 @@ public:
     typedef msr::airlib::Pose Pose;
     typedef msr::airlib::Vector3r Vector3r;
     typedef msr::airlib::MeshPositionVertexBuffersResponse MeshPositionVertexBuffersResponse;
+    typedef msr::airlib::ImageCaptureBase ImageCaptureBase;
 
     WorldSimApi(SimModeBase* simmode, std::string vehicle_name);
     virtual ~WorldSimApi();
@@ -71,6 +72,22 @@ public:
 
     virtual bool testLineOfSightBetweenPoints(const msr::airlib::GeoPoint& point1, const msr::airlib::GeoPoint& point2) const override;
     virtual std::vector<msr::airlib::GeoPoint> getWorldExtents() const override;
+
+    // Image APIs
+    virtual msr::airlib::CameraInfo getCameraInfo(const std::string& camera_name, const std::string& vehicle_name = "", bool external = false) const override;
+    virtual void setCameraPose(const std::string& camera_name, const msr::airlib::Pose& pose,
+                               const std::string& vehicle_name = "", bool external = false) override;
+    virtual void setCameraFoV(const std::string& camera_name, float fov_degrees,
+                              const std::string& vehicle_name = "", bool external = false) override;
+    virtual void setDistortionParam(const std::string& camera_name, const std::string& param_name, float value,
+                                    const std::string& vehicle_name = "", bool external = false) override;
+    virtual std::vector<float> getDistortionParams(const std::string& camera_name, const std::string& vehicle_name = "",
+                                                   bool external = false) const override;
+
+    virtual std::vector<ImageCaptureBase::ImageResponse> getImages(const std::vector<ImageCaptureBase::ImageRequest>& requests,
+                                                                   const std::string& vehicle_name = "", bool external = false) const override;
+    virtual std::vector<uint8_t> getImage(const std::string& camera_name, msr::airlib::ImageCaptureBase::ImageType image_type,
+                                          const std::string& vehicle_name = "", bool external = false) const override;
 
 private:
     SimModeBase* simmode_;

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.h
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.h
@@ -82,9 +82,8 @@ public:
     virtual std::vector<float> getDistortionParams(const CameraDetails& camera_details) const override;
 
     virtual std::vector<ImageCaptureBase::ImageResponse> getImages(const std::vector<ImageCaptureBase::ImageRequest>& requests,
-                                                                   const std::string& vehicle_name = "", bool external = false) const override;
-    virtual std::vector<uint8_t> getImage(const std::string& camera_name, msr::airlib::ImageCaptureBase::ImageType image_type,
-                                          const std::string& vehicle_name = "", bool external = false) const override;
+                                                                   const std::string& vehicle_name, bool external) const override;
+    virtual std::vector<uint8_t> getImage(ImageCaptureBase::ImageType image_type, const CameraDetails& camera_details) const override;
 
     virtual void addDetectionFilterMeshName(ImageCaptureBase::ImageType image_type, const std::string& mesh_name, const CameraDetails& camera_details) override;
     virtual void setDetectionFilterRadius(ImageCaptureBase::ImageType image_type, float radius_cm, const CameraDetails& camera_details) override;

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.h
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.h
@@ -73,7 +73,7 @@ public:
     virtual bool testLineOfSightBetweenPoints(const msr::airlib::GeoPoint& point1, const msr::airlib::GeoPoint& point2) const override;
     virtual std::vector<msr::airlib::GeoPoint> getWorldExtents() const override;
 
-    // Image APIs
+    // Camera APIs
     virtual msr::airlib::CameraInfo getCameraInfo(const std::string& camera_name, const std::string& vehicle_name = "", bool external = false) const override;
     virtual void setCameraPose(const std::string& camera_name, const msr::airlib::Pose& pose,
                                const std::string& vehicle_name = "", bool external = false) override;
@@ -88,6 +88,15 @@ public:
                                                                    const std::string& vehicle_name = "", bool external = false) const override;
     virtual std::vector<uint8_t> getImage(const std::string& camera_name, msr::airlib::ImageCaptureBase::ImageType image_type,
                                           const std::string& vehicle_name = "", bool external = false) const override;
+
+    virtual void addDetectionFilterMeshName(const std::string& camera_name, ImageCaptureBase::ImageType image_type, const std::string& mesh_name,
+                                            const std::string& vehicle_name = "", bool external = false) override;
+    virtual void setDetectionFilterRadius(const std::string& camera_name, ImageCaptureBase::ImageType image_type, float radius_cm,
+                                          const std::string& vehicle_name = "", bool external = false) override;
+    virtual void clearDetectionMeshNames(const std::string& camera_name, ImageCaptureBase::ImageType image_type,
+                                         const std::string& vehicle_name = "", bool external = false) override;
+    virtual std::vector<msr::airlib::DetectionInfo> getDetections(const std::string& camera_name, ImageCaptureBase::ImageType image_type,
+                                                                  const std::string& vehicle_name = "", bool external = false) override;
 
 private:
     SimModeBase* simmode_;

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.h
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.h
@@ -11,6 +11,7 @@ public:
     typedef msr::airlib::Vector3r Vector3r;
     typedef msr::airlib::MeshPositionVertexBuffersResponse MeshPositionVertexBuffersResponse;
     typedef msr::airlib::ImageCaptureBase ImageCaptureBase;
+    typedef msr::airlib::CameraDetails CameraDetails;
 
     WorldSimApi(SimModeBase* simmode, std::string vehicle_name);
     virtual ~WorldSimApi();
@@ -74,29 +75,21 @@ public:
     virtual std::vector<msr::airlib::GeoPoint> getWorldExtents() const override;
 
     // Camera APIs
-    virtual msr::airlib::CameraInfo getCameraInfo(const std::string& camera_name, const std::string& vehicle_name = "", bool external = false) const override;
-    virtual void setCameraPose(const std::string& camera_name, const msr::airlib::Pose& pose,
-                               const std::string& vehicle_name = "", bool external = false) override;
-    virtual void setCameraFoV(const std::string& camera_name, float fov_degrees,
-                              const std::string& vehicle_name = "", bool external = false) override;
-    virtual void setDistortionParam(const std::string& camera_name, const std::string& param_name, float value,
-                                    const std::string& vehicle_name = "", bool external = false) override;
-    virtual std::vector<float> getDistortionParams(const std::string& camera_name, const std::string& vehicle_name = "",
-                                                   bool external = false) const override;
+    virtual msr::airlib::CameraInfo getCameraInfo(const CameraDetails& camera_details) const override;
+    virtual void setCameraPose(const msr::airlib::Pose& pose, const CameraDetails& camera_details) override;
+    virtual void setCameraFoV(float fov_degrees, const CameraDetails& camera_details) override;
+    virtual void setDistortionParam(const std::string& param_name, float value, const CameraDetails& camera_details) override;
+    virtual std::vector<float> getDistortionParams(const CameraDetails& camera_details) const override;
 
     virtual std::vector<ImageCaptureBase::ImageResponse> getImages(const std::vector<ImageCaptureBase::ImageRequest>& requests,
                                                                    const std::string& vehicle_name = "", bool external = false) const override;
     virtual std::vector<uint8_t> getImage(const std::string& camera_name, msr::airlib::ImageCaptureBase::ImageType image_type,
                                           const std::string& vehicle_name = "", bool external = false) const override;
 
-    virtual void addDetectionFilterMeshName(const std::string& camera_name, ImageCaptureBase::ImageType image_type, const std::string& mesh_name,
-                                            const std::string& vehicle_name = "", bool external = false) override;
-    virtual void setDetectionFilterRadius(const std::string& camera_name, ImageCaptureBase::ImageType image_type, float radius_cm,
-                                          const std::string& vehicle_name = "", bool external = false) override;
-    virtual void clearDetectionMeshNames(const std::string& camera_name, ImageCaptureBase::ImageType image_type,
-                                         const std::string& vehicle_name = "", bool external = false) override;
-    virtual std::vector<msr::airlib::DetectionInfo> getDetections(const std::string& camera_name, ImageCaptureBase::ImageType image_type,
-                                                                  const std::string& vehicle_name = "", bool external = false) override;
+    virtual void addDetectionFilterMeshName(ImageCaptureBase::ImageType image_type, const std::string& mesh_name, const CameraDetails& camera_details) override;
+    virtual void setDetectionFilterRadius(ImageCaptureBase::ImageType image_type, float radius_cm, const CameraDetails& camera_details) override;
+    virtual void clearDetectionMeshNames(ImageCaptureBase::ImageType image_type, const CameraDetails& camera_details) override;
+    virtual std::vector<msr::airlib::DetectionInfo> getDetections(ImageCaptureBase::ImageType image_type, const CameraDetails& camera_details) override;
 
 private:
     SimModeBase* simmode_;

--- a/Unreal/Plugins/AirSim/Source/DetectionComponent.cpp
+++ b/Unreal/Plugins/AirSim/Source/DetectionComponent.cpp
@@ -186,3 +186,22 @@ FRotator UDetectionComponent::getRelativeRotation(FVector in_location, FRotator 
     FTransform relative_object_transform = camera_transform.GetRelativeTransform(FTransform(in_rotation, in_location));
     return relative_object_transform.Rotator();
 }
+
+void UDetectionComponent::addMeshName(const std::string& mesh_name)
+{
+    FString name(mesh_name.c_str());
+
+    if (!object_filter_.wildcard_mesh_names_.Contains(name)) {
+        object_filter_.wildcard_mesh_names_.Add(name);
+    }
+}
+
+void UDetectionComponent::setFilterRadius(const float radius_cm)
+{
+    max_distance_to_camera_ = radius_cm;
+}
+
+void UDetectionComponent::clearMeshNames()
+{
+    object_filter_.wildcard_mesh_names_.Empty();
+}

--- a/Unreal/Plugins/AirSim/Source/DetectionComponent.h
+++ b/Unreal/Plugins/AirSim/Source/DetectionComponent.h
@@ -44,6 +44,10 @@ public:
 
     const TArray<FDetectionInfo>& getDetections();
 
+    void addMeshName(const std::string& mesh_name);
+    void setFilterRadius(const float radius_cm);
+    void clearMeshNames();
+
 private:
     bool calcBoundingFromViewInfo(AActor* actor, FBox2D& box_out);
 
@@ -53,15 +57,15 @@ private:
 
 public:
     UPROPERTY()
+    UTextureRenderTarget2D* texture_target_;
+
+private:
+    UPROPERTY()
     FObjectFilter object_filter_;
 
     UPROPERTY(EditAnywhere, Category = "Tracked Actors")
     float max_distance_to_camera_;
 
-    UPROPERTY()
-    UTextureRenderTarget2D* texture_target_;
-
-private:
     UPROPERTY()
     USceneCaptureComponent2D* scene_capture_component_2D_;
 

--- a/Unreal/Plugins/AirSim/Source/PIPCamera.cpp
+++ b/Unreal/Plugins/AirSim/Source/PIPCamera.cpp
@@ -311,7 +311,7 @@ std::vector<float> APIPCamera::getDistortionParams() const
 {
     std::vector<float> param_values(5, 0.0);
 
-    auto getParamValue = [this](const auto &name, float &val) {
+    auto getParamValue = [this](const auto& name, float& val) {
         distortion_param_instance_->GetScalarParameterValue(FName(name), val);
     };
 

--- a/Unreal/Plugins/AirSim/Source/PIPCamera.cpp
+++ b/Unreal/Plugins/AirSim/Source/PIPCamera.cpp
@@ -270,8 +270,10 @@ void APIPCamera::setCameraTypeEnabled(ImageType type, bool enabled)
     enableCaptureComponent(type, enabled);
 }
 
-void APIPCamera::setCameraPose(const FTransform& pose)
+void APIPCamera::setCameraPose(const msr::airlib::Pose& relative_pose)
 {
+    FTransform pose = ned_transform_->fromRelativeNed(relative_pose);
+
     FVector position = pose.GetLocation();
     this->SetActorRelativeLocation(pose.GetLocation());
 
@@ -292,6 +294,39 @@ void APIPCamera::setCameraFoV(float fov_degrees)
     }
 
     camera_->SetFieldOfView(fov_degrees);
+}
+
+msr::airlib::CameraInfo APIPCamera::getCameraInfo() const
+{
+    msr::airlib::CameraInfo camera_info;
+
+    camera_info.pose.position = ned_transform_->toLocalNed(this->GetActorLocation());
+    camera_info.pose.orientation = ned_transform_->toNed(this->GetActorRotation().Quaternion());
+    camera_info.fov = camera_->FieldOfView;
+    camera_info.proj_mat = getProjectionMatrix(ImageType::Scene);
+    return camera_info;
+}
+
+std::vector<float> APIPCamera::getDistortionParams() const
+{
+    std::vector<float> param_values(5, 0.0);
+
+    auto getParamValue = [this](const auto &name, float &val) {
+        distortion_param_instance_->GetScalarParameterValue(FName(name), val);
+    };
+
+    getParamValue(TEXT("K1"), param_values[0]);
+    getParamValue(TEXT("K2"), param_values[1]);
+    getParamValue(TEXT("K3"), param_values[2]);
+    getParamValue(TEXT("P1"), param_values[3]);
+    getParamValue(TEXT("P2"), param_values[4]);
+
+    return param_values;
+}
+
+void APIPCamera::setDistortionParam(const std::string& param_name, float value)
+{
+    distortion_param_instance_->SetScalarParameterValue(FName(param_name.c_str()), value);
 }
 
 void APIPCamera::setupCameraFromSettings(const APIPCamera::CameraSetting& camera_setting, const NedTransform& ned_transform)

--- a/Unreal/Plugins/AirSim/Source/PIPCamera.h
+++ b/Unreal/Plugins/AirSim/Source/PIPCamera.h
@@ -41,14 +41,14 @@ public:
 
     void setCameraTypeEnabled(ImageType type, bool enabled);
     bool getCameraTypeEnabled(ImageType type) const;
-    void setupCameraFromSettings(const APIPCamera::CameraSetting& camera_setting, const NedTransform& ned_transform);
+    void setupCameraFromSettings(const CameraSetting& camera_setting, const NedTransform& ned_transform);
     void setCameraPose(const msr::airlib::Pose& relative_pose);
     void setCameraFoV(float fov_degrees);
     msr::airlib::CameraInfo getCameraInfo() const;
     std::vector<float> getDistortionParams() const;
     void setDistortionParam(const std::string& param_name, float value);
 
-    msr::airlib::ProjectionMatrix getProjectionMatrix(const APIPCamera::ImageType image_type) const;
+    msr::airlib::ProjectionMatrix getProjectionMatrix(const ImageType image_type) const;
 
     USceneCaptureComponent2D* getCaptureComponent(const ImageType type, bool if_active);
     UTextureRenderTarget2D* getRenderTarget(const ImageType type, bool if_active);

--- a/Unreal/Plugins/AirSim/Source/PIPCamera.h
+++ b/Unreal/Plugins/AirSim/Source/PIPCamera.h
@@ -55,10 +55,12 @@ public:
     UDetectionComponent* getDetectionComponent(const ImageType type, bool if_active) const;
 
     msr::airlib::Pose getPose() const;
-    
+
 private: //members
-    UPROPERTY() UMaterialParameterCollection* distortion_param_collection_;
-    UPROPERTY() UMaterialParameterCollectionInstance* distortion_param_instance_;
+    UPROPERTY()
+    UMaterialParameterCollection* distortion_param_collection_;
+    UPROPERTY()
+    UMaterialParameterCollectionInstance* distortion_param_instance_;
 
     UPROPERTY()
     TArray<USceneCaptureComponent2D*> captures_;

--- a/Unreal/Plugins/AirSim/Source/PIPCamera.h
+++ b/Unreal/Plugins/AirSim/Source/PIPCamera.h
@@ -42,8 +42,11 @@ public:
     void setCameraTypeEnabled(ImageType type, bool enabled);
     bool getCameraTypeEnabled(ImageType type) const;
     void setupCameraFromSettings(const APIPCamera::CameraSetting& camera_setting, const NedTransform& ned_transform);
-    void setCameraPose(const FTransform& pose);
+    void setCameraPose(const msr::airlib::Pose& relative_pose);
     void setCameraFoV(float fov_degrees);
+    msr::airlib::CameraInfo getCameraInfo() const;
+    std::vector<float> getDistortionParams() const;
+    void setDistortionParam(const std::string& param_name, float value);
 
     msr::airlib::ProjectionMatrix getProjectionMatrix(const APIPCamera::ImageType image_type) const;
 
@@ -52,13 +55,11 @@ public:
     UDetectionComponent* getDetectionComponent(const ImageType type, bool if_active) const;
 
     msr::airlib::Pose getPose() const;
-
-    UPROPERTY()
-    UMaterialParameterCollection* distortion_param_collection_;
-    UPROPERTY()
-    UMaterialParameterCollectionInstance* distortion_param_instance_;
-
+    
 private: //members
+    UPROPERTY() UMaterialParameterCollection* distortion_param_collection_;
+    UPROPERTY() UMaterialParameterCollectionInstance* distortion_param_instance_;
+
     UPROPERTY()
     TArray<USceneCaptureComponent2D*> captures_;
     UPROPERTY()

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
@@ -503,8 +503,7 @@ void PawnSimApi::plot(std::istream& s, FColor color, const Vector3r& offset)
 
 msr::airlib::CameraInfo PawnSimApi::getCameraInfo(const std::string& camera_name) const
 {
-    const APIPCamera* camera = getCamera(camera_name);
-    return camera->getCameraInfo();
+    return getCamera(camera_name)->getCameraInfo();
 }
 
 void PawnSimApi::setCameraPose(const std::string& camera_name, const msr::airlib::Pose& pose)

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
@@ -501,11 +501,6 @@ void PawnSimApi::plot(std::istream& s, FColor color, const Vector3r& offset)
     }
 }
 
-msr::airlib::CameraInfo PawnSimApi::getCameraInfo(const std::string& camera_name) const
-{
-    return getCamera(camera_name)->getCameraInfo();
-}
-
 void PawnSimApi::setCameraPose(const std::string& camera_name, const msr::airlib::Pose& pose)
 {
     UAirBlueprintLib::RunCommandOnGameThread([this, camera_name, pose]() {

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
@@ -501,40 +501,6 @@ void PawnSimApi::plot(std::istream& s, FColor color, const Vector3r& offset)
     }
 }
 
-void PawnSimApi::setCameraPose(const std::string& camera_name, const msr::airlib::Pose& pose)
-{
-    UAirBlueprintLib::RunCommandOnGameThread([this, camera_name, pose]() {
-        APIPCamera* camera = getCamera(camera_name);
-        camera->setCameraPose(pose);
-    }, true);
-}
-
-void PawnSimApi::setCameraFoV(const std::string& camera_name, float fov_degrees)
-{
-    UAirBlueprintLib::RunCommandOnGameThread([this, camera_name, fov_degrees]() {
-        APIPCamera* camera = getCamera(camera_name);
-        camera->setCameraFoV(fov_degrees);
-    },
-                                             true);
-}
-
-void PawnSimApi::setDistortionParam(const std::string& camera_name, const std::string& param_name, float value)
-{
-    UAirBlueprintLib::RunCommandOnGameThread([this, &camera_name, &param_name, &value]() {
-        getCamera(camera_name)->setDistortionParam(param_name, value);
-    }, true);
-}
-
-std::vector<float> PawnSimApi::getDistortionParams(const std::string& camera_name) const
-{
-    std::vector<float> param_values;
-    UAirBlueprintLib::RunCommandOnGameThread([this, &camera_name, &param_values]() {
-        param_values = getCamera(camera_name)->getDistortionParams();
-    }, true);
-
-    return param_values;
-}
-
 //parameters in NED frame
 PawnSimApi::Pose PawnSimApi::getPose() const
 {

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
@@ -184,27 +184,6 @@ APawn* PawnSimApi::getPawn()
     return params_.pawn;
 }
 
-std::vector<PawnSimApi::ImageCaptureBase::ImageResponse> PawnSimApi::getImages(
-    const std::vector<ImageCaptureBase::ImageRequest>& requests) const
-{
-    std::vector<ImageCaptureBase::ImageResponse> responses;
-
-    const ImageCaptureBase* camera = getImageCapture();
-    camera->getImages(requests, responses);
-
-    return responses;
-}
-
-std::vector<uint8_t> PawnSimApi::getImage(const std::string& camera_name, ImageCaptureBase::ImageType image_type) const
-{
-    std::vector<ImageCaptureBase::ImageRequest> request = { ImageCaptureBase::ImageRequest(camera_name, image_type) };
-    const std::vector<ImageCaptureBase::ImageResponse>& response = getImages(request);
-    if (response.size() > 0)
-        return response.at(0).image_data_uint8;
-    else
-        return std::vector<uint8_t>();
-}
-
 void PawnSimApi::setRCForceFeedback(float rumble_strength, float auto_center)
 {
     if (joystick_state_.is_initialized) {

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
@@ -337,69 +337,6 @@ void PawnSimApi::reportState(msr::airlib::StateReporter& reporter)
     reporter.writeValue("unreal pos", Vector3r(unrealPosition.X, unrealPosition.Y, unrealPosition.Z));
 }
 
-void PawnSimApi::addDetectionFilterMeshName(const std::string& camera_name, ImageCaptureBase::ImageType image_type, const std::string& mesh_name)
-{
-    UAirBlueprintLib::RunCommandOnGameThread([this, camera_name, image_type, mesh_name]() {
-        const APIPCamera* camera = getCamera(camera_name);
-        UDetectionComponent* detection_comp = camera->getDetectionComponent(image_type, false);
-
-        FString name = FString(mesh_name.c_str());
-
-        if (!detection_comp->object_filter_.wildcard_mesh_names_.Contains(name)) {
-            detection_comp->object_filter_.wildcard_mesh_names_.Add(name);
-        }
-    },
-                                             true);
-}
-
-void PawnSimApi::clearDetectionMeshNames(const std::string& camera_name, ImageCaptureBase::ImageType image_type)
-{
-    UAirBlueprintLib::RunCommandOnGameThread([this, camera_name, image_type]() {
-        const APIPCamera* camera = getCamera(camera_name);
-        camera->getDetectionComponent(image_type, false)->object_filter_.wildcard_mesh_names_.Empty();
-    },
-                                             true);
-}
-
-void PawnSimApi::setDetectionFilterRadius(const std::string& camera_name, ImageCaptureBase::ImageType image_type, const float radius_cm)
-{
-    UAirBlueprintLib::RunCommandOnGameThread([this, camera_name, image_type, radius_cm]() {
-        const APIPCamera* camera = getCamera(camera_name);
-        camera->getDetectionComponent(image_type, false)->max_distance_to_camera_ = radius_cm;
-    },
-                                             true);
-}
-
-std::vector<PawnSimApi::DetectionInfo> PawnSimApi::getDetections(const std::string& camera_name, ImageCaptureBase::ImageType image_type) const
-{
-    std::vector<msr::airlib::DetectionInfo> result;
-
-    UAirBlueprintLib::RunCommandOnGameThread([this, camera_name, image_type, &result]() {
-        const APIPCamera* camera = getCamera(camera_name);
-        const TArray<FDetectionInfo>& detections = camera->getDetectionComponent(image_type, false)->getDetections();
-        result.resize(detections.Num());
-
-        for (int i = 0; i < detections.Num(); i++) {
-            result[i].name = std::string(TCHAR_TO_UTF8(*(detections[i].Actor->GetFName().ToString())));
-
-            Vector3r nedWrtOrigin = ned_transform_.toGlobalNed(detections[i].Actor->GetActorLocation());
-            result[i].geo_point = msr::airlib::EarthUtils::nedToGeodetic(nedWrtOrigin,
-                                                                         AirSimSettings::singleton().origin_geopoint);
-
-            result[i].box2D.min = Vector2r(detections[i].Box2D.Min.X, detections[i].Box2D.Min.Y);
-            result[i].box2D.max = Vector2r(detections[i].Box2D.Max.X, detections[i].Box2D.Max.Y);
-
-            result[i].box3D.min = ned_transform_.toLocalNed(detections[i].Box3D.Min);
-            result[i].box3D.max = ned_transform_.toLocalNed(detections[i].Box3D.Max);
-
-            result[i].relative_pose = toPose(detections[i].RelativeTransform.GetTranslation(), detections[i].RelativeTransform.GetRotation());
-        }
-    },
-                                             true);
-
-    return result;
-}
-
 //void playBack()
 //{
 //if (params_.pawn->GetRootPrimitiveComponent()->IsAnySimulatingPhysics()) {

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
@@ -130,9 +130,7 @@ void PawnSimApi::createCamerasFromSettings()
         const auto& setting = camera_setting_pair.second;
 
         //get pose
-        FVector position = transform.fromLocalNed(
-                               NedTransform::Vector3r(setting.position.x(), setting.position.y(), setting.position.z())) -
-                           transform.fromLocalNed(NedTransform::Vector3r(0.0, 0.0, 0.0));
+        FVector position = transform.fromLocalNed(setting.position) - transform.fromLocalNed(Vector3r::Zero());
         FTransform camera_transform(FRotator(setting.rotation.pitch, setting.rotation.yaw, setting.rotation.roll),
                                     position,
                                     FVector(1., 1., 1.));

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.h
@@ -71,8 +71,6 @@ public: //implementation of VehicleSimApiBase
     virtual void update() override;
 
     virtual const UnrealImageCapture* getImageCapture() const override;
-    virtual std::vector<ImageCaptureBase::ImageResponse> getImages(const std::vector<ImageCaptureBase::ImageRequest>& request) const override;
-    virtual std::vector<uint8_t> getImage(const std::string& camera_name, ImageCaptureBase::ImageType image_type) const override;
     virtual Pose getPose() const override;
     virtual void setPose(const Pose& pose, bool ignore_collision) override;
 

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.h
@@ -75,10 +75,6 @@ public: //implementation of VehicleSimApiBase
     virtual std::vector<uint8_t> getImage(const std::string& camera_name, ImageCaptureBase::ImageType image_type) const override;
     virtual Pose getPose() const override;
     virtual void setPose(const Pose& pose, bool ignore_collision) override;
-    virtual void setCameraPose(const std::string& camera_name, const Pose& pose) override;
-    virtual void setCameraFoV(const std::string& camera_name, float fov_degrees) override;
-    virtual void setDistortionParam(const std::string& camera_name, const std::string& param_name, float value) override;
-    virtual std::vector<float> getDistortionParams(const std::string& camera_name) const override;
 
     virtual CollisionInfo getCollisionInfo() const override;
     virtual int getRemoteControlID() const override;

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.h
@@ -54,12 +54,17 @@ public: //types
         }
 
         Params(APawn* pawn_val, const NedTransform* global_transform_val, PawnEvents* pawn_events_val,
-            const common_utils::UniqueValueMap<std::string, APIPCamera*>& cameras_val, UClass* pip_camera_class_val,
-            UParticleSystem* collision_display_template_val, const msr::airlib::GeoPoint& home_geopoint_val,
-            const std::string& vehicle_name_val)
-        : pawn(pawn_val), global_transform(global_transform_val), pawn_events(pawn_events_val), cameras(cameras_val),
-          pip_camera_class(pip_camera_class_val), collision_display_template(collision_display_template_val),
-          home_geopoint(home_geopoint_val), vehicle_name(vehicle_name_val)
+               const common_utils::UniqueValueMap<std::string, APIPCamera*>& cameras_val, UClass* pip_camera_class_val,
+               UParticleSystem* collision_display_template_val, const msr::airlib::GeoPoint& home_geopoint_val,
+               const std::string& vehicle_name_val)
+            : pawn(pawn_val)
+            , global_transform(global_transform_val)
+            , pawn_events(pawn_events_val)
+            , cameras(cameras_val)
+            , pip_camera_class(pip_camera_class_val)
+            , collision_display_template(collision_display_template_val)
+            , home_geopoint(home_geopoint_val)
+            , vehicle_name(vehicle_name_val)
         {
         }
     };

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.h
@@ -54,18 +54,13 @@ public: //types
         }
 
         Params(APawn* pawn_val, const NedTransform* global_transform_val, PawnEvents* pawn_events_val,
-               const common_utils::UniqueValueMap<std::string, APIPCamera*> cameras_val, UClass* pip_camera_class_val,
-               UParticleSystem* collision_display_template_val, const msr::airlib::GeoPoint home_geopoint_val,
-               std::string vehicle_name_val)
+            const common_utils::UniqueValueMap<std::string, APIPCamera*>& cameras_val, UClass* pip_camera_class_val,
+            UParticleSystem* collision_display_template_val, const msr::airlib::GeoPoint& home_geopoint_val,
+            const std::string& vehicle_name_val)
+        : pawn(pawn_val), global_transform(global_transform_val), pawn_events(pawn_events_val), cameras(cameras_val),
+          pip_camera_class(pip_camera_class_val), collision_display_template(collision_display_template_val),
+          home_geopoint(home_geopoint_val), vehicle_name(vehicle_name_val)
         {
-            pawn = pawn_val;
-            global_transform = global_transform_val;
-            pawn_events = pawn_events_val;
-            cameras = cameras_val;
-            pip_camera_class = pip_camera_class_val;
-            collision_display_template = collision_display_template_val;
-            home_geopoint = home_geopoint_val;
-            vehicle_name = vehicle_name_val;
         }
     };
 

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.h
@@ -79,7 +79,7 @@ public: //implementation of VehicleSimApiBase
     virtual void setCameraPose(const std::string& camera_name, const Pose& pose) override;
     virtual void setCameraFoV(const std::string& camera_name, float fov_degrees) override;
     virtual void setDistortionParam(const std::string& camera_name, const std::string& param_name, float value) override;
-    virtual std::vector<float> getDistortionParams(const std::string& camera_name) override;
+    virtual std::vector<float> getDistortionParams(const std::string& camera_name) const override;
 
     virtual CollisionInfo getCollisionInfo() const override;
     virtual int getRemoteControlID() const override;

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.h
@@ -75,7 +75,6 @@ public: //implementation of VehicleSimApiBase
     virtual std::vector<uint8_t> getImage(const std::string& camera_name, ImageCaptureBase::ImageType image_type) const override;
     virtual Pose getPose() const override;
     virtual void setPose(const Pose& pose, bool ignore_collision) override;
-    virtual msr::airlib::CameraInfo getCameraInfo(const std::string& camera_name) const override;
     virtual void setCameraPose(const std::string& camera_name, const Pose& pose) override;
     virtual void setCameraFoV(const std::string& camera_name, float fov_degrees) override;
     virtual void setDistortionParam(const std::string& camera_name, const std::string& param_name, float value) override;

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.h
@@ -96,11 +96,6 @@ public: //implementation of VehicleSimApiBase
     virtual std::string getRecordFileLine(bool is_header_line) const override;
     virtual void reportState(msr::airlib::StateReporter& reporter) override;
 
-    virtual void addDetectionFilterMeshName(const std::string& camera_name, ImageCaptureBase::ImageType image_type, const std::string& mesh_name) override;
-    virtual void setDetectionFilterRadius(const std::string& camera_name, ImageCaptureBase::ImageType image_type, const float radius_cm) override;
-    virtual void clearDetectionMeshNames(const std::string& camera_name, ImageCaptureBase::ImageType image_type) override;
-    virtual std::vector<DetectionInfo> getDetections(const std::string& camera_name, ImageCaptureBase::ImageType image_type) const override;
-
 protected: //additional interface for derived class
     virtual void pawnTick(float dt);
     void setPoseInternal(const Pose& pose, bool ignore_collision);

--- a/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
@@ -333,7 +333,7 @@ void ASimHUD::initializeSubWindows()
     }
 
     for (const auto& setting : getSubWindowSettings()) {
-        auto camera = simmode_->getCamera(setting.camera_name, setting.vehicle_name, setting.external);
+        APIPCamera* camera = simmode_->getCamera(msr::airlib::CameraDetails(setting.camera_name, setting.vehicle_name, setting.external));
         if (camera)
             subwindow_cameras_[setting.window_index] = camera;
         else

--- a/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
@@ -332,23 +332,13 @@ void ASimHUD::initializeSubWindows()
             subwindow_cameras_[0] = subwindow_cameras_[1] = subwindow_cameras_[2] = nullptr;
     }
 
-    for (size_t window_index = 0; window_index < AirSimSettings::kSubwindowCount; ++window_index) {
-
-        const auto& subwindow_setting = AirSimSettings::singleton().subwindow_settings.at(window_index);
-        auto vehicle_sim_api = simmode_->getVehicleSimApi(subwindow_setting.vehicle_name);
-
-        if (vehicle_sim_api) {
-            if (vehicle_sim_api->getCamera(subwindow_setting.camera_name) != nullptr)
-                subwindow_cameras_[subwindow_setting.window_index] = vehicle_sim_api->getCamera(subwindow_setting.camera_name);
-            else
-                UAirBlueprintLib::LogMessageString("CameraID in <SubWindows> element in settings.json is invalid",
-                                                   std::to_string(window_index),
-                                                   LogDebugLevel::Failure);
-        }
+    for (const auto& setting : getSubWindowSettings()) {
+        auto camera = simmode_->getCamera(setting.camera_name, setting.vehicle_name, setting.external);
+        if (camera)
+            subwindow_cameras_[setting.window_index] = camera;
         else
-            UAirBlueprintLib::LogMessageString("Vehicle in <SubWindows> element in settings.json is invalid",
-                                               std::to_string(window_index),
-                                               LogDebugLevel::Failure);
+            UAirBlueprintLib::LogMessageString("Invalid Camera settings in <SubWindows> element",
+                std::to_string(setting.window_index), LogDebugLevel::Failure);
     }
 }
 

--- a/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
@@ -338,7 +338,8 @@ void ASimHUD::initializeSubWindows()
             subwindow_cameras_[setting.window_index] = camera;
         else
             UAirBlueprintLib::LogMessageString("Invalid Camera settings in <SubWindows> element",
-                std::to_string(setting.window_index), LogDebugLevel::Failure);
+                                               std::to_string(setting.window_index),
+                                               LogDebugLevel::Failure);
     }
 }
 

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
@@ -511,9 +511,10 @@ bool ASimModeBase::isRecording() const
     return FRecordingThread::isRecording();
 }
 
-const APIPCamera* ASimModeBase::getCamera(const std::string& camera_name, const std::string& vehicle_name, bool external) const
+const APIPCamera* ASimModeBase::getCamera(const msr::airlib::CameraDetails& camera_details) const
 {
-    return external ? getExternalCamera(camera_name) : getVehicleSimApi(vehicle_name)->getCamera(camera_name);
+    return camera_details.external ? getExternalCamera(camera_details.camera_name)
+                                   : getVehicleSimApi(camera_details.vehicle_name)->getCamera(camera_details.camera_name);
 }
 
 const UnrealImageCapture* ASimModeBase::getImageCapture(const std::string& vehicle_name, bool external) const

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
@@ -472,7 +472,8 @@ void ASimModeBase::initializeExternalCameras()
         //get pose
         FVector position = transform.fromLocalNed(setting.position) - transform.fromLocalNed(Vector3r::Zero());
         FTransform camera_transform(FRotator(setting.rotation.pitch, setting.rotation.yaw, setting.rotation.roll),
-            position, FVector(1., 1., 1.));
+                                    position,
+                                    FVector(1., 1., 1.));
 
         //spawn and attach camera to pawn
         camera_spawn_params.Name = FName(("external_" + camera_setting_pair.first).c_str());
@@ -512,14 +513,12 @@ bool ASimModeBase::isRecording() const
 
 const APIPCamera* ASimModeBase::getCamera(const std::string& camera_name, const std::string& vehicle_name, bool external) const
 {
-    return external ? getExternalCamera(camera_name) :
-                      getVehicleSimApi(vehicle_name)->getCamera(camera_name);
+    return external ? getExternalCamera(camera_name) : getVehicleSimApi(vehicle_name)->getCamera(camera_name);
 }
 
 const UnrealImageCapture* ASimModeBase::getImageCapture(const std::string& vehicle_name, bool external) const
 {
-    return external ? external_image_capture_.get() :
-                      getVehicleSimApi(vehicle_name)->getImageCapture();
+    return external ? external_image_capture_.get() : getVehicleSimApi(vehicle_name)->getImageCapture();
 }
 
 //API server start/stop

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
@@ -523,6 +523,14 @@ const APIPCamera* ASimModeBase::getCamera(const std::string& camera_name, const 
         return getVehicleSimApi(vehicle_name)->getCamera(camera_name);
 }
 
+const UnrealImageCapture* ASimModeBase::getImageCapture(const std::string& vehicle_name, bool external) const
+{
+    if (external)
+        return external_image_capture_.get();
+    else
+        getVehicleSimApi(vehicle_name)->getImageCapture();
+}
+
 //API server start/stop
 void ASimModeBase::startApiServer()
 {
@@ -734,6 +742,8 @@ void ASimModeBase::setupVehiclesAndCamera()
 
     // Create External Cameras
     initializeExternalCameras();
+    // external_image_capture_.reset(new UnrealImageCapture(&external_cameras_));
+    external_image_capture_ = std::make_unique<UnrealImageCapture>(&external_cameras_);
 
     if (getApiProvider()->hasDefaultVehicle()) {
         //TODO: better handle no FPV vehicles scenario

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
@@ -515,12 +515,12 @@ bool ASimModeBase::isRecording() const
     return FRecordingThread::isRecording();
 }
 
-msr::airlib::CameraInfo ASimModeBase::getCameraInfo(const std::string& camera_name, const std::string& vehicle_name, bool external) const
+const APIPCamera* ASimModeBase::getCamera(const std::string& camera_name, const std::string& vehicle_name, bool external) const
 {
     if (external)
-        return getExternalCamera(camera_name)->getCameraInfo();
+        return getExternalCamera(camera_name);
     else
-        return getVehicleSimApi(vehicle_name)->getCameraInfo(camera_name);
+        return getVehicleSimApi(vehicle_name)->getCamera(camera_name);
 }
 
 //API server start/stop

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
@@ -512,18 +512,14 @@ bool ASimModeBase::isRecording() const
 
 const APIPCamera* ASimModeBase::getCamera(const std::string& camera_name, const std::string& vehicle_name, bool external) const
 {
-    if (external)
-        return getExternalCamera(camera_name);
-    else
-        return getVehicleSimApi(vehicle_name)->getCamera(camera_name);
+    return external ? getExternalCamera(camera_name) :
+                      getVehicleSimApi(vehicle_name)->getCamera(camera_name);
 }
 
 const UnrealImageCapture* ASimModeBase::getImageCapture(const std::string& vehicle_name, bool external) const
 {
-    if (external)
-        return external_image_capture_.get();
-    else
-        return getVehicleSimApi(vehicle_name)->getImageCapture();
+    return external ? external_image_capture_.get() :
+                      getVehicleSimApi(vehicle_name)->getImageCapture();
 }
 
 //API server start/stop

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
@@ -459,6 +459,37 @@ void ASimModeBase::initializeCameraDirector(const FTransform& camera_transform, 
     }
 }
 
+void ASimModeBase::initializeExternalCameras()
+{
+     //UStaticMeshComponent* bodyMesh = UAirBlueprintLib::GetActorComponent<UStaticMeshComponent>(this, TEXT("BodyMesh"));
+    // USceneComponent* bodyMesh = params_.pawn->GetRootComponent();
+    FActorSpawnParameters camera_spawn_params;
+    camera_spawn_params.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AdjustIfPossibleButAlwaysSpawn;
+    const auto& transform = getGlobalNedTransform();
+
+    //for each camera in settings
+    for (const auto& camera_setting_pair : getSettings().external_cameras) {
+        const auto& setting = camera_setting_pair.second;
+
+        //get pose
+        FVector position = transform.fromLocalNed(
+            NedTransform::Vector3r(setting.position.x(), setting.position.y(), setting.position.z()))
+            - transform.fromLocalNed(NedTransform::Vector3r(0.0, 0.0, 0.0));
+        FTransform camera_transform(FRotator(setting.rotation.pitch, setting.rotation.yaw, setting.rotation.roll),
+            position, FVector(1., 1., 1.));
+
+        //spawn and attach camera to pawn
+        camera_spawn_params.Name = FName(("external_" + camera_setting_pair.first).c_str());
+        APIPCamera* camera = this->GetWorld()->SpawnActor<APIPCamera>(pip_camera_class, camera_transform, camera_spawn_params);
+        // camera->AttachToComponent(bodyMesh, FAttachmentTransformRules::KeepRelativeTransform);
+
+        camera->setupCameraFromSettings(setting, transform);
+
+        //add on to our collection
+        external_cameras_.insert_or_assign(camera_setting_pair.first, camera);
+    }
+}
+
 bool ASimModeBase::toggleRecording()
 {
     if (isRecording())
@@ -692,6 +723,9 @@ void ASimModeBase::setupVehiclesAndCamera()
             vehicle_sim_apis_.push_back(std::move(vehicle_sim_api));
         }
     }
+
+    // Create External Cameras
+    initializeExternalCameras();
 
     if (getApiProvider()->hasDefaultVehicle()) {
         //TODO: better handle no FPV vehicles scenario

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
@@ -515,6 +515,14 @@ bool ASimModeBase::isRecording() const
     return FRecordingThread::isRecording();
 }
 
+msr::airlib::CameraInfo ASimModeBase::getCameraInfo(const std::string& camera_name, const std::string& vehicle_name, bool external) const
+{
+    if (external)
+        return getExternalCamera(camera_name)->getCameraInfo();
+    else
+        return getVehicleSimApi(vehicle_name)->getCameraInfo(camera_name);
+}
+
 //API server start/stop
 void ASimModeBase::startApiServer()
 {

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.h
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.h
@@ -121,6 +121,7 @@ protected: //optional overrides
     void initializeCameraDirector(const FTransform& camera_transform, float follow_distance);
     void checkVehicleReady(); //checks if vehicle is available to use
     virtual void updateDebugReport(msr::airlib::StateReporterWrapper& debug_reporter);
+    virtual void initializeExternalCameras();
 
 protected: //Utility methods for derived classes
     virtual const msr::airlib::AirSimSettings& getSettings() const;
@@ -174,6 +175,7 @@ private:
     msr::airlib::StateReporterWrapper debug_reporter_;
 
     std::vector<std::unique_ptr<msr::airlib::VehicleSimApiBase>> vehicle_sim_apis_;
+    common_utils::UniqueValueMap<std::string, APIPCamera*> external_cameras_;
 
     UPROPERTY()
     TArray<AActor*> spawned_actors_; //keep refs alive from Unreal GC

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.h
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.h
@@ -70,8 +70,6 @@ public:
     virtual void stopRecording();
     virtual bool isRecording() const;
 
-    virtual msr::airlib::CameraInfo getCameraInfo(const std::string& camera_name, const std::string& vehicle_name, bool external) const;
-
     void startApiServer();
     void stopApiServer();
     bool isApiServerStarted();
@@ -99,11 +97,7 @@ public:
         return external_cameras_.findOrDefault(camera_name, nullptr);
     }
 
-    APIPCamera* getExternalCamera(const std::string& camera_name)
-    {
-        return const_cast<APIPCamera*>(
-            static_cast<const ASimModeBase*>(this)->getExternalCamera(camera_name));
-    }
+    const APIPCamera* getCamera(const std::string& camera_name, const std::string& vehicle_name = "", bool external = false) const;    
 
     TMap<FString, FAssetData> asset_map;
     TMap<FString, AActor*> scene_object_map;

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.h
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.h
@@ -70,6 +70,8 @@ public:
     virtual void stopRecording();
     virtual bool isRecording() const;
 
+    virtual msr::airlib::CameraInfo getCameraInfo(const std::string& camera_name, const std::string& vehicle_name, bool external) const;
+
     void startApiServer();
     void stopApiServer();
     bool isApiServerStarted();
@@ -90,6 +92,17 @@ public:
     PawnSimApi* getVehicleSimApi(const std::string& vehicle_name = "")
     {
         return static_cast<PawnSimApi*>(api_provider_->getVehicleSimApi(vehicle_name));
+    }
+
+    const APIPCamera* getExternalCamera(const std::string& camera_name) const
+    {
+        return external_cameras_.findOrDefault(camera_name, nullptr);
+    }
+
+    APIPCamera* getExternalCamera(const std::string& camera_name)
+    {
+        return const_cast<APIPCamera*>(
+            static_cast<const ASimModeBase*>(this)->getExternalCamera(camera_name));
     }
 
     TMap<FString, FAssetData> asset_map;

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.h
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.h
@@ -150,7 +150,7 @@ protected: //optional overrides
     virtual void initializeExternalCameras();
 
 protected: //Utility methods for derived classes
-    virtual const msr::airlib::AirSimSettings& getSettings() const;
+    virtual const AirSimSettings& getSettings() const;
     FRotator toFRotator(const AirSimSettings::Rotation& rotation, const FRotator& default_val);
 
 protected:

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.h
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.h
@@ -104,10 +104,11 @@ public:
             static_cast<const ASimModeBase*>(this)->getExternalCamera(camera_name));
     }
 
-    APIPCamera* getCamera(const std::string& camera_name, const std::string& vehicle_name = "", bool external = false)
+    const APIPCamera* getCamera(const msr::airlib::CameraDetails& camera_details) const;
+
+    APIPCamera* getCamera(const msr::airlib::CameraDetails& camera_details)
     {
-        return const_cast<APIPCamera*>(
-            static_cast<const ASimModeBase*>(this)->getCamera(camera_name, vehicle_name, external));
+        return const_cast<APIPCamera*>(static_cast<const ASimModeBase*>(this)->getCamera(camera_details));
     }
 
     const UnrealImageCapture* getExternalImageCapture() const
@@ -115,7 +116,6 @@ public:
         return external_image_capture_.get();
     }
 
-    const APIPCamera* getCamera(const std::string& camera_name, const std::string& vehicle_name = "", bool external = false) const;
     const UnrealImageCapture* getImageCapture(const std::string& vehicle_name = "", bool external = false) const;
 
     TMap<FString, FAssetData> asset_map;

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.h
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.h
@@ -15,6 +15,7 @@
 #include "PawnSimApi.h"
 #include "common/StateReporterWrapper.hpp"
 #include "LoadingScreenWidget.h"
+#include "UnrealImageCapture.h"
 #include "SimModeBase.generated.h"
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FLevelLoaded);
@@ -102,14 +103,20 @@ public:
         return const_cast<APIPCamera*>(
             static_cast<const ASimModeBase*>(this)->getExternalCamera(camera_name));
     }
-
-    const APIPCamera* getCamera(const std::string& camera_name, const std::string& vehicle_name = "", bool external = false) const;
     
     APIPCamera* getCamera(const std::string& camera_name, const std::string& vehicle_name = "", bool external = false)
     {
         return const_cast<APIPCamera*>(
             static_cast<const ASimModeBase*>(this)->getCamera(camera_name, vehicle_name, external));
-    } 
+    }
+
+    const UnrealImageCapture* getExternalImageCapture() const
+    {
+        return external_image_capture_.get();
+    }
+
+    const APIPCamera* getCamera(const std::string& camera_name, const std::string& vehicle_name = "", bool external = false) const;
+    const UnrealImageCapture* getImageCapture(const std::string& vehicle_name = "", bool external = false) const;
 
     TMap<FString, FAssetData> asset_map;
     TMap<FString, AActor*> scene_object_map;
@@ -195,6 +202,7 @@ private:
 
     std::vector<std::unique_ptr<msr::airlib::VehicleSimApiBase>> vehicle_sim_apis_;
     common_utils::UniqueValueMap<std::string, APIPCamera*> external_cameras_;
+    std::unique_ptr<UnrealImageCapture> external_image_capture_;
 
     UPROPERTY()
     TArray<AActor*> spawned_actors_; //keep refs alive from Unreal GC

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.h
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.h
@@ -97,7 +97,19 @@ public:
         return external_cameras_.findOrDefault(camera_name, nullptr);
     }
 
-    const APIPCamera* getCamera(const std::string& camera_name, const std::string& vehicle_name = "", bool external = false) const;    
+    APIPCamera* getExternalCamera(const std::string& camera_name)
+    {
+        return const_cast<APIPCamera*>(
+            static_cast<const ASimModeBase*>(this)->getExternalCamera(camera_name));
+    }
+
+    const APIPCamera* getCamera(const std::string& camera_name, const std::string& vehicle_name = "", bool external = false) const;
+    
+    APIPCamera* getCamera(const std::string& camera_name, const std::string& vehicle_name = "", bool external = false)
+    {
+        return const_cast<APIPCamera*>(
+            static_cast<const ASimModeBase*>(this)->getCamera(camera_name, vehicle_name, external));
+    } 
 
     TMap<FString, FAssetData> asset_map;
     TMap<FString, AActor*> scene_object_map;

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.h
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.h
@@ -103,7 +103,7 @@ public:
         return const_cast<APIPCamera*>(
             static_cast<const ASimModeBase*>(this)->getExternalCamera(camera_name));
     }
-    
+
     APIPCamera* getCamera(const std::string& camera_name, const std::string& vehicle_name = "", bool external = false)
     {
         return const_cast<APIPCamera*>(

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
@@ -793,11 +793,13 @@ std::vector<WorldSimApi::ImageCaptureBase::ImageResponse> WorldSimApi::getImages
     return responses;
 }
 
-std::vector<uint8_t> WorldSimApi::getImage(const std::string& camera_name, ImageCaptureBase::ImageType image_type,
-                                           const std::string& vehicle_name, bool external) const
+std::vector<uint8_t> WorldSimApi::getImage(ImageCaptureBase::ImageType image_type, const CameraDetails& camera_details) const
 {
-    std::vector<ImageCaptureBase::ImageRequest> request{ ImageCaptureBase::ImageRequest(camera_name, image_type) };
-    const auto& response = getImages(request);
+    std::vector<ImageCaptureBase::ImageRequest> request{
+        ImageCaptureBase::ImageRequest(camera_details.camera_name, image_type)
+    };
+
+    const auto& response = getImages(request, camera_details.vehicle_name, camera_details.external);
     if (response.size() > 0)
         return response.at(0).image_data_uint8;
     else

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
@@ -730,3 +730,14 @@ std::vector<msr::airlib::GeoPoint> WorldSimApi::getWorldExtents() const
 
     return result;
 }
+
+CameraInfo WorldSimApi::getCameraInfo(const std::string& camera_name, const std::string& vehicle_name, bool external) const
+{
+    CameraInfo info;
+    UAirBlueprintLib::RunCommandOnGameThread([this, &camera_name, &vehicle_name, external, &info]() {
+        info = simmode_->getCameraInfo(camera_name, vehicle_name, external);
+    },
+                                             true);
+
+    return info;
+}

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
@@ -797,7 +797,7 @@ std::vector<WorldSimApi::ImageCaptureBase::ImageResponse> WorldSimApi::getImages
 std::vector<uint8_t> WorldSimApi::getImage(const std::string& camera_name, ImageCaptureBase::ImageType image_type,
     const std::string& vehicle_name, bool external) const
 {
-    std::vector<ImageCaptureBase::ImageRequest> request = { ImageCaptureBase::ImageRequest(camera_name, image_type) };
+    std::vector<ImageCaptureBase::ImageRequest> request{ ImageCaptureBase::ImageRequest(camera_name, image_type) };
     const auto& response = getImages(request);
     if (response.size() > 0)
         return response.at(0).image_data_uint8;

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
@@ -731,12 +731,11 @@ std::vector<msr::airlib::GeoPoint> WorldSimApi::getWorldExtents() const
     return result;
 }
 
-CameraInfo WorldSimApi::getCameraInfo(const std::string& camera_name, const std::string& vehicle_name, bool external) const
+msr::airlib::CameraInfo WorldSimApi::getCameraInfo(const std::string& camera_name, const std::string& vehicle_name, bool external) const
 {
-    CameraInfo info;
-
-    UAirBlueprintLib::RunCommandOnGameThread([this, &camera_name, &vehicle_name, &external, &info]() {
-        auto camera = simmode_->getCamera(camera_name, vehicle_name, external);
+    msr::airlib::CameraInfo info;
+    const auto* camera = simmode_->getCamera(camera_name, vehicle_name, external);
+    UAirBlueprintLib::RunCommandOnGameThread([camera, &info]() {
         info = camera->getCameraInfo();
     },
                                              true);
@@ -745,40 +744,43 @@ CameraInfo WorldSimApi::getCameraInfo(const std::string& camera_name, const std:
 }
 
 void WorldSimApi::setCameraPose(const std::string& camera_name, const msr::airlib::Pose& pose,
-                               const std::string& vehicle_name, bool external)
+                                const std::string& vehicle_name, bool external)
 {
-    UAirBlueprintLib::RunCommandOnGameThread([this, &camera_name, &vehicle_name, &external, &pose]() {
-        auto camera = simmode_->getCamera(camera_name, vehicle_name, external);
+    auto* camera = simmode_->getCamera(camera_name, vehicle_name, external);
+    UAirBlueprintLib::RunCommandOnGameThread([camera, &pose]() {
         camera->setCameraPose(pose);
-    }, true);
+    },
+                                             true);
 }
 
 void WorldSimApi::setCameraFoV(const std::string& camera_name, float fov_degrees,
                                const std::string& vehicle_name, bool external)
 {
-    UAirBlueprintLib::RunCommandOnGameThread([this, &camera_name, &vehicle_name, &external, &fov_degrees]() {
-        auto camera = simmode_->getCamera(camera_name, vehicle_name, external);
+    auto* camera = simmode_->getCamera(camera_name, vehicle_name, external);
+    UAirBlueprintLib::RunCommandOnGameThread([camera, &fov_degrees]() {
         camera->setCameraFoV(fov_degrees);
-    }, true);
+    },
+                                             true);
 }
 
 void WorldSimApi::setDistortionParam(const std::string& camera_name, const std::string& param_name, float value,
-                                    const std::string& vehicle_name, bool external)
+                                     const std::string& vehicle_name, bool external)
 {
-    UAirBlueprintLib::RunCommandOnGameThread([this, &camera_name, &vehicle_name, &external,
-                                              &param_name, &value]() {
-        auto camera = simmode_->getCamera(camera_name, vehicle_name, external);
+    auto* camera = simmode_->getCamera(camera_name, vehicle_name, external);
+    UAirBlueprintLib::RunCommandOnGameThread([camera, &param_name, &value]() {
         camera->setDistortionParam(param_name, value);
-    }, true);
+    },
+                                             true);
 }
 
 std::vector<float> WorldSimApi::getDistortionParams(const std::string& camera_name, const std::string& vehicle_name, bool external) const
 {
     std::vector<float> param_values;
-    UAirBlueprintLib::RunCommandOnGameThread([this, &camera_name, &vehicle_name, &external, &param_values]() {
-        auto camera = simmode_->getCamera(camera_name, vehicle_name, external);
+    const auto* camera = simmode_->getCamera(camera_name, vehicle_name, external);
+    UAirBlueprintLib::RunCommandOnGameThread([camera, &param_values]() {
         param_values = camera->getDistortionParams();
-    }, true);
+    },
+                                             true);
 
     return param_values;
 }
@@ -795,7 +797,7 @@ std::vector<WorldSimApi::ImageCaptureBase::ImageResponse> WorldSimApi::getImages
 }
 
 std::vector<uint8_t> WorldSimApi::getImage(const std::string& camera_name, ImageCaptureBase::ImageType image_type,
-    const std::string& vehicle_name, bool external) const
+                                           const std::string& vehicle_name, bool external) const
 {
     std::vector<ImageCaptureBase::ImageRequest> request{ ImageCaptureBase::ImageRequest(camera_name, image_type) };
     const auto& response = getImages(request);

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
@@ -782,3 +782,25 @@ std::vector<float> WorldSimApi::getDistortionParams(const std::string& camera_na
 
     return param_values;
 }
+
+std::vector<WorldSimApi::ImageCaptureBase::ImageResponse> WorldSimApi::getImages(
+    const std::vector<ImageCaptureBase::ImageRequest>& requests, const std::string& vehicle_name, bool external) const
+{
+    std::vector<ImageCaptureBase::ImageResponse> responses;
+
+    const auto* camera = simmode_->getImageCapture(vehicle_name, external);
+    camera->getImages(requests, responses);
+
+    return responses;
+}
+
+std::vector<uint8_t> WorldSimApi::getImage(const std::string& camera_name, ImageCaptureBase::ImageType image_type,
+    const std::string& vehicle_name, bool external) const
+{
+    std::vector<ImageCaptureBase::ImageRequest> request = { ImageCaptureBase::ImageRequest(camera_name, image_type) };
+    const auto& response = getImages(request);
+    if (response.size() > 0)
+        return response.at(0).image_data_uint8;
+    else
+        return std::vector<uint8_t>();
+}

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
@@ -734,8 +734,10 @@ std::vector<msr::airlib::GeoPoint> WorldSimApi::getWorldExtents() const
 CameraInfo WorldSimApi::getCameraInfo(const std::string& camera_name, const std::string& vehicle_name, bool external) const
 {
     CameraInfo info;
-    UAirBlueprintLib::RunCommandOnGameThread([this, &camera_name, &vehicle_name, external, &info]() {
-        info = simmode_->getCameraInfo(camera_name, vehicle_name, external);
+
+    UAirBlueprintLib::RunCommandOnGameThread([this, &camera_name, &vehicle_name, &external, &info]() {
+        auto camera = simmode_->getCamera(camera_name, vehicle_name, external);
+        info = camera->getCameraInfo();
     },
                                              true);
 

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
@@ -731,10 +731,10 @@ std::vector<msr::airlib::GeoPoint> WorldSimApi::getWorldExtents() const
     return result;
 }
 
-msr::airlib::CameraInfo WorldSimApi::getCameraInfo(const std::string& camera_name, const std::string& vehicle_name, bool external) const
+msr::airlib::CameraInfo WorldSimApi::getCameraInfo(const CameraDetails& camera_details) const
 {
     msr::airlib::CameraInfo info;
-    const auto* camera = simmode_->getCamera(camera_name, vehicle_name, external);
+    const APIPCamera* camera = simmode_->getCamera(camera_details);
     UAirBlueprintLib::RunCommandOnGameThread([camera, &info]() {
         info = camera->getCameraInfo();
     },
@@ -743,40 +743,37 @@ msr::airlib::CameraInfo WorldSimApi::getCameraInfo(const std::string& camera_nam
     return info;
 }
 
-void WorldSimApi::setCameraPose(const std::string& camera_name, const msr::airlib::Pose& pose,
-                                const std::string& vehicle_name, bool external)
+void WorldSimApi::setCameraPose(const msr::airlib::Pose& pose, const CameraDetails& camera_details)
 {
-    auto* camera = simmode_->getCamera(camera_name, vehicle_name, external);
+    APIPCamera* camera = simmode_->getCamera(camera_details);
     UAirBlueprintLib::RunCommandOnGameThread([camera, &pose]() {
         camera->setCameraPose(pose);
     },
                                              true);
 }
 
-void WorldSimApi::setCameraFoV(const std::string& camera_name, float fov_degrees,
-                               const std::string& vehicle_name, bool external)
+void WorldSimApi::setCameraFoV(float fov_degrees, const CameraDetails& camera_details)
 {
-    auto* camera = simmode_->getCamera(camera_name, vehicle_name, external);
+    APIPCamera* camera = simmode_->getCamera(camera_details);
     UAirBlueprintLib::RunCommandOnGameThread([camera, &fov_degrees]() {
         camera->setCameraFoV(fov_degrees);
     },
                                              true);
 }
 
-void WorldSimApi::setDistortionParam(const std::string& camera_name, const std::string& param_name, float value,
-                                     const std::string& vehicle_name, bool external)
+void WorldSimApi::setDistortionParam(const std::string& param_name, float value, const CameraDetails& camera_details)
 {
-    auto* camera = simmode_->getCamera(camera_name, vehicle_name, external);
+    APIPCamera* camera = simmode_->getCamera(camera_details);
     UAirBlueprintLib::RunCommandOnGameThread([camera, &param_name, &value]() {
         camera->setDistortionParam(param_name, value);
     },
                                              true);
 }
 
-std::vector<float> WorldSimApi::getDistortionParams(const std::string& camera_name, const std::string& vehicle_name, bool external) const
+std::vector<float> WorldSimApi::getDistortionParams(const CameraDetails& camera_details) const
 {
     std::vector<float> param_values;
-    const auto* camera = simmode_->getCamera(camera_name, vehicle_name, external);
+    const APIPCamera* camera = simmode_->getCamera(camera_details);
     UAirBlueprintLib::RunCommandOnGameThread([camera, &param_values]() {
         param_values = camera->getDistortionParams();
     },
@@ -790,7 +787,7 @@ std::vector<WorldSimApi::ImageCaptureBase::ImageResponse> WorldSimApi::getImages
 {
     std::vector<ImageCaptureBase::ImageResponse> responses;
 
-    const auto* camera = simmode_->getImageCapture(vehicle_name, external);
+    const UnrealImageCapture* camera = simmode_->getImageCapture(vehicle_name, external);
     camera->getImages(requests, responses);
 
     return responses;
@@ -807,10 +804,9 @@ std::vector<uint8_t> WorldSimApi::getImage(const std::string& camera_name, Image
         return std::vector<uint8_t>();
 }
 
-void WorldSimApi::addDetectionFilterMeshName(const std::string& camera_name, ImageCaptureBase::ImageType image_type, const std::string& mesh_name,
-                                             const std::string& vehicle_name, bool external)
+void WorldSimApi::addDetectionFilterMeshName(ImageCaptureBase::ImageType image_type, const std::string& mesh_name, const CameraDetails& camera_details)
 {
-    const APIPCamera* camera = simmode_->getCamera(camera_name, vehicle_name, external);
+    const APIPCamera* camera = simmode_->getCamera(camera_details);
 
     UAirBlueprintLib::RunCommandOnGameThread([camera, image_type, &mesh_name]() {
         camera->getDetectionComponent(image_type, false)->addMeshName(mesh_name);
@@ -818,10 +814,9 @@ void WorldSimApi::addDetectionFilterMeshName(const std::string& camera_name, Ima
                                              true);
 }
 
-void WorldSimApi::setDetectionFilterRadius(const std::string& camera_name, ImageCaptureBase::ImageType image_type, float radius_cm,
-                                           const std::string& vehicle_name, bool external)
+void WorldSimApi::setDetectionFilterRadius(ImageCaptureBase::ImageType image_type, float radius_cm, const CameraDetails& camera_details)
 {
-    const APIPCamera* camera = simmode_->getCamera(camera_name, vehicle_name, external);
+    const APIPCamera* camera = simmode_->getCamera(camera_details);
 
     UAirBlueprintLib::RunCommandOnGameThread([camera, image_type, radius_cm]() {
         camera->getDetectionComponent(image_type, false)->setFilterRadius(radius_cm);
@@ -829,10 +824,9 @@ void WorldSimApi::setDetectionFilterRadius(const std::string& camera_name, Image
                                              true);
 }
 
-void WorldSimApi::clearDetectionMeshNames(const std::string& camera_name, ImageCaptureBase::ImageType image_type,
-                                          const std::string& vehicle_name, bool external)
+void WorldSimApi::clearDetectionMeshNames(ImageCaptureBase::ImageType image_type, const CameraDetails& camera_details)
 {
-    const APIPCamera* camera = simmode_->getCamera(camera_name, vehicle_name, external);
+    const APIPCamera* camera = simmode_->getCamera(camera_details);
 
     UAirBlueprintLib::RunCommandOnGameThread([camera, image_type]() {
         camera->getDetectionComponent(image_type, false)->clearMeshNames();
@@ -840,14 +834,14 @@ void WorldSimApi::clearDetectionMeshNames(const std::string& camera_name, ImageC
                                              true);
 }
 
-std::vector<msr::airlib::DetectionInfo> WorldSimApi::getDetections(const std::string& camera_name, ImageCaptureBase::ImageType image_type,
-                                                                   const std::string& vehicle_name, bool external)
+std::vector<msr::airlib::DetectionInfo> WorldSimApi::getDetections(ImageCaptureBase::ImageType image_type, const CameraDetails& camera_details)
 {
     std::vector<msr::airlib::DetectionInfo> result;
 
-    const APIPCamera* camera = simmode_->getCamera(camera_name, vehicle_name, external);
-    const NedTransform& ned_transform = external ? simmode_->getGlobalNedTransform()
-                                                 : simmode_->getVehicleSimApi(vehicle_name)->getNedTransform();
+    const APIPCamera* camera = simmode_->getCamera(camera_details);
+    const NedTransform& ned_transform = camera_details.external
+                                            ? simmode_->getGlobalNedTransform()
+                                            : simmode_->getVehicleSimApi(camera_details.vehicle_name)->getNedTransform();
 
     UAirBlueprintLib::RunCommandOnGameThread([camera, image_type, &result, &ned_transform]() {
         const TArray<FDetectionInfo>& detections = camera->getDetectionComponent(image_type, false)->getDetections();

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
@@ -743,3 +743,42 @@ CameraInfo WorldSimApi::getCameraInfo(const std::string& camera_name, const std:
 
     return info;
 }
+
+void WorldSimApi::setCameraPose(const std::string& camera_name, const msr::airlib::Pose& pose,
+                               const std::string& vehicle_name, bool external)
+{
+    UAirBlueprintLib::RunCommandOnGameThread([this, &camera_name, &vehicle_name, &external, &pose]() {
+        auto camera = simmode_->getCamera(camera_name, vehicle_name, external);
+        camera->setCameraPose(pose);
+    }, true);
+}
+
+void WorldSimApi::setCameraFoV(const std::string& camera_name, float fov_degrees,
+                               const std::string& vehicle_name, bool external)
+{
+    UAirBlueprintLib::RunCommandOnGameThread([this, &camera_name, &vehicle_name, &external, &fov_degrees]() {
+        auto camera = simmode_->getCamera(camera_name, vehicle_name, external);
+        camera->setCameraFoV(fov_degrees);
+    }, true);
+}
+
+void WorldSimApi::setDistortionParam(const std::string& camera_name, const std::string& param_name, float value,
+                                    const std::string& vehicle_name, bool external)
+{
+    UAirBlueprintLib::RunCommandOnGameThread([this, &camera_name, &vehicle_name, &external,
+                                              &param_name, &value]() {
+        auto camera = simmode_->getCamera(camera_name, vehicle_name, external);
+        camera->setDistortionParam(param_name, value);
+    }, true);
+}
+
+std::vector<float> WorldSimApi::getDistortionParams(const std::string& camera_name, const std::string& vehicle_name, bool external) const
+{
+    std::vector<float> param_values;
+    UAirBlueprintLib::RunCommandOnGameThread([this, &camera_name, &vehicle_name, &external, &param_values]() {
+        auto camera = simmode_->getCamera(camera_name, vehicle_name, external);
+        param_values = camera->getDistortionParams();
+    }, true);
+
+    return param_values;
+}

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.h
@@ -88,9 +88,8 @@ public:
     virtual std::vector<float> getDistortionParams(const CameraDetails& camera_details) const override;
 
     virtual std::vector<ImageCaptureBase::ImageResponse> getImages(const std::vector<ImageCaptureBase::ImageRequest>& requests,
-                                                                   const std::string& vehicle_name = "", bool external = false) const override;
-    virtual std::vector<uint8_t> getImage(const std::string& camera_name, ImageCaptureBase::ImageType image_type,
-                                          const std::string& vehicle_name = "", bool external = false) const override;
+                                                                   const std::string& vehicle_name, bool external) const override;
+    virtual std::vector<uint8_t> getImage(ImageCaptureBase::ImageType image_type, const CameraDetails& camera_details) const override;
 
     virtual void addDetectionFilterMeshName(ImageCaptureBase::ImageType image_type, const std::string& mesh_name, const CameraDetails& camera_details) override;
     virtual void setDetectionFilterRadius(ImageCaptureBase::ImageType image_type, float radius_cm, const CameraDetails& camera_details) override;

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.h
@@ -16,6 +16,7 @@ public:
     typedef msr::airlib::Pose Pose;
     typedef msr::airlib::Vector3r Vector3r;
     typedef msr::airlib::MeshPositionVertexBuffersResponse MeshPositionVertexBuffersResponse;
+    typedef msr::airlib::ImageCaptureBase ImageCaptureBase;
 
     WorldSimApi(ASimModeBase* simmode);
     virtual ~WorldSimApi() = default;
@@ -88,6 +89,11 @@ public:
                                     const std::string& vehicle_name = "", bool external = false) override;
     virtual std::vector<float> getDistortionParams(const std::string& camera_name, const std::string& vehicle_name = "",
                                                    bool external = false) const override;
+
+    std::vector<ImageCaptureBase::ImageResponse> getImages(const std::vector<ImageCaptureBase::ImageRequest>& requests,
+                                                           const std::string& vehicle_name = "", bool external = false) const;
+    std::vector<uint8_t> getImage(const std::string& camera_name, ImageCaptureBase::ImageType image_type,
+                                  const std::string& vehicle_name = "", bool external = false) const;
 
 private:
     AActor* createNewActor(const FActorSpawnParameters& spawn_params, const FTransform& actor_transform, const Vector3r& scale, UStaticMesh* static_mesh);

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.h
@@ -78,6 +78,10 @@ public:
     virtual bool testLineOfSightBetweenPoints(const msr::airlib::GeoPoint& point1, const msr::airlib::GeoPoint& point2) const override;
     virtual std::vector<msr::airlib::GeoPoint> getWorldExtents() const override;
 
+    // Image APIs
+    virtual msr::airlib::CameraInfo getCameraInfo(const std::string& camera_name, const std::string& vehicle_name = "",
+                                                  bool external = false) const override;
+
 private:
     AActor* createNewActor(const FActorSpawnParameters& spawn_params, const FTransform& actor_transform, const Vector3r& scale, UStaticMesh* static_mesh);
     void spawnPlayer();

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.h
@@ -79,7 +79,7 @@ public:
     virtual bool testLineOfSightBetweenPoints(const msr::airlib::GeoPoint& point1, const msr::airlib::GeoPoint& point2) const override;
     virtual std::vector<msr::airlib::GeoPoint> getWorldExtents() const override;
 
-    // Image APIs
+    // Camera APIs
     virtual msr::airlib::CameraInfo getCameraInfo(const std::string& camera_name, const std::string& vehicle_name = "", bool external = false) const override;
     virtual void setCameraPose(const std::string& camera_name, const msr::airlib::Pose& pose,
                                const std::string& vehicle_name = "", bool external = false) override;
@@ -94,6 +94,15 @@ public:
                                                                    const std::string& vehicle_name = "", bool external = false) const override;
     virtual std::vector<uint8_t> getImage(const std::string& camera_name, ImageCaptureBase::ImageType image_type,
                                           const std::string& vehicle_name = "", bool external = false) const override;
+
+    virtual void addDetectionFilterMeshName(const std::string& camera_name, ImageCaptureBase::ImageType image_type, const std::string& mesh_name,
+                                            const std::string& vehicle_name = "", bool external = false) override;
+    virtual void setDetectionFilterRadius(const std::string& camera_name, ImageCaptureBase::ImageType image_type, float radius_cm,
+                                          const std::string& vehicle_name = "", bool external = false) override;
+    virtual void clearDetectionMeshNames(const std::string& camera_name, ImageCaptureBase::ImageType image_type,
+                                         const std::string& vehicle_name = "", bool external = false) override;
+    virtual std::vector<msr::airlib::DetectionInfo> getDetections(const std::string& camera_name, ImageCaptureBase::ImageType image_type,
+                                                                  const std::string& vehicle_name = "", bool external = false) override;
 
 private:
     AActor* createNewActor(const FActorSpawnParameters& spawn_params, const FTransform& actor_transform, const Vector3r& scale, UStaticMesh* static_mesh);

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.h
@@ -17,6 +17,7 @@ public:
     typedef msr::airlib::Vector3r Vector3r;
     typedef msr::airlib::MeshPositionVertexBuffersResponse MeshPositionVertexBuffersResponse;
     typedef msr::airlib::ImageCaptureBase ImageCaptureBase;
+    typedef msr::airlib::CameraDetails CameraDetails;
 
     WorldSimApi(ASimModeBase* simmode);
     virtual ~WorldSimApi() = default;
@@ -80,29 +81,21 @@ public:
     virtual std::vector<msr::airlib::GeoPoint> getWorldExtents() const override;
 
     // Camera APIs
-    virtual msr::airlib::CameraInfo getCameraInfo(const std::string& camera_name, const std::string& vehicle_name = "", bool external = false) const override;
-    virtual void setCameraPose(const std::string& camera_name, const msr::airlib::Pose& pose,
-                               const std::string& vehicle_name = "", bool external = false) override;
-    virtual void setCameraFoV(const std::string& camera_name, float fov_degrees,
-                              const std::string& vehicle_name = "", bool external = false) override;
-    virtual void setDistortionParam(const std::string& camera_name, const std::string& param_name, float value,
-                                    const std::string& vehicle_name = "", bool external = false) override;
-    virtual std::vector<float> getDistortionParams(const std::string& camera_name, const std::string& vehicle_name = "",
-                                                   bool external = false) const override;
+    virtual msr::airlib::CameraInfo getCameraInfo(const CameraDetails& camera_details) const override;
+    virtual void setCameraPose(const msr::airlib::Pose& pose, const CameraDetails& camera_details) override;
+    virtual void setCameraFoV(float fov_degrees, const CameraDetails& camera_details) override;
+    virtual void setDistortionParam(const std::string& param_name, float value, const CameraDetails& camera_details) override;
+    virtual std::vector<float> getDistortionParams(const CameraDetails& camera_details) const override;
 
     virtual std::vector<ImageCaptureBase::ImageResponse> getImages(const std::vector<ImageCaptureBase::ImageRequest>& requests,
                                                                    const std::string& vehicle_name = "", bool external = false) const override;
     virtual std::vector<uint8_t> getImage(const std::string& camera_name, ImageCaptureBase::ImageType image_type,
                                           const std::string& vehicle_name = "", bool external = false) const override;
 
-    virtual void addDetectionFilterMeshName(const std::string& camera_name, ImageCaptureBase::ImageType image_type, const std::string& mesh_name,
-                                            const std::string& vehicle_name = "", bool external = false) override;
-    virtual void setDetectionFilterRadius(const std::string& camera_name, ImageCaptureBase::ImageType image_type, float radius_cm,
-                                          const std::string& vehicle_name = "", bool external = false) override;
-    virtual void clearDetectionMeshNames(const std::string& camera_name, ImageCaptureBase::ImageType image_type,
-                                         const std::string& vehicle_name = "", bool external = false) override;
-    virtual std::vector<msr::airlib::DetectionInfo> getDetections(const std::string& camera_name, ImageCaptureBase::ImageType image_type,
-                                                                  const std::string& vehicle_name = "", bool external = false) override;
+    virtual void addDetectionFilterMeshName(ImageCaptureBase::ImageType image_type, const std::string& mesh_name, const CameraDetails& camera_details) override;
+    virtual void setDetectionFilterRadius(ImageCaptureBase::ImageType image_type, float radius_cm, const CameraDetails& camera_details) override;
+    virtual void clearDetectionMeshNames(ImageCaptureBase::ImageType image_type, const CameraDetails& camera_details) override;
+    virtual std::vector<msr::airlib::DetectionInfo> getDetections(ImageCaptureBase::ImageType image_type, const CameraDetails& camera_details) override;
 
 private:
     AActor* createNewActor(const FActorSpawnParameters& spawn_params, const FTransform& actor_transform, const Vector3r& scale, UStaticMesh* static_mesh);

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.h
@@ -90,10 +90,10 @@ public:
     virtual std::vector<float> getDistortionParams(const std::string& camera_name, const std::string& vehicle_name = "",
                                                    bool external = false) const override;
 
-    std::vector<ImageCaptureBase::ImageResponse> getImages(const std::vector<ImageCaptureBase::ImageRequest>& requests,
-                                                           const std::string& vehicle_name = "", bool external = false) const;
-    std::vector<uint8_t> getImage(const std::string& camera_name, ImageCaptureBase::ImageType image_type,
-                                  const std::string& vehicle_name = "", bool external = false) const;
+    virtual std::vector<ImageCaptureBase::ImageResponse> getImages(const std::vector<ImageCaptureBase::ImageRequest>& requests,
+                                                                   const std::string& vehicle_name = "", bool external = false) const override;
+    virtual std::vector<uint8_t> getImage(const std::string& camera_name, ImageCaptureBase::ImageType image_type,
+                                          const std::string& vehicle_name = "", bool external = false) const override;
 
 private:
     AActor* createNewActor(const FActorSpawnParameters& spawn_params, const FTransform& actor_transform, const Vector3r& scale, UStaticMesh* static_mesh);

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.h
@@ -79,8 +79,15 @@ public:
     virtual std::vector<msr::airlib::GeoPoint> getWorldExtents() const override;
 
     // Image APIs
-    virtual msr::airlib::CameraInfo getCameraInfo(const std::string& camera_name, const std::string& vehicle_name = "",
-                                                  bool external = false) const override;
+    virtual msr::airlib::CameraInfo getCameraInfo(const std::string& camera_name, const std::string& vehicle_name = "", bool external = false) const override;
+    virtual void setCameraPose(const std::string& camera_name, const msr::airlib::Pose& pose,
+                               const std::string& vehicle_name = "", bool external = false) override;
+    virtual void setCameraFoV(const std::string& camera_name, float fov_degrees,
+                              const std::string& vehicle_name = "", bool external = false) override;
+    virtual void setDistortionParam(const std::string& camera_name, const std::string& param_name, float value,
+                                    const std::string& vehicle_name = "", bool external = false) override;
+    virtual std::vector<float> getDistortionParams(const std::string& camera_name, const std::string& vehicle_name = "",
+                                                   bool external = false) const override;
 
 private:
     AActor* createNewActor(const FActorSpawnParameters& spawn_params, const FTransform& actor_transform, const Vector3r& scale, UStaticMesh* static_mesh);

--- a/docs/image_apis.md
+++ b/docs/image_apis.md
@@ -172,6 +172,11 @@ camera_pose = airsim.Pose(airsim.Vector3r(0, 0, 0), airsim.to_quaternion(0.26179
 client.simSetCameraPose(0, camera_pose);
 ```
 
+- `simSetCameraFov` allows changing the Field-of-View of the camera at runtime.
+- `simSetDistortionParams`, `simGetDistortionParams` allow setting and fetching the distortion parameters K1, K2, K3, P1, P2
+
+All Camera APIs take in 3 common parameters apart from the API-specific ones, `camera_name`(str), `vehicle_name`(str) and `external`(bool, to indicate [External Camera](settings.md#external-cameras)). Camera and vehicle name is used to get the specific camera, if `external` is set to `true`, then the vehicle name is ignored. Also see [external_camera.py](https://github.com/microsoft/AirSim/blob/master/PythonClient/computer_vision/external_camera.py) for example usage of these APIs.
+
 ### Gimbal
 You can set stabilization for pitch, roll or yaw for any camera [using settings](settings.md#gimbal).
 

--- a/docs/image_apis.md
+++ b/docs/image_apis.md
@@ -133,6 +133,9 @@ For a more complete ready to run sample code please see [sample code in HelloDro
 See also [other example code](https://github.com/Microsoft/AirSim/tree/master/Examples/DataCollection/StereoImageGenerator.hpp) that generates specified number of stereo images along with ground truth depth and disparity and saving it to [pfm format](pfm.md).
 
 ## Available Cameras
+
+These are the default cameras already available in each vehicle. Apart from these, you can add more cameras to the vehicles and external cameras which are not attached to any vehicle through the [settings](settings.md).
+
 ### Car
 The cameras on car can be accessed by following names in API calls: `front_center`, `front_right`, `front_left`, `fpv` and `back_center`. Here FPV camera is driver's head position in the car.
 ### Multirotor

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -132,9 +132,9 @@ Below are complete list of settings available along with their default values. I
     "UpdateIntervalSecs": 60
   },
   "SubWindows": [
-    {"WindowID": 0, "CameraName": "0", "ImageType": 3, "VehicleName": "", "Visible": false},
-    {"WindowID": 1, "CameraName": "0", "ImageType": 5, "VehicleName": "", "Visible": false},
-    {"WindowID": 2, "CameraName": "0", "ImageType": 0, "VehicleName": "", "Visible": false}
+    {"WindowID": 0, "CameraName": "0", "ImageType": 3, "VehicleName": "", "Visible": false, "External": false},
+    {"WindowID": 1, "CameraName": "0", "ImageType": 5, "VehicleName": "", "Visible": false, "External": false},
+    {"WindowID": 2, "CameraName": "0", "ImageType": 0, "VehicleName": "", "Visible": false, "External": false}
   ],
   "SegmentationSettings": {
     "InitMethod": "",
@@ -188,6 +188,14 @@ Below are complete list of settings available along with their default values. I
       "X": NaN, "Y": NaN, "Z": NaN,
       "Pitch": NaN, "Roll": NaN, "Yaw": NaN
     }
+  },
+  "ExternalCameras": {
+    "FixedCamera1": {
+        // same elements as in CameraDefaults above
+    },
+    "FixedCamera2": {
+        // same elements as in CameraDefaults above
+    }
   }
 }
 ```
@@ -218,7 +226,13 @@ Also see [Time of Day API](apis.md#time-of-day-api).
 This setting specifies the latitude, longitude and altitude of the Player Start component placed in the Unreal environment. The vehicle's home point is computed using this transformation. Note that all coordinates exposed via APIs are using NED system in SI units which means each vehicle starts at (0, 0, 0) in NED system. Time of Day settings are computed for geographical coordinates specified in `OriginGeopoint`.
 
 ## SubWindows
-This setting determines what is shown in each of 3 subwindows which are visible when you press 0,1,2 keys. The `WindowID` can be 0 to 2, `CameraName` is any [available camera](image_apis.md#available_cameras) on the vehicle. `ImageType` integer value determines what kind of image gets shown according to [ImageType enum](image_apis.md#available-imagetype). `VehicleName` string allows you to specify the vehicle to use the camera from, used when multiple vehicles are specified in the settings. First vehicle's camera will be used if there are any mistakes such as incorrect vehicle name, or only a single vehicle.
+This setting determines what is shown in each of 3 subwindows which are visible when you press 1,2,3 keys. 
+
+* `WindowID`: Can be 0 to 2
+* `CameraName` is any [available camera](image_apis.md#available_cameras) on the vehicle.
+* `ImageType` integer value determines what kind of image gets shown according to [ImageType enum](image_apis.md#available-imagetype).
+* `VehicleName` string allows you to specify the vehicle to use the camera from, used when multiple vehicles are specified in the settings. First vehicle's camera will be used if there are any mistakes such as incorrect vehicle name, or only a single vehicle.
+* `External`: Set it to `true` if the camera is an external camera. If true, then the `VehicleName` parameter is ignored
 
 For example, for a single car vehicle, below shows driver view, front bumper view and rear view as scene, depth and surface normals respectively.
 ```json
@@ -329,6 +343,9 @@ This adds fluctuations on horizontal line.
 
 ### Gimbal
 The `Gimbal` element allows to freeze camera orientation for pitch, roll and/or yaw. This setting is ignored unless `ImageType` is -1. The `Stabilization` is defaulted to 0 meaning no gimbal i.e. camera orientation changes with body orientation on all axis. The value of 1 means full stabilization. The value between 0 to 1 acts as a weight for fixed angles specified (in degrees, in world-frame) in `Pitch`, `Roll` and `Yaw` elements and orientation of the vehicle body. When any of the angles is omitted from json or set to NaN, that angle is not stabilized (i.e. it moves along with vehicle body).
+
+## External Cameras
+This element allows specifying cameras which are separate from the cameras attached to the vehicle, such as a CCTV camera. These are fixed cameras, and don't move along with the vehicles. The key in the element is the name of the camera, and the value i.e. settings are the same as `CameraDefaults` described above. All the camera APIs work with external cameras, including capturing images, changing the pose, etc by passing the parameter `external=True` in the API call.
 
 ## Vehicles Settings
 Each simulation mode will go through the list of vehicles specified in this setting and create the ones that has `"AutoCreate": true`. Each vehicle specified in this setting has key which becomes the name of the vehicle. If `"Vehicles"` element is missing then this list is populated with default car named "PhysXCar" and default multirotor named "SimpleFlight".

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -229,9 +229,9 @@ This setting specifies the latitude, longitude and altitude of the Player Start 
 This setting determines what is shown in each of 3 subwindows which are visible when you press 1,2,3 keys. 
 
 * `WindowID`: Can be 0 to 2
-* `CameraName` is any [available camera](image_apis.md#available_cameras) on the vehicle.
-* `ImageType` integer value determines what kind of image gets shown according to [ImageType enum](image_apis.md#available-imagetype).
-* `VehicleName` string allows you to specify the vehicle to use the camera from, used when multiple vehicles are specified in the settings. First vehicle's camera will be used if there are any mistakes such as incorrect vehicle name, or only a single vehicle.
+* `CameraName`: is any [available camera](image_apis.md#available-cameras) on the vehicle or external camera
+* `ImageType`: integer value determines what kind of image gets shown according to [ImageType enum](image_apis.md#available-imagetype-values).
+* `VehicleName`: string allows you to specify the vehicle to use the camera from, used when multiple vehicles are specified in the settings. First vehicle's camera will be used if there are any mistakes such as incorrect vehicle name, or only a single vehicle.
 * `External`: Set it to `true` if the camera is an external camera. If true, then the `VehicleName` parameter is ignored
 
 For example, for a single car vehicle, below shows driver view, front bumper view and rear view as scene, depth and surface normals respectively.
@@ -264,6 +264,7 @@ The recording feature allows you to record data such as position, orientation, v
     * When `PixelsAsFloat` is true, image is saved as [pfm](pfm.md) file instead of png file.
     * `VehicleName` option allows you to specify separate cameras for individual vehicles. If the `Cameras` element isn't present, `Scene` image from the default camera of each vehicle will be recorded.
     * If you don't want to record any images and just the vehicle's physics data, then specify the `Cameras` element but leave it empty, like this: `"Cameras": []`
+    * External cameras are currently not supported in recording
 
 For example, the `Cameras` element below records scene & segmentation images for `Car1` & scene for `Car2`-
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #3208 
Fixes: #1896, 
Fixes: #1709, 
Fixes: #610, 
Fixes: #599
<!-- add this line for each issue your PR solves. --> 
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
This PR adds the capability to create a fixed camera separate from the cameras on the vehicle, such as a CCTV camera. I'm not aware of any simple way to go about doing this currently, and therefore thought to try it out. I haven't checked the issues very thoroughly, so please let me know if there are other related issues and ways to go about doing this.

PR has been opened to get ideas and suggestions and whether this is actually required. This will likely become a big PR, so it can be split into parts for easier review also.

Currently have added a boolean field `external` in the `getCameraInfo` API, went for this since there are currently 7 camera related APIs, which could increase later on as well. Having completely separate APIs will duplicate the code in many places, the new API while doesn't look the cleanest felt like the better choice to me. Do comment if splitting into a different API or some other way is more preferred.

TODO (Comment if something's missing) -
- Camera APIs implementation
  - [x] `getImages`
  - [x] `set/getDistortionParams`
  - [x] `getCameraInfo`
  - [x] `setCameraFov`
  - [x] `setCameraPose`
  - [x] Detection APIs
- Allow External Cameras in -
  - [x] Subwindows
  - [ ] Recording (This will likely require a bit of tinkering, after #2861, possibly even in a separate PR)
- [x] Documentation updates
- [x] Docstrings update
- [x] Unity fixes to preserve earlier behaviour (No external camera implementation currently)

Also removes the `simSetCameraOrientation` API kept around for backward compatibility

The last commit to add an internal `CameraDetails` struct is a NFC commit, just to clean up the multiple parameters being passed everywhere. If it's not desirable then the coomit can be dropped easily. Any suggestions on the struct naming are welcome!

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->

<details>
<summary>Example Settings</summary>

```json
{
    "SettingsVersion": 1.2,
    "SimMode": "Car",
    "ExternalCameras": {
        "fixed1": {
            "X": 0, "Y": 0, "Z": -10,
            "Pitch": -90, "Roll": 0, "Yaw": 0
        },

        "fixed2": {
            "CaptureSettings": [
                {
                  "ImageType": 0,
                  "Width": 256,
                  "Height": 144,
                  "FOV_Degrees": 90,
                  "AutoExposureSpeed": 100,
                  "AutoExposureBias": 0,
                  "AutoExposureMaxBrightness": 0.64,
                  "AutoExposureMinBrightness": 0.03,
                  "MotionBlurAmount": 0,
                  "TargetGamma": 1.0,
                  "ProjectionMode": "",
                  "OrthoWidth": 5.12
                }
            ],
            "NoiseSettings": [
              {
                "Enabled": false,
                "ImageType": 0,

                "RandContrib": 0.2,
                "RandSpeed": 100000.0,
                "RandSize": 500.0,
                "RandDensity": 2,
                "HorzWaveContrib":0.03,
                "HorzWaveStrength": 0.08,
                "HorzWaveVertSize": 1.0,
                "HorzWaveScreenSize": 1.0,
                "HorzNoiseLinesContrib": 1.0,
                "HorzNoiseLinesDensityY": 0.01,
                "HorzNoiseLinesDensityXY": 0.5,
                "HorzDistortionContrib": 1.0,
                "HorzDistortionStrength": 0.002
              }
            ],
            "X": 10, "Y": 0, "Z": 0,
            "Pitch": 0, "Roll": 0, "Yaw": 0
        }
    }
}
```

</details>

Example API Call -

```python
client.simGetCameraInfo("fixed1", external=True)
```

An example Python script has been added, the FoV change will be reflected in the info only after https://github.com/microsoft/AirSim/pull/3278

<details>
<summary>Script Output</summary>

```
$ python external_camera.py
Connected!
Client Ver:1 (Min Req: 1), Server Ver:1 (Min Req: 1)

Saving images to /tmp/airsim_cv_mode
Camera: fixed1, External = True
<CameraInfo> {   'fov': 90.0,
    'pose': <Pose> {   'orientation': <Quaternionr> {   'w_val': 0.7071067094802856,
    'x_val': 0.0,
    'y_val': -0.7071067690849304,
    'z_val': 0.0},
    'position': <Vector3r> {   'x_val': 0.0,
    'y_val': 0.0,
    'z_val': -5.0}},
    'proj_mat': <ProjectionMatrix> {   'matrix': [   [   0.0,
                      1.0,
                      0.0,
                      0.0],
                  [   0.0,
                      0.0,
                      -1.7777777910232544,
                      0.0],
                  [   0.0,
                      0.0,
                      0.0,
                      10.0],
                  [   -1.0,
                      0.0,
                      0.0,
                      0.0]]}}
Press any key to get images
Type 0, size 39292, pos <Vector3r> {   'x_val': 0.0,
    'y_val': 0.0,
    'z_val': -5.0}
Type 1, size 3514, pos <Vector3r> {   'x_val': 0.0,
    'y_val': 0.0,
    'z_val': -5.0}
Type 3, size 4443, pos <Vector3r> {   'x_val': 0.0,
    'y_val': 0.0,
    'z_val': -5.0}
Type 5, size 983, pos <Vector3r> {   'x_val': 0.0,
    'y_val': 0.0,
    'z_val': -5.0}
Type 6, size 8761, pos <Vector3r> {   'x_val': 0.0,
    'y_val': 0.0,
    'z_val': -5.0}
Press any key to change FoV and get images
Type 0, size 34747, pos <Vector3r> {   'x_val': 0.0,
    'y_val': 0.0,
    'z_val': -5.0}
Type 1, size 2437, pos <Vector3r> {   'x_val': 0.0,
    'y_val': 0.0,
    'z_val': -5.0}
Type 3, size 6756, pos <Vector3r> {   'x_val': 0.0,
    'y_val': 0.0,
    'z_val': -5.0}
Type 5, size 983, pos <Vector3r> {   'x_val': 0.0,
    'y_val': 0.0,
    'z_val': -5.0}
Type 6, size 4360, pos <Vector3r> {   'x_val': 0.0,
    'y_val': 0.0,
    'z_val': -5.0}
Old FOV: 90.0, New FOV: 90.0
Type 0, size 46250, pos <Vector3r> {   'x_val': -10.0,
    'y_val': -5.0,
    'z_val': -5.0}
Type 1, size 7357, pos <Vector3r> {   'x_val': -10.0,
    'y_val': -5.0,
    'z_val': -5.0}
Type 3, size 2015, pos <Vector3r> {   'x_val': -10.0,
    'y_val': -5.0,
    'z_val': -5.0}
Type 5, size 1840, pos <Vector3r> {   'x_val': -10.0,
    'y_val': -5.0,
    'z_val': -5.0}
Type 6, size 12998, pos <Vector3r> {   'x_val': -10.0,
    'y_val': -5.0,
    'z_val': -5.0}
Old Pose: <Pose> {   'orientation': <Quaternionr> {   'w_val': 0.7071067094802856,
    'x_val': 0.0,
    'y_val': -0.7071067690849304,
    'z_val': 0.0},
    'position': <Vector3r> {   'x_val': 0.0,
    'y_val': 0.0,
    'z_val': -5.0}}, New Pose: <Pose> {   'orientation': <Quaternionr> {   'w_val': 0.9975020885467529,
    'x_val': -0.002497921697795391,
    'y_val': 0.04991671442985535,
    'z_val': 0.049916788935661316},
    'position': <Vector3r> {   'x_val': -10.0,
    'y_val': -5.0,
    'z_val': -5.0}}
Distortion Params: [0.0, 0.0, 0.0, 0.0, 0.0]
Setting distortion params as {'K1': 0.1, 'K2': 0.01, 'K3': 0.0, 'P1': 0.0, 'P2': 0.0}
Distortion Params: [0.10000000149011612, 0.009999999776482582, 0.0, 0.0, 0.0]
```

</details>

Subwindws Testing: 

<details>
<summary>Subwindow Settings</summary>

```json
{
    "SettingsVersion": 1.2,
    "SimMode": "Car",
    "ExternalCameras": {
        "fixed1": {
            "X": 0, "Y": 0, "Z": -5,
            "Pitch": -90, "Roll": 0, "Yaw": 0
        },
        "fixed2": {
            "X": -10, "Y": 0, "Z": -5,
            "Pitch": -45, "Roll": 0, "Yaw": 0
        }
    },
    "SubWindows": [
        {"WindowID": 0, "ImageType": 0, "CameraName": "fixed1", "Visible": true, "External": true},
        {"WindowID": 1, "ImageType": 0, "CameraName": "fixed2", "Visible": true, "External": true},
        {"WindowID": 2, "ImageType": 0, "CameraName": "0", "Visible": true}
    ]
}
```

</details>

The `external_camera.py` can be easily used for testing all the camera APIs, as well as vehicle cameras by setting the flag. The `detection.py` script has also been tested to be working after these changes.

## Screenshots (if appropriate):
Old FoV (90):
![old_fov_0](https://user-images.githubusercontent.com/37938604/107555904-bc00d080-6bfd-11eb-9026-cd51958d9ad7.png)

New Fov (120):
![new_fov_0](https://user-images.githubusercontent.com/37938604/107555929-c7ec9280-6bfd-11eb-8783-c4083811d120.png)

Subwindows:
![Screenshot from 2021-02-11 18-23-44](https://user-images.githubusercontent.com/37938604/107639404-d33fcc80-6c96-11eb-82c9-2f98efa3bd30.png)


[airsim_cv_mode.zip](https://github.com/microsoft/AirSim/files/5965126/airsim_cv_mode.zip)

