### PR TITLE
Add quick tip for syncing image API with physics state

### DIFF
--- a/docs/image_apis.md
+++ b/docs/image_apis.md
@@ -88,6 +88,8 @@ airsim.write_png(os.path.normpath(filename + '.png'), img_rgb)
     ```
     You can also save float array to .pfm file (Portable Float Map format) using `airsim.write_pfm()` function.
 
+- If you are looking to query position and orientation information in sync with a call to one of the image APIs, you can use `client.simPause(True)` and `client.simPause(False)` to pause the simulation while calling the image API and querying the desired physics state, ensuring that the physics state remains the same immediately after the image API call.
+
 ### C++
 
 ```cpp


### PR DESCRIPTION


<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #1494

## About
Update image_apis.md to add quick tip for capturing physics state in sync with a call to an image API.

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->

## Screenshots (if appropriate):