### PR TITLE
Fix drone starting paused in packaged version

### DIFF
--- a/AirLib/include/common/common_utils/ScheduledExecutor.hpp
+++ b/AirLib/include/common/common_utils/ScheduledExecutor.hpp
@@ -31,7 +31,7 @@ public:
         callback_ = callback;
         period_nanos_ = period_nanos;
         started_ = false;
-
+        frame_countdown_enabled_ = false;
     }
 
     void start()


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #3607
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
This PR addresses an issue where the drone will start paused when launching a packaged version of AirSim. The root cause of this issue is an uninitialized member variable in ScheduledExecutor. This fix adds initialization of the frame_countdown_enabled_ member variable in the ScheduledExecutor class.

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
A packaged version containing this fix was launched and the drone was confirmed to be moving via running 'commander takeoff' and 'commander land' commands in PX4.

## Screenshots (if appropriate):