### PR TITLE
Fix drone shaking at high altitudes

### DIFF
--- a/AirLib/src/vehicles/multirotor/api/MultirotorApiBase.cpp
+++ b/AirLib/src/vehicles/multirotor/api/MultirotorApiBase.cpp
@@ -704,7 +704,7 @@ void MultirotorApiBase::moveToPathPosition(const Vector3r& dest, float velocity,
     //send commands
     //try to maintain altitude if path was in XY plan only, velocity based control is not as good
     if (std::abs(cur.z() - dest.z()) <= getDistanceAccuracy()) //for paths in XY plan current code leaves z untouched, so we can compare with strict equality
-        moveByVelocityZInternal(velocity_vect.x(), velocity_vect.y(), dest.z(), yaw_mode);
+        moveByVelocityInternal(velocity_vect.x(), velocity_vect.y(), 0, yaw_mode);
     else
         moveByVelocityInternal(velocity_vect.x(), velocity_vect.y(), velocity_vect.z(), yaw_mode);
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #1394
Fixes: #2802

## About
Updates MultirotorApiBase.cpp to use the velocity PID with target z velocity 0 when we are close to our goal altitude to fix drone shaking. Thank you @ACLeighner for finding this fix!

## How Has This Been Tested?
A test script was used that calls moveToPositionAsync to send the drone to an altitude of 60m then flies the drone in a square path to observe the shaking described in #1394.

## Screenshots (if appropriate):