### PR TITLE
Add moveByVelocityZBodyFrame

### DIFF
--- a/AirLib/include/vehicles/multirotor/api/MultirotorApiBase.hpp
+++ b/AirLib/include/vehicles/multirotor/api/MultirotorApiBase.hpp
@@ -90,6 +90,7 @@ public: //these APIs uses above low level APIs
     virtual bool goHome(float timeout_sec);
 
     virtual bool moveByVelocityBodyFrame(float vx, float vy, float vz, float duration, DrivetrainType drivetrain, const YawMode& yaw_mode);
+    virtual bool moveByVelocityZBodyFrame(float vx, float vy, float z, float duration, DrivetrainType drivetrain, const YawMode& yaw_mode);
     virtual bool moveByMotorPWMs(float front_right_pwm, float rear_left_pwm, float front_left_pwm, float rear_right_pwm, float duration);
     virtual bool moveByRollPitchYawZ(float roll, float pitch, float yaw, float z, float duration);
     virtual bool moveByRollPitchYawThrottle(float roll, float pitch, float yaw, float throttle, float duration);

--- a/AirLib/include/vehicles/multirotor/api/MultirotorRpcLibClient.hpp
+++ b/AirLib/include/vehicles/multirotor/api/MultirotorRpcLibClient.hpp
@@ -25,6 +25,8 @@ public:
 
     MultirotorRpcLibClient* moveByVelocityBodyFrameAsync(float vx, float vy, float vz, float duration,
         DrivetrainType drivetrain = DrivetrainType::MaxDegreeOfFreedom, const YawMode& yaw_mode = YawMode(), const std::string& vehicle_name = "");
+    MultirotorRpcLibClient* moveByVelocityZBodyFrameAsync(float vx, float vy, float z, float duration,
+        DrivetrainType drivetrain = DrivetrainType::MaxDegreeOfFreedom, const YawMode& yaw_mode = YawMode(), const std::string& vehicle_name = "");
     MultirotorRpcLibClient* moveByMotorPWMsAsync(float front_right_pwm, float rear_left_pwm, float front_left_pwm, float rear_right_pwm, float duration, const std::string& vehicle_name = "");
     MultirotorRpcLibClient* moveByRollPitchYawZAsync(float roll, float pitch, float yaw, float z, float duration, const std::string& vehicle_name = "");
     MultirotorRpcLibClient* moveByRollPitchYawThrottleAsync(float roll, float pitch, float yaw, float throttle, float duration, const std::string& vehicle_name = "");

--- a/AirLib/src/vehicles/multirotor/api/MultirotorApiBase.cpp
+++ b/AirLib/src/vehicles/multirotor/api/MultirotorApiBase.cpp
@@ -75,13 +75,14 @@ bool MultirotorApiBase::goHome(float timeout_sec)
 bool MultirotorApiBase::moveByVelocityBodyFrame(float vx, float vy, float vz, float duration, DrivetrainType drivetrain, const YawMode& yaw_mode)
 {
     SingleTaskCall lock(this);
+
+    if (duration <= 0)
+        return true;
+
     float pitch, roll, yaw;
     VectorMath::toEulerianAngle(getKinematicsEstimated().pose.orientation, pitch, roll, yaw);
     float vx_new = (vx * (float)std::cos(yaw)) - (vy * (float)std::sin(yaw));
     float vy_new = (vx * (float)std::sin(yaw)) + (vy * (float)std::cos(yaw));
-    
-    if (duration <= 0)
-        return true;
     
     YawMode adj_yaw_mode(yaw_mode.is_rate, yaw_mode.yaw_or_rate);
     adjustYaw(vx_new, vy_new, drivetrain, adj_yaw_mode);
@@ -95,13 +96,14 @@ bool MultirotorApiBase::moveByVelocityBodyFrame(float vx, float vy, float vz, fl
 bool MultirotorApiBase::moveByVelocityZBodyFrame(float vx, float vy, float z, float duration, DrivetrainType drivetrain, const YawMode& yaw_mode)
 {
     SingleTaskCall lock(this);
+
+    if (duration <= 0)
+        return true;
+
     float pitch, roll, yaw;
     VectorMath::toEulerianAngle(getKinematicsEstimated().pose.orientation, pitch, roll, yaw);
     float vx_new = (vx * (float)std::cos(yaw)) - (vy * (float)std::sin(yaw));
     float vy_new = (vx * (float)std::sin(yaw)) + (vy * (float)std::cos(yaw));
-
-    if (duration <= 0)
-        return true;
 
     YawMode adj_yaw_mode(yaw_mode.is_rate, yaw_mode.yaw_or_rate);
     adjustYaw(vx_new, vy_new, drivetrain, adj_yaw_mode);

--- a/AirLib/src/vehicles/multirotor/api/MultirotorApiBase.cpp
+++ b/AirLib/src/vehicles/multirotor/api/MultirotorApiBase.cpp
@@ -91,6 +91,27 @@ bool MultirotorApiBase::moveByVelocityBodyFrame(float vx, float vy, float vz, fl
         return false; //keep moving until timeout
         }, duration).isTimeout();
 }
+
+bool MultirotorApiBase::moveByVelocityZBodyFrame(float vx, float vy, float z, float duration, DrivetrainType drivetrain, const YawMode& yaw_mode)
+{
+    SingleTaskCall lock(this);
+    float pitch, roll, yaw;
+    VectorMath::toEulerianAngle(getKinematicsEstimated().pose.orientation, pitch, roll, yaw);
+    float vx_new = (vx * (float)std::cos(yaw)) - (vy * (float)std::sin(yaw));
+    float vy_new = (vx * (float)std::sin(yaw)) + (vy * (float)std::cos(yaw));
+
+    if (duration <= 0)
+        return true;
+
+    YawMode adj_yaw_mode(yaw_mode.is_rate, yaw_mode.yaw_or_rate);
+    adjustYaw(vx_new, vy_new, drivetrain, adj_yaw_mode);
+
+    return waitForFunction([&]() {
+        moveByVelocityZInternal(vx_new, vy_new, z, adj_yaw_mode);
+        return false; //keep moving until timeout
+        }, duration).isTimeout();
+}
+
 bool MultirotorApiBase::moveByMotorPWMs(float front_right_pwm, float rear_left_pwm, float front_left_pwm, float rear_right_pwm, float duration)
 {
     SingleTaskCall lock(this);

--- a/AirLib/src/vehicles/multirotor/api/MultirotorRpcLibClient.cpp
+++ b/AirLib/src/vehicles/multirotor/api/MultirotorRpcLibClient.cpp
@@ -83,6 +83,14 @@ MultirotorRpcLibClient* MultirotorRpcLibClient::moveByVelocityBodyFrameAsync(flo
     return this;
 }
 
+MultirotorRpcLibClient* MultirotorRpcLibClient::moveByVelocityZBodyFrameAsync(float vx, float vy, float z, float duration,
+    DrivetrainType drivetrain, const YawMode& yaw_mode, const std::string& vehicle_name)
+{
+    pimpl_->last_future = static_cast<rpc::client*>(getClient())->async_call("moveByVelocityZBodyFrame", vx, vy, z, duration,
+        drivetrain, MultirotorRpcLibAdapators::YawMode(yaw_mode), vehicle_name);
+    return this;
+}
+
 MultirotorRpcLibClient* MultirotorRpcLibClient::moveByMotorPWMsAsync(float front_right_pwm, float rear_left_pwm, float front_left_pwm, float rear_right_pwm, float duration, const std::string& vehicle_name)
 {
     pimpl_->last_future = static_cast<rpc::client*>(getClient())->async_call("moveByMotorPWMs", front_right_pwm, rear_left_pwm, front_left_pwm, rear_right_pwm, duration, vehicle_name);

--- a/AirLib/src/vehicles/multirotor/api/MultirotorRpcLibServer.cpp
+++ b/AirLib/src/vehicles/multirotor/api/MultirotorRpcLibServer.cpp
@@ -59,6 +59,11 @@ MultirotorRpcLibServer::MultirotorRpcLibServer(ApiProvider* api_provider, string
         return getVehicleApi(vehicle_name)->moveByVelocityBodyFrame(vx, vy, vz, duration, drivetrain, yaw_mode.to());
     });
     (static_cast<rpc::server*>(getServer()))->
+        bind("moveByVelocityZBodyFrame", [&](float vx, float vy, float z, float duration, DrivetrainType drivetrain,
+            const MultirotorRpcLibAdapators::YawMode& yaw_mode, const std::string& vehicle_name) -> bool {
+        return getVehicleApi(vehicle_name)->moveByVelocityZBodyFrame(vx, vy, z, duration, drivetrain, yaw_mode.to());
+    });
+    (static_cast<rpc::server*>(getServer()))->
         bind("moveByMotorPWMs", [&](float front_right_pwm, float rear_left_pwm, float front_left_pwm, float rear_right_pwm, float duration, const std::string& vehicle_name) ->
         bool { return getVehicleApi(vehicle_name)->moveByMotorPWMs(front_right_pwm, rear_left_pwm, front_left_pwm, rear_right_pwm, duration);
     });

--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -934,6 +934,20 @@ class MultirotorClient(VehicleClient, object):
         return self.client.call_async('moveByVelocityBodyFrame', vx, vy, vz, duration, drivetrain, yaw_mode, vehicle_name)
 
     def moveByVelocityZBodyFrameAsync(self, vx, vy, z, duration, drivetrain = DrivetrainType.MaxDegreeOfFreedom, yaw_mode = YawMode(), vehicle_name = ''):
+        """
+        Args:
+            vx (float): desired velocity in the X axis of the vehicle's local NED frame
+            vy (float): desired velocity in the Y axis of the vehicle's local NED frame
+            z (float): desired Z value (in local NED frame of the vehicle)
+            duration (float): Desired amount of time (seconds), to send this command for
+            drivetrain (DrivetrainType, optional):
+            yaw_mode (YawMode, optional):
+            vehicle_name (str, optional): Name of the multirotor to send this command to
+
+        Returns:
+            msgpackrpc.future.Future: future. call .join() to wait for method to finish. Example: client.METHOD().join()
+        """
+
         return self.client.call_async('moveByVelocityZBodyFrame', vx, vy, z, duration, drivetrain, yaw_mode, vehicle_name)
 
     def moveByAngleZAsync(self, pitch, roll, z, yaw, duration, vehicle_name = ''):

--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -932,7 +932,10 @@ class MultirotorClient(VehicleClient, object):
             msgpackrpc.future.Future: future. call .join() to wait for method to finish. Example: client.METHOD().join()
         """
         return self.client.call_async('moveByVelocityBodyFrame', vx, vy, vz, duration, drivetrain, yaw_mode, vehicle_name)
-        
+
+    def moveByVelocityZBodyFrameAsync(self, vx, vy, z, duration, drivetrain = DrivetrainType.MaxDegreeOfFreedom, yaw_mode = YawMode(), vehicle_name = ''):
+        return self.client.call_async('moveByVelocityZBodyFrame', vx, vy, z, duration, drivetrain, yaw_mode, vehicle_name)
+
     def moveByAngleZAsync(self, pitch, roll, z, yaw, duration, vehicle_name = ''):
         return self.client.call_async('moveByAngleZ', pitch, roll, z, yaw, duration, vehicle_name)
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #3476 
<!-- Fixes: # -->

## About
To be consistent, I propose to add function `moveByVelocityZBodyFrame` to Multirotor API.

Indeed, the function `moveByVelocity` has its associated `moveByVelocityBodyFrame`. It is not the case for the function `moveByVelocityZ`.

More over, I experienced a small problem with function `moveByVelocityBodyFrame` (when used to move in X-Y plane): multiple calls, separated by a small amount of time (for example, the time to process and analyze an image) leads the UAV to move downwards gradually.

A small video illustrating this problem is available here: [https://youtu.be/iiWdGzhMKqA](https://youtu.be/iiWdGzhMKqA).

The use of `moveByVelocityZ` solved this problem, but unfortunately its associated `moveByVelocityZBodyFrame` does not exist, so I propose to add it.

The implementation is (almost) exactly the same as this PR: #3169.

Usage: `moveByVelocityZBodyFrameAsync(vx, vy, z, duration, drivetrain (optional), yaw_mode (optional), vehicle_name (optional))`.

## How Has This Been Tested?
I used the modified version of the AirSim plugin in my Python project. I tested the function in multiple environments by simply moving the UAV using `moveByVelocityZBodyFrame` . The UAV successfully moves by velocity in its direction's X-Y frame.

A use case of my project is available here: [https://youtu.be/mODIlYtCzP8?t=15](https://youtu.be/mODIlYtCzP8?t=15).

In this example, the drone moves using `moveByVelocityZBodyFrame`. It can be seen that the drone stops very briefly from time to time to perform calculations and still keeps a constant altitude during its movement.

## Screenshots (if appropriate):

/