### PR TITLE
Update airsim ros docs to fix settings.json link

### DIFF
--- a/docs/airsim_ros_pkgs.md
+++ b/docs/airsim_ros_pkgs.md
@@ -54,7 +54,7 @@ Let's look at the ROS API for both nodes:
 ### AirSim ROS Wrapper Node
 #### Publishers:
 - `/airsim_node/origin_geo_point` [airsim_ros_pkgs/GPSYaw](https://github.com/microsoft/AirSim/tree/master/ros/src/airsim_ros_pkgs/msg/GPSYaw.msg)   
-GPS coordinates corresponding to global NED frame. This is set in the airsim's [settings.json](https://microsoft.github.io/AirSim/docs/settings/) file under the `OriginGeopoint` key. 
+GPS coordinates corresponding to global NED frame. This is set in the airsim's [settings.json](https://microsoft.github.io/AirSim/settings/) file under the `OriginGeopoint` key. 
   
 - `/airsim_node/VEHICLE_NAME/global_gps` [sensor_msgs/NavSatFix](https://docs.ros.org/api/sensor_msgs/html/msg/NavSatFix.html)   
 This the current GPS coordinates of the drone in airsim. 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
This PR just fixes a link on [AirSim ros packages doc page](https://microsoft.github.io/AirSim/airsim_ros_pkgs/), which should point to [AirSim settings doc page](https://microsoft.github.io/AirSim/settings/).

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
The broken link was returning 404 error before. Now the fixed link points to correct page.

## Screenshots (if appropriate):