### PR TITLE
Multirotor mass limit clarification & broken link fix

### DIFF
--- a/AirLib/include/vehicles/multirotor/MultiRotorParams.hpp
+++ b/AirLib/include/vehicles/multirotor/MultiRotorParams.hpp
@@ -223,9 +223,10 @@ protected: //static utility functions for derived classes to use
         std::vector<real_T> arm_lengths(params.rotor_count, 0.2275f);
 
         //set up mass
-        //this has to be between max_thrust*rotor_count/10 (1.6kg using default parameters in RotorParams.hpp) and 0.5*max_thrust*rotor_count/10 (0.8kg using default parameters)
+        //this has to be between max_thrust*rotor_count/10 (1.6kg using default parameters in RotorParams.hpp) and (idle throttle percentage)*max_thrust*rotor_count/10 (0.8kg using default parameters and SimpleFlight)
         //any value above the maximum would result in the motors not being able to lift the body even at max thrust,
-        //and any value below the minimum would cause the drone to fly upwards on idling throttle (50% of the max throttle)
+        //and any value below the minimum would cause the drone to fly upwards on idling throttle (50% of the max throttle if using SimpleFlight)
+        //Note that the default idle throttle percentage is 50% if you are using SimpleFlight
         params.mass = 1.0f; 
 
         real_T motor_assembly_weight = 0.055f;  //weight for MT2212 motor for F450 frame
@@ -254,9 +255,9 @@ protected: //static utility functions for derived classes to use
         std::vector<real_T> arm_lengths(params.rotor_count, 0.2275f);
 
         //set up mass
-        //this has to be between max_thrust*rotor_count/10 (2.5kg using default parameters in RotorParams.hpp) and 0.5*max_thrust*rotor_count/10 (1.25kg using default parameters)
+        //this has to be between max_thrust*rotor_count/10 (2.5kg using default parameters in RotorParams.hpp) and (idle throttle percentage)*max_thrust*rotor_count/10 (1.25kg using default parameters and SimpleFlight)
         //any value above the maximum would result in the motors not being able to lift the body even at max thrust,
-        //and any value below the minimum would cause the drone to fly upwards on idling throttle (50% of the max throttle)
+        //and any value below the minimum would cause the drone to fly upwards on idling throttle (50% of the max throttle if using SimpleFlight)
         params.mass = 1.0f;
 
         real_T motor_assembly_weight = 0.055f;  //weight for MT2212 motor for F450 frame

--- a/AirLib/include/vehicles/multirotor/MultiRotorParams.hpp
+++ b/AirLib/include/vehicles/multirotor/MultiRotorParams.hpp
@@ -223,7 +223,11 @@ protected: //static utility functions for derived classes to use
         std::vector<real_T> arm_lengths(params.rotor_count, 0.2275f);
 
         //set up mass
-        params.mass = 1.0f; //can be varied from 0.800 to 1.600
+        //this has to be between max_thrust*rotor_count/10 (1.6kg using default parameters in RotorParams.hpp) and 0.5*max_thrust*rotor_count/10 (0.8kg using default parameters)
+        //any value above the maximum would result in the motors not being able to lift the body even at max thrust,
+        //and any value below the minimum would cause the drone to fly upwards on idling throttle (50% of the max throttle)
+        params.mass = 1.0f; 
+
         real_T motor_assembly_weight = 0.055f;  //weight for MT2212 motor for F450 frame
         real_T box_mass = params.mass - params.rotor_count * motor_assembly_weight;
 
@@ -250,7 +254,11 @@ protected: //static utility functions for derived classes to use
         std::vector<real_T> arm_lengths(params.rotor_count, 0.2275f);
 
         //set up mass
-        params.mass = 1.0f; //can be varied from 0.800 to 1.600
+        //this has to be between max_thrust*rotor_count/10 (2.5kg using default parameters in RotorParams.hpp) and 0.5*max_thrust*rotor_count/10 (1.25kg using default parameters)
+        //any value above the maximum would result in the motors not being able to lift the body even at max thrust,
+        //and any value below the minimum would cause the drone to fly upwards on idling throttle (50% of the max throttle)
+        params.mass = 1.0f;
+
         real_T motor_assembly_weight = 0.055f;  //weight for MT2212 motor for F450 frame
         real_T box_mass = params.mass - params.rotor_count * motor_assembly_weight;
 

--- a/docs/image_apis.md
+++ b/docs/image_apis.md
@@ -220,7 +220,7 @@ When you specify `ImageType = DepthVis` in `ImageRequest`, you get an image that
 You normally want to retrieve disparity image as float (i.e. set `pixels_as_float = true` and specify `ImageType = DisparityNormalized` in `ImageRequest`) in which case each pixel is `(Xl - Xr)/Xmax`, which is thereby normalized to values between 0 to 1.
 
 ### Segmentation
-When you specify `ImageType = Segmentation` in `ImageRequest`, you get an image that gives you ground truth segmentation of the scene. At the startup, AirSim assigns value 0 to 255 to each mesh available in environment. This value is then mapped to a specific color in [the pallet](https://github.com/Microsoft/AirSim/tree/master/Unreal//Plugins/AirSim/Content/HUDAssets/seg_color_pallet.png). The RGB values for each object ID can be found in [this file](seg_rgbs.txt).
+When you specify `ImageType = Segmentation` in `ImageRequest`, you get an image that gives you ground truth segmentation of the scene. At the startup, AirSim assigns value 0 to 255 to each mesh available in environment. This value is then mapped to a specific color in [the pallet](https://raw.githubusercontent.com/microsoft/AirSim/master/Unreal/Plugins/AirSim/Content/HUDAssets/seg_color_palette.png). The RGB values for each object ID can be found in [this file](seg_rgbs.txt).
 
 You can assign a specific value (limited to the range 0-255) to a specific mesh using APIs. For example, below Python code sets the object ID for the mesh called "Ground" to 20 in Blocks environment and hence changes its color in Segmentation view:
 


### PR DESCRIPTION
Fixes: #3400

## About
This PR adds some clarification about where the mass bounds in [MultiRotorParams.hpp](https://github.com/microsoft/AirSim/blob/288c90ca78ce09ed58de8508622cb97071c8f217/AirLib/include/vehicles/multirotor/MultiRotorParams.hpp#L226) come from. 
Where the max limit is actually the mass equivalent to the maximum lift force the rotors+propellers would be able to generate.
![image](https://user-images.githubusercontent.com/49626509/108325380-a3a92c80-718e-11eb-8863-b4d38e7aee11.png)
![image](https://user-images.githubusercontent.com/49626509/108325458-b3287580-718e-11eb-97b5-4be7f5ec8ae6.png)
(1.6kg if using the parameters in [RotorParams.hpp](https://github.com/microsoft/AirSim/blob/288c90ca78ce09ed58de8508622cb97071c8f217/AirLib/include/vehicles/multirotor/RotorParams.hpp#L45) on a quadrotor)
and the min limit is the minimum weight equivalent to 50%of the maximum lift power, aka: the lift power at 50% throttle which is the idling throttle (on SimpleFlight). Anything lower than this will lift off as soon as the drone is armed (ie: with the throttle stick untouched)
(0.8kg  if using the parameters in [RotorParams.hpp](https://github.com/microsoft/AirSim/blob/288c90ca78ce09ed58de8508622cb97071c8f217/AirLib/include/vehicles/multirotor/RotorParams.hpp#L45) on a quadrotor)

This PR also fixed a broken link in [the docs](https://microsoft.github.io/AirSim/image_apis/#changing-colors-for-object-ids)
