### PR TITLE
Change frame_id of ROS camera_info message

### DIFF
--- a/ros/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
+++ b/ros/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
@@ -1455,7 +1455,7 @@ sensor_msgs::CameraInfo AirsimROSWrapper::generate_cam_info(const std::string& c
                                                             const CaptureSetting& capture_setting) const
 {
     sensor_msgs::CameraInfo cam_info_msg;
-    cam_info_msg.header.frame_id = camera_name + "/" + image_type_int_to_string_map_.at(capture_setting.image_type) + "_optical";
+    cam_info_msg.header.frame_id = camera_name + "_optical";
     cam_info_msg.height = capture_setting.height;
     cam_info_msg.width = capture_setting.width;
     float f_x = (capture_setting.width / 2.0) / tan(math_common::deg2rad(capture_setting.fov_degrees / 2.0));


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #3532    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
This pull request fixes the issue described in #3532. In short, it changes the `frame_id` field of [sensor_msgs/CameraInfo](https://docs.ros.org/api/sensor_msgs/html/msg/CameraInfo.html) messages that AirSim ROS wrapper publishes, in order to be consistent with ROS tf tree and `frame_id` field of [sensor_msgs/Image](https://docs.ros.org/api/sensor_msgs/html/msg/Image.html) messages.

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
This has been tested under following setup:
- AirSim Version/#commit: v1.4.0 - Linux / 6d20663e0818448613be0332009b02bd6341589e
- UE/Unity version: UE4 version 4.25.1
- autopilot version: N/A
- OS Version: Ubuntu 18.04

The reproducing steps described in #3532 is followed before and after this change, and observed that the `frame_id` field of [sensor_msgs/CameraInfo](https://docs.ros.org/api/sensor_msgs/html/msg/CameraInfo.html) message is changed from `MyCamera1/Scene_optical` to `MyCamera1_optical`.
