### PR TITLE
PythonClient: replace time.clock with time.time

### DIFF
--- a/PythonClient/multirotor/opencv_show.py
+++ b/PythonClient/multirotor/opencv_show.py
@@ -48,7 +48,7 @@ textSize, baseline = cv2.getTextSize("FPS", fontFace, fontScale, thickness)
 print (textSize)
 textOrg = (10, 10 + textSize[1])
 frameCount = 0
-startTime=time.clock()
+startTime=time.time()
 fps = 0
 
 while True:
@@ -63,7 +63,7 @@ while True:
         cv2.imshow("Depth", png)
 
     frameCount  = frameCount  + 1
-    endTime=time.clock()
+    endTime=time.time()
     diff = endTime - startTime
     if (diff > 1):
         fps = frameCount


### PR DESCRIPTION
## About
This allows to run the opencv_show.py example even on Ubuntu 20.04 with Python3.8+ as time.clock() got deprecated.

## How Has This Been Tested?
Tested on Ubuntu 20.04