### PR TITLE
Avoid using deprecated git clone with basic auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ cmake_install.cmake
 CMakeCache.txt
 
 #Unreal Engine
+/UnrealEngine
 StarterContent/
 Saved/
 !DefaultEditorPerProjectUserSettings.ini #contains use less CPU setting

--- a/docs/build_linux.md
+++ b/docs/build_linux.md
@@ -22,7 +22,7 @@ Please see instructions [here](https://github.com/Microsoft/AirSim/blob/master/d
 
 ```bash
 # go to the folder where you clone GitHub projects
-git clone -b 4.25 https://github.com/EpicGames/UnrealEngine.git
+git clone -b 4.25 git@github.com:EpicGames/UnrealEngine.git
 cd UnrealEngine
 ./Setup.sh
 ./GenerateProjectFiles.sh

--- a/install_unreal.sh
+++ b/install_unreal.sh
@@ -23,7 +23,7 @@ fi
 
 #install unreal
 if [[ !(-d "$UnrealDir") ]]; then
-	git clone -b 4.25 https://github.com/EpicGames/UnrealEngine.git "$UnrealDir"
+	git clone -b 4.25 git@github.com:EpicGames/UnrealEngine.git "$UnrealDir"
 	pushd "$UnrealDir" >/dev/null
 
 	./Setup.sh


### PR DESCRIPTION
GitHub is complaining if you try to clone UnrealEngine, which requires
you to authenticate into GitHub:

```
You recently used a password to access the repository at EpicGames/UnrealEngine with git using git/2.25.1.

Basic authentication using a password to Git is deprecated and will soon no longer work. Visit https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/ for more information around suggested workarounds and removal dates.
```

Also adding the default install location for UnrealEngine to .gitignore