### PR TITLE
Add Ubuntu 20.04 to Actions CI

### DIFF
--- a/.github/workflows/test_ubuntu.yml
+++ b/.github/workflows/test_ubuntu.yml
@@ -5,7 +5,10 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

<!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
Adds Ubuntu 20.04 to GitHub Actions for basic compilation checks

I wanted to add OSX 11 as well but it's currently only in limited preview beta, see a [test run here](https://github.com/rajat2004/AirSim/actions/runs/554740521)

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
Actions CI :)

## Screenshots (if appropriate):