### PR TITLE
Fixed crash when calling simLoadLevel

### DIFF
--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -396,6 +396,18 @@ class VehicleClient:
             list[str]: List containing all the names
         """
         return self.client.call('simListSceneObjects', name_regex)
+        
+    def simLoadLevel(self, level_name):
+        """
+        Loads a level specified by its name
+
+        Args:
+            level_name (str): Name of the level to load
+
+        Returns:
+            bool: True if the level was successfully loaded
+        """
+        return self.client.call('simLoadLevel', level_name)
 
     def simSpawnObject(self, object_name, asset_name, pose, scale, physics_enabled=False):
         """Spawned selected object in the world

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
@@ -73,11 +73,12 @@ void ASimModeBase::toggleLoadingScreen(bool is_visible)
     if (loading_screen_widget_ == nullptr)
         return;
     else {
-
-        if (is_visible)
-            loading_screen_widget_->SetVisibility(ESlateVisibility::Visible);
-        else
-            loading_screen_widget_->SetVisibility(ESlateVisibility::Hidden);
+        UAirBlueprintLib::RunCommandOnGameThread([this, is_visible]() {
+            if (is_visible)
+                loading_screen_widget_->SetVisibility(ESlateVisibility::Visible);
+            else
+                loading_screen_widget_->SetVisibility(ESlateVisibility::Hidden);
+        }, true);
     }
 }
 

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
@@ -78,7 +78,8 @@ void ASimModeBase::toggleLoadingScreen(bool is_visible)
                 loading_screen_widget_->SetVisibility(ESlateVisibility::Visible);
             else
                 loading_screen_widget_->SetVisibility(ESlateVisibility::Hidden);
-        }, true);
+        },
+                                                 true);
     }
 }
 


### PR DESCRIPTION
Fixes #3340

## About
Fixed Unreal Engine crash when calling `simLoadLevel`.

## How Has This Been Tested?
I tested this fix on ubuntu 18.04 with UE4 4.25