### PR TITLE
Fix crash due to access after delete

### DIFF
--- a/AirLib/include/common/common_utils/Signal.hpp
+++ b/AirLib/include/common/common_utils/Signal.hpp
@@ -81,8 +81,9 @@ public:
 
     // calls all connected functions
     void emit(Args... p) {
-        for (auto it : slots_) {
-            it.second(p...);
+        for(auto it=slots_.begin(); it!=slots_.end(); ) {
+            // Increment here so that the entry can be erased from inside the method as well
+            (it++)->second(p...);
         }
     }
 

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Multirotor/FlyingPawn.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Multirotor/FlyingPawn.cpp
@@ -45,6 +45,9 @@ void AFlyingPawn::EndPlay(const EEndPlayReason::Type EndPlayReason)
     camera_back_center_ = nullptr;
     camera_bottom_center_ = nullptr;
 
+    pawn_events_.getActuatorSignal().disconnect_all();
+    rotating_movements_.Empty();
+
     Super::EndPlay(EndPlayReason);
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #3448    <!-- add this line for each issue your PR solves. -->
Fixes: #3452
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
This PR fixes a crash due to access after `erase` in the map. #3402 added a method that is only supposed to be called once, and after that removes itself. However, the range-based for loop is not suitable for this and causes a crash after the method returns due to the iterator now essentially being invalid. Also, see https://stackoverflow.com/questions/8234779/how-to-remove-from-a-map-while-iterating-it/8234813

The second commit adds some cleanup, it isn't actually required but makes things clearer. Can be easily dropped if not preferred

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->

Currently only tested with the default multirotor. Also tested by starting and stopping the play and using debug statements to make sure that things are working correctly and no extra items are added to the array

## Screenshots (if appropriate):