### PR TITLE
Fix compile error due to rename of RpcLibAdaptors

### DIFF
--- a/AirLib/src/vehicles/multirotor/api/MultirotorRpcLibClient.cpp
+++ b/AirLib/src/vehicles/multirotor/api/MultirotorRpcLibClient.cpp
@@ -87,7 +87,7 @@ MultirotorRpcLibClient* MultirotorRpcLibClient::moveByVelocityZBodyFrameAsync(fl
     DrivetrainType drivetrain, const YawMode& yaw_mode, const std::string& vehicle_name)
 {
     pimpl_->last_future = static_cast<rpc::client*>(getClient())->async_call("moveByVelocityZBodyFrame", vx, vy, z, duration,
-        drivetrain, MultirotorRpcLibAdapators::YawMode(yaw_mode), vehicle_name);
+        drivetrain, MultirotorRpcLibAdaptors::YawMode(yaw_mode), vehicle_name);
     return this;
 }
 

--- a/AirLib/src/vehicles/multirotor/api/MultirotorRpcLibServer.cpp
+++ b/AirLib/src/vehicles/multirotor/api/MultirotorRpcLibServer.cpp
@@ -60,7 +60,7 @@ MultirotorRpcLibServer::MultirotorRpcLibServer(ApiProvider* api_provider, string
     });
     (static_cast<rpc::server*>(getServer()))->
         bind("moveByVelocityZBodyFrame", [&](float vx, float vy, float z, float duration, DrivetrainType drivetrain,
-            const MultirotorRpcLibAdapators::YawMode& yaw_mode, const std::string& vehicle_name) -> bool {
+            const MultirotorRpcLibAdaptors::YawMode& yaw_mode, const std::string& vehicle_name) -> bool {
         return getVehicleApi(vehicle_name)->moveByVelocityZBodyFrame(vx, vy, z, duration, drivetrain, yaw_mode.to());
     });
     (static_cast<rpc::server*>(getServer()))->


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
https://github.com/microsoft/AirSim/pull/3475 didn't fit well after https://github.com/microsoft/AirSim/pull/3477, the PR build passed since it was before #3477 got merged.

Noticed when the [latest master build](https://github.com/microsoft/AirSim/runs/2176583536) failed

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->

## Screenshots (if appropriate):