### PR TITLE
Bug fix no module named 'skbuild' for docker binary

### DIFF
--- a/docker/Dockerfile_binary
+++ b/docker/Dockerfile_binary
@@ -13,6 +13,8 @@ RUN apt-get install \
 	x11-xserver-utils \
 	-y --no-install-recommends
 RUN pip3 install setuptools wheel
+RUN python3 -m pip install --upgrade pip
+RUN pip3 install scikit-build
 RUN pip3 install airsim
 
 RUN adduser --force-badname --disabled-password --gecos '' --shell /bin/bash airsim_user && \ 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #3369     <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->


## About
<!-- Describe what your PR is about. -->
This PR adds instructions to install scikit-build in the Dockerfile_binary to create the binary file without any dependency error for opencv-contrib-python. 

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
Rebuilt the docker container using updated Dockerfile_binary without any errors.
## Screenshots (if appropriate):