### PR TITLE
Add iter to unpack Vector3r, Quaternionr and Pose

### DIFF
--- a/PythonClient/airsim/types.py
+++ b/PythonClient/airsim/types.py
@@ -136,6 +136,8 @@ class Vector3r(MsgpackMixin):
     def to_numpy_array(self):
         return np.array([self.x_val, self.y_val, self.z_val], dtype=np.float32)
 
+    def __iter__(self):
+        return iter((self.x_val, self.y_val, self.z_val))
 
 class Quaternionr(MsgpackMixin):
     w_val = 0.0
@@ -226,14 +228,16 @@ class Quaternionr(MsgpackMixin):
     def to_numpy_array(self):
         return np.array([self.x_val, self.y_val, self.z_val, self.w_val], dtype=np.float32)
 
+    def __iter__(self):
+        return iter((self.x_val, self.y_val, self.z_val, self.w_val))
 
 class Pose(MsgpackMixin):
     position = Vector3r()
     orientation = Quaternionr()
 
     def __init__(self, position_val = None, orientation_val = None):
-        position_val = position_val if position_val != None else Vector3r()
-        orientation_val = orientation_val if orientation_val != None else Quaternionr()
+        position_val = position_val if position_val is not None else Vector3r()
+        orientation_val = orientation_val if orientation_val is not None else Quaternionr()
         self.position = position_val
         self.orientation = orientation_val
 
@@ -244,6 +248,8 @@ class Pose(MsgpackMixin):
     def containsNan(self):
         return (self.position.containsNan() or self.orientation.containsNan())
 
+    def __iter__(self):
+        return iter((self.position, self.orientation))
 
 class CollisionInfo(MsgpackMixin):
     has_collided = False
@@ -451,7 +457,7 @@ class PIDGains():
     """
     Struct to store values of PID gains. Used to transmit controller gain values while instantiating
     AngleLevel/AngleRate/Velocity/PositionControllerGains objects.
-    
+
     Attributes:
         kP (float): Proportional gain
         kI (float): Integrator gain
@@ -468,7 +474,7 @@ class PIDGains():
 class AngleRateControllerGains():
     """
     Struct to contain controller gains used by angle level PID controller
-    
+
     Attributes:
         roll_gains (PIDGains): kP, kI, kD for roll axis
         pitch_gains (PIDGains): kP, kI, kD for pitch axis
@@ -480,14 +486,14 @@ class AngleRateControllerGains():
         self.roll_gains = roll_gains
         self.pitch_gains = pitch_gains
         self.yaw_gains = yaw_gains
-    
+
     def to_lists(self):
         return [self.roll_gains.kp, self.pitch_gains.kp, self.yaw_gains.kp], [self.roll_gains.ki, self.pitch_gains.ki, self.yaw_gains.ki], [self.roll_gains.kd, self.pitch_gains.kd, self.yaw_gains.kd]
 
 class AngleLevelControllerGains():
     """
     Struct to contain controller gains used by angle rate PID controller
-    
+
     Attributes:
         roll_gains (PIDGains): kP, kI, kD for roll axis
         pitch_gains (PIDGains): kP, kI, kD for pitch axis
@@ -499,14 +505,14 @@ class AngleLevelControllerGains():
         self.roll_gains = roll_gains
         self.pitch_gains = pitch_gains
         self.yaw_gains = yaw_gains
-    
+
     def to_lists(self):
         return [self.roll_gains.kp, self.pitch_gains.kp, self.yaw_gains.kp], [self.roll_gains.ki, self.pitch_gains.ki, self.yaw_gains.ki], [self.roll_gains.kd, self.pitch_gains.kd, self.yaw_gains.kd]
 
 class VelocityControllerGains():
     """
     Struct to contain controller gains used by velocity PID controller
-    
+
     Attributes:
         x_gains (PIDGains): kP, kI, kD for X axis
         y_gains (PIDGains): kP, kI, kD for Y axis
@@ -518,14 +524,14 @@ class VelocityControllerGains():
         self.x_gains = x_gains
         self.y_gains = y_gains
         self.z_gains = z_gains
-    
+
     def to_lists(self):
         return [self.x_gains.kp, self.y_gains.kp, self.z_gains.kp], [self.x_gains.ki, self.y_gains.ki, self.z_gains.ki], [self.x_gains.kd, self.y_gains.kd, self.z_gains.kd]
 
 class PositionControllerGains():
     """
     Struct to contain controller gains used by position PID controller
-    
+
     Attributes:
         x_gains (PIDGains): kP, kI, kD for X axis
         y_gains (PIDGains): kP, kI, kD for Y axis
@@ -537,7 +543,7 @@ class PositionControllerGains():
         self.x_gains = x_gains
         self.y_gains = y_gains
         self.z_gains = z_gains
-    
+
     def to_lists(self):
         return [self.x_gains.kp, self.y_gains.kp, self.z_gains.kp], [self.x_gains.ki, self.y_gains.ki, self.z_gains.ki], [self.x_gains.kd, self.y_gains.kd, self.z_gains.kd]
 


### PR DESCRIPTION
## About
Implements `__iter__` for `Vector3r`, `Quaternionr` and `Pose` so that the `*` operator can be used for [unpacking](https://www.python.org/dev/peps/pep-0448/#abstract).

This leads to some "quality of life" improvements since it removes the need to call `.x_val`, `.y_val`, etc. separately when we want to extract the components from a vector or quaternion.

Currently, this unpacking behavior can only be achieved by first calling `.to_numpy_array()`. However, this leads to the following error when used with `moveToPositionAsync`:
```
AttributeError: 'numpy.float32' object has no attribute 'to_msgpack'
```

## How Has This Been Tested?
The following test program illustrates the changes this introduces:
```python
import time
import airsim

def main():
    client = airsim.MultirotorClient()
    client.confirmConnection()
    client.enableApiControl(True)
    client.armDisarm(True)

    try:
        while True:
            pose = client.simGetVehiclePose()
            position, orientation = pose  # unpacks Pose into a Vector3r and a Quaternionr
            new_position = position + airsim.Vector3r(0, 0, -2)

            print("1:", position)   # prints a Vector3r
            print("2:", *position)  # unpacks the Vector3r's x_val, y_val and z_val components
            x, y, z = position      # ditto
            print("3:", x, y, z)    # this has the same result as the previous call to print

            # thus, we can now get the same result of doing:
            print("4:", orientation.x_val, orientation.y_val, orientation.z_val, orientation.w_val)
            # by simply using the * operator:
            print("5:", *orientation)

            # furthermore, this allows calling functions that expect separate x, y, z values:
            client.moveToPositionAsync(*new_position, velocity=2).join()

            # which currently do not work if we try to unpack the return of to_numpy_array,
            # with "AttributeError: 'numpy.float32' object has no attribute 'to_msgpack'":
            # # client.moveToPositionAsync(*new_position.to_numpy_array(), velocity=2).join()

            client.hoverAsync().join()
            time.sleep(1)
            print()
    except KeyboardInterrupt:
        client.reset()

if __name__ == "__main__":
    main()
```

## Screenshots:
Output from the test program listed above:
![image](https://user-images.githubusercontent.com/13294013/112481051-615aa880-8d55-11eb-8387-7ba3ab554179.png)
