### PR TITLE
ROS: Use the same settings as AirSim 

### DIFF
--- a/AirLib/include/api/RpcLibClientBase.hpp
+++ b/AirLib/include/api/RpcLibClientBase.hpp
@@ -120,6 +120,8 @@ public:
 
     void simSetWind(const Vector3r& wind) const;
 
+    std::string getSettingsString() const;
+
 protected:
     void* getClient();
     const void* getClient() const;

--- a/AirLib/include/api/WorldSimApiBase.hpp
+++ b/AirLib/include/api/WorldSimApiBase.hpp
@@ -79,6 +79,8 @@ public:
     virtual bool isRecording() const = 0;
 
     virtual void setWind(const Vector3r& wind) const = 0;
+
+    virtual std::string getSettingsString() const = 0;
 };
 
 

--- a/AirLib/include/common/AirSimSettings.hpp
+++ b/AirLib/include/common/AirSimSettings.hpp
@@ -377,6 +377,8 @@ public: //fields
     std::map<std::string, std::unique_ptr<SensorSetting>> sensor_defaults;
     Vector3r wind = Vector3r::Zero();
 
+    std::string settings_text_ = "";
+
 public: //methods
     static AirSimSettings& singleton()
     {
@@ -417,6 +419,7 @@ public: //methods
 
     static void initializeSettings(const std::string& json_settings_text)
     {
+        singleton().settings_text_ = json_settings_text;
         Settings& settings_json = Settings::loadJSonString(json_settings_text);
         if (! settings_json.isLoadSuccess())
             throw std::invalid_argument("Cannot parse JSON settings_json string.");
@@ -424,12 +427,14 @@ public: //methods
 
     static void createDefaultSettingsFile()
     {
-        std::string settings_filename = Settings::getUserDirectoryFullPath("settings.json");
-        Settings& settings_json = Settings::loadJSonString("{}");
+        initializeSettings("{}");
+
+        Settings& settings_json = Settings::singleton();
         //write some settings_json in new file otherwise the string "null" is written if all settings_json are empty
         settings_json.setString("SeeDocsAt", "https://github.com/Microsoft/AirSim/blob/master/docs/settings.md");
         settings_json.setDouble("SettingsVersion", 1.2);
 
+        std::string settings_filename = Settings::getUserDirectoryFullPath("settings.json");
         //TODO: there is a crash in Linux due to settings_json.saveJSonString(). Remove this workaround after we only support Unreal 4.17
         //https://answers.unrealengine.com/questions/664905/unreal-crashes-on-two-lines-of-extremely-simple-st.html
         settings_json.saveJSonFile(settings_filename);

--- a/AirLib/src/api/RpcLibClientBase.cpp
+++ b/AirLib/src/api/RpcLibClientBase.cpp
@@ -470,6 +470,11 @@ void RpcLibClientBase::simSetWind(const Vector3r& wind) const
     pimpl_->client.call("simSetWind", conv_wind);
 }
 
+std::string RpcLibClientBase::getSettingsString() const
+{
+    return pimpl_->client.call("getSettingsString").as<std::string>();
+}
+
 void* RpcLibClientBase::getClient()
 {
     return &pimpl_->client;

--- a/AirLib/src/api/RpcLibServerBase.cpp
+++ b/AirLib/src/api/RpcLibServerBase.cpp
@@ -383,6 +383,10 @@ RpcLibServerBase::RpcLibServerBase(ApiProvider* api_provider, const std::string&
         getWorldSimApi()->setWind(wind.to());
     });
 
+    pimpl_->server.bind("getSettingsString", [&]() -> std::string {
+        return getWorldSimApi()->getSettingsString();
+    });
+
     //if we don't suppress then server will bomb out for exceptions raised by any method
     pimpl_->server.suppress_exceptions(true);
 }

--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -872,6 +872,15 @@ class VehicleClient:
         """
         return self.client.call('simAddVehicle', vehicle_name, vehicle_type, pose, pawn_path)
 
+    def getSettingsString(self):
+        """
+        Fetch the settings text being used by AirSim
+
+        Returns:
+            str: Settings text in JSON format
+        """
+        return self.client.call('getSettingsString')
+
 # -----------------------------------  Multirotor APIs ---------------------------------------------
 class MultirotorClient(VehicleClient, object):
     def __init__(self, ip = "", port = 41451, timeout_value = 3600):

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.cpp
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.cpp
@@ -202,5 +202,10 @@ bool WorldSimApi::addVehicle(const std::string& vehicle_name, const std::string&
     return false;
 }
 
+std::string WorldSimApi::getSettingsString() const
+{
+    return msr::airlib::AirSimSettings::singleton().settings_text_;
+}
+
 
 #pragma endregion

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.h
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.h
@@ -66,6 +66,8 @@ public:
     virtual bool createVoxelGrid(const Vector3r& position, const int& x_size, const int& y_size, const int& z_size, const float& res, const std::string& output_file) override;
     virtual bool addVehicle(const std::string& vehicle_name, const std::string& vehicle_type, const Pose& pose, const std::string& pawn_path = "") override;
 
+    virtual std::string getSettingsString() const override;
+
 private:
 	SimModeBase * simmode_;
 	std::string vehicle_name_;

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
@@ -573,3 +573,8 @@ void WorldSimApi::setWind(const Vector3r& wind) const
 {
     simmode_->setWind(wind);
 }
+
+std::string WorldSimApi::getSettingsString() const
+{
+    return msr::airlib::AirSimSettings::singleton().settings_text_;
+}

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.h
@@ -70,6 +70,8 @@ public:
     virtual void setWind(const Vector3r& wind) const override;
     virtual bool createVoxelGrid(const Vector3r& position, const int& x_size, const int& y_size, const int& z_size, const float& res, const std::string& output_file) override;
 
+    virtual std::string getSettingsString() const override;
+
 private:
     AActor* createNewActor(const FActorSpawnParameters& spawn_params, const FTransform& actor_transform, const Vector3r& scale, UStaticMesh* static_mesh);
     void spawnPlayer();

--- a/ros/src/airsim_ros_pkgs/include/airsim_ros_wrapper.h
+++ b/ros/src/airsim_ros_pkgs/include/airsim_ros_wrapper.h
@@ -319,7 +319,6 @@ private:
     msr::airlib::GeoPoint origin_geo_point_;// gps coord of unreal origin 
     airsim_ros_pkgs::GPSYaw origin_geo_point_msg_; // todo duplicate
 
-    std::vector<VehicleSetting> vehicle_setting_vec_;
     AirSimSettingsParser airsim_settings_parser_;
     std::unordered_map< std::string, std::unique_ptr< VehicleROS > > vehicle_name_ptr_map_;
     static const std::unordered_map<int, std::string> image_type_int_to_string_map_;

--- a/ros/src/airsim_ros_pkgs/include/airsim_settings_parser.h
+++ b/ros/src/airsim_ros_pkgs/include/airsim_settings_parser.h
@@ -17,20 +17,19 @@ class AirSimSettingsParser
 {
 public:
     typedef msr::airlib::AirSimSettings AirSimSettings;
-    typedef msr::airlib::AirSimSettings::VehicleSetting VehicleSetting;
 
 public:
-    AirSimSettingsParser();
+    AirSimSettingsParser(const std::string& host_ip);
     ~AirSimSettingsParser() {};
 
     bool success();
 
 private:
     std::string getSimMode();
-    bool readSettingsTextFromFile(std::string settingsFilepath, std::string& settingsText);
-    bool getSettingsText(std::string& settingsText);
+    bool getSettingsText(std::string& settings_text) const;
     bool initializeSettings();
 
     bool success_;
-    std::string settingsText_;
+    std::string settings_text_;
+    std::string host_ip_;
 };

--- a/ros/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
+++ b/ros/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
@@ -34,13 +34,14 @@ AirsimROSWrapper::AirsimROSWrapper(const ros::NodeHandle& nh, const ros::NodeHan
     host_ip_(host_ip),
     airsim_client_images_(host_ip),
     airsim_client_lidar_(host_ip),
+    airsim_settings_parser_(host_ip),
     tf_listener_(tf_buffer_)
 {
     ros_clock_.clock.fromSec(0);
     is_used_lidar_timer_cb_queue_ = false;
     is_used_img_timer_cb_queue_ = false;
 
-    if (AirSimSettings::singleton().simmode_name != "Car")
+    if (AirSimSettings::singleton().simmode_name != AirSimSettings::kSimModeTypeCar)
     {
         airsim_mode_ = AIRSIM_MODE::DRONE;
         ROS_INFO("Setting ROS wrapper to DRONE mode");
@@ -68,7 +69,7 @@ void AirsimROSWrapper::initialize_airsim()
         }
         else
         {
-            airsim_client_ = std::move(std::unique_ptr<msr::airlib::RpcLibClientBase>(new msr::airlib::CarRpcLibClient(host_ip_)));
+            airsim_client_ = std::unique_ptr<msr::airlib::RpcLibClientBase>(new msr::airlib::CarRpcLibClient(host_ip_));
         }
         airsim_client_->confirmConnection();
         airsim_client_images_.confirmConnection();
@@ -189,7 +190,7 @@ void AirsimROSWrapper::create_ros_pubs_from_settings_json()
         {
             auto& camera_setting = curr_camera_elem.second;
             auto& curr_camera_name = curr_camera_elem.first;
-            // vehicle_setting_vec_.push_back(*vehicle_setting.get());
+
             set_nans_to_zeros_in_pose(*vehicle_setting, camera_setting);
             append_static_camera_tf(vehicle_ros.get(), curr_camera_name, camera_setting);
             // camera_setting.gimbal


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #3530    <!-- add this line for each issue your PR solves. -->
Fixes: #3464
Fixes: #2415
Others: #2365, #2009
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
This adds an API to get the settings text which is being used by AirSim. The API is then used by the ROS wrapper to fetch the settings text and uses it to instantiate its own settings.
This felt like the cleaner way to fix the problem at its root, it'll avoid requiring the same logic to search for the settings.json file, and now doesn't matter if Airsim and the ROS wrapper are running in different machines. 

Any suggestions on a better way to implement this would be great!

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->

## Screenshots (if appropriate):