### PR TITLE
remove duplicate definition of ImageType class

### DIFF
--- a/PythonClient/airsim/types.py
+++ b/PythonClient/airsim/types.py
@@ -19,17 +19,6 @@ class MsgpackMixin:
         #return cls(**msgpack.unpack(encoded))
         return obj
 
-
-class ImageType:
-    Scene = 0
-    DepthPlanar = 1
-    DepthPerspective = 2
-    DepthVis = 3
-    DisparityNormalized = 4
-    Segmentation = 5
-    SurfaceNormals = 6
-    Infrared = 7
-
 class _ImageType(type):
     @property
     def Scene(cls):
@@ -55,7 +44,14 @@ class _ImageType(type):
             raise AttributeError
 
 class ImageType(metaclass=_ImageType):
-    pass
+    Scene = 0
+    DepthPlanar = 1
+    DepthPerspective = 2
+    DepthVis = 3
+    DisparityNormalized = 4
+    Segmentation = 5
+    SurfaceNormals = 6
+    Infrared = 7
 
 class DrivetrainType:
     MaxDegreeOfFreedom = 0


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #3533
Fixes: #3553
Related to: #3550 

## About
This PR addresses an error where accessing fields in the ImageType class would generate an error: "AttributeError: 'function' object has no attribute 'to_msgpack'". The fix is to remove a duplicate definition of the ImageType class in types.py

## How Has This Been Tested?
hello_drone.py script was run and confirmed to complete execution without error

## Screenshots (if appropriate):