### PR TITLE
Fix rotor count bug

### DIFF
--- a/Unreal/Plugins/AirSim/Source/Vehicles/Multirotor/FlyingPawn.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Multirotor/FlyingPawn.cpp
@@ -6,16 +6,13 @@
 
 AFlyingPawn::AFlyingPawn()
 {
+    init_id = pawn_events_.getActuatorSignal().connect_member(this, &AFlyingPawn::initializeRotors);
     pawn_events_.getActuatorSignal().connect_member(this, &AFlyingPawn::setRotorSpeed);
 }
 
 void AFlyingPawn::BeginPlay()
 {
     Super::BeginPlay();
-
-    for (auto i = 0; i < rotor_count; ++i) {
-        rotating_movements_[i] = UAirBlueprintLib::GetActorComponent<URotatingMovementComponent>(this, TEXT("Rotation") + FString::FromInt(i));
-    }
 }
 
 void AFlyingPawn::initializeForBeginPlay()
@@ -91,3 +88,10 @@ void AFlyingPawn::setRotorSpeed(const std::vector<MultirotorPawnEvents::RotorAct
     }
 }
 
+void AFlyingPawn::initializeRotors(const std::vector<MultirotorPawnEvents::RotorActuatorInfo>& rotor_infos)
+{
+    for (auto i = 0; i < rotor_infos.size(); ++i) {
+        rotating_movements_.Add(UAirBlueprintLib::GetActorComponent<URotatingMovementComponent>(this, TEXT("Rotation") + FString::FromInt(i)));
+    }
+    pawn_events_.getActuatorSignal().disconnect(init_id);
+}

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Multirotor/FlyingPawn.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Multirotor/FlyingPawn.cpp
@@ -6,7 +6,7 @@
 
 AFlyingPawn::AFlyingPawn()
 {
-    init_id = pawn_events_.getActuatorSignal().connect_member(this, &AFlyingPawn::initializeRotors);
+    init_id_ = pawn_events_.getActuatorSignal().connect_member(this, &AFlyingPawn::initializeRotors);
     pawn_events_.getActuatorSignal().connect_member(this, &AFlyingPawn::setRotorSpeed);
 }
 
@@ -93,5 +93,5 @@ void AFlyingPawn::initializeRotors(const std::vector<MultirotorPawnEvents::Rotor
     for (auto i = 0; i < rotor_infos.size(); ++i) {
         rotating_movements_.Add(UAirBlueprintLib::GetActorComponent<URotatingMovementComponent>(this, TEXT("Rotation") + FString::FromInt(i)));
     }
-    pawn_events_.getActuatorSignal().disconnect(init_id);
+    pawn_events_.getActuatorSignal().disconnect(init_id_);
 }

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Multirotor/FlyingPawn.h
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Multirotor/FlyingPawn.h
@@ -49,5 +49,5 @@ private: //variables
     UPROPERTY() TArray<URotatingMovementComponent*> rotating_movements_;
 
     MultirotorPawnEvents pawn_events_;
-    int init_id;
+    int init_id_;
 };

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Multirotor/FlyingPawn.h
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Multirotor/FlyingPawn.h
@@ -35,18 +35,19 @@ public:
     }
     //called by API to set rotor speed
     void setRotorSpeed(const std::vector<MultirotorPawnEvents::RotorActuatorInfo>& rotor_infos);
+    void initializeRotors(const std::vector<MultirotorPawnEvents::RotorActuatorInfo>& rotor_infos);
 
 
 private: //variables
     //Unreal components
-    static constexpr size_t rotor_count = 4;
     UPROPERTY() APIPCamera* camera_front_left_;
     UPROPERTY() APIPCamera* camera_front_right_;
     UPROPERTY() APIPCamera* camera_front_center_;
     UPROPERTY() APIPCamera* camera_back_center_;
     UPROPERTY() APIPCamera* camera_bottom_center_;
 
-    UPROPERTY() URotatingMovementComponent* rotating_movements_[rotor_count];
+    UPROPERTY() TArray<URotatingMovementComponent*> rotating_movements_;
 
     MultirotorPawnEvents pawn_events_;
+    int init_id;
 };


### PR DESCRIPTION
## About
This PR fixes a bug that causes UE4 to crash on running AirSim in Hexacopter mode. This happens because the rotor count is hardcoded to '4' in [FlyingPawn.h](https://github.com/microsoft/AirSim/blob/288c90ca78ce09ed58de8508622cb97071c8f217/Unreal/Plugins/AirSim/Source/Vehicles/Multirotor/FlyingPawn.h#L42) resulting in:
![image](https://user-images.githubusercontent.com/49626509/108336879-208dd380-719a-11eb-8731-4d5708799d2c.png)
as `AFlyingPawn::setRotorSpeed` is called when starting the simulation with `Model` set to `Hexacopter` in [settings.json](settings.json)

The solution proposed in this PR is to set `rotating_movements_`to be a dynamic TArray that gets [populated](https://github.com/ahmed-elsaharti/AirSim/blob/006e7fcfcfaac32957ba5bb045089485a96269bd/Unreal/Plugins/AirSim/Source/Vehicles/Multirotor/FlyingPawn.cpp#L93-L95) based on the true rotor count through [`AFlyingPawn::initializeRotors`](https://github.com/ahmed-elsaharti/AirSim/blob/006e7fcfcfaac32957ba5bb045089485a96269bd/Unreal/Plugins/AirSim/Source/Vehicles/Multirotor/FlyingPawn.cpp#L91-L97) which gets [called](https://github.com/ahmed-elsaharti/AirSim/blob/006e7fcfcfaac32957ba5bb045089485a96269bd/Unreal/Plugins/AirSim/Source/Vehicles/Multirotor/MultirotorPawnSimApi.cpp#L125) once during the first [`MultirotorPawnSimApi::updateRendering`](https://github.com/ahmed-elsaharti/AirSim/blob/006e7fcfcfaac32957ba5bb045089485a96269bd/Unreal/Plugins/AirSim/Source/Vehicles/Multirotor/MultirotorPawnSimApi.cpp#L86-L126) and then [disconnects itself](https://github.com/ahmed-elsaharti/AirSim/blob/006e7fcfcfaac32957ba5bb045089485a96269bd/Unreal/Plugins/AirSim/Source/Vehicles/Multirotor/FlyingPawn.cpp#L96) from the signal.


**Note:** a simpler yet less elegant solution to this issue would be to hardcode the rotor count to 6. This would fix the issue for Hexacopters and in the case of Quadcopters rotating_movements_[4] and rotating_movements_[5] would be null pointers anyway so they would be disregarded.

## How Has This Been Tested?
This was tested on Windows using PX4 SITL with the following settings:
```json
{
  "SettingsVersion": 1.2,
  "SimMode": "Multirotor",
  "ClockSpeed": 1,
  "PawnPaths": {
    "DefaultQuadrotor": {"PawnBP": "Class'/Airsim/Blueprints/BP_FlyingHex.BP_FlyingHex_C'"}
  },
  "Vehicles": {
      "PX4": {
          "VehicleType": "PX4Multirotor",
          "Model": "Hexacopter",
          "UseSerial": false,
          "UseTcp": true,
          "TcpPort": 4560,
          "ControlPort": 14580
      }
  }
}
```

## Screenshots (if appropriate):
Before:
![Before](https://user-images.githubusercontent.com/49626509/108342231-2f778480-71a0-11eb-8e92-73372206ad2b.gif)

After:
![After](https://user-images.githubusercontent.com/49626509/108341724-934d7d80-719f-11eb-9705-024d5071a069.gif)
