### PR TITLE
Return sensor data as const references rather than by value

### DIFF
--- a/AirLib/include/api/VehicleApiBase.hpp
+++ b/AirLib/include/api/VehicleApiBase.hpp
@@ -88,11 +88,11 @@ Some methods may not be applicable to specific vehicle in which case an exceptio
         }
 
         /*
-    For RCs, there are two cases: (1) vehicle may be configured to use
-    RC bound to its hardware (2) vehicle may be configured to get RC data
-    supplied via API calls. Below two APIs are not symmetrical, i.e.,
-    getRCData() may or may not return same thing as setRCData().
-    */
+        For RCs, there are two cases: (1) vehicle may be configured to use
+        RC bound to its hardware (2) vehicle may be configured to get RC data
+        supplied via API calls. Below two APIs are not symmetrical, i.e.,
+        getRCData() may or may not return same thing as setRCData().
+        */
         //get reading from RC bound to vehicle (if unsupported then RCData::is_valid = false)
         virtual RCData getRCData() const
         {
@@ -114,7 +114,7 @@ Some methods may not be applicable to specific vehicle in which case an exceptio
         }
 
         // Lidar APIs
-        virtual LidarData getLidarData(const std::string& lidar_name) const
+        virtual const LidarData& getLidarData(const std::string& lidar_name) const
         {
             auto* lidar = static_cast<const LidarBase*>(findSensorByName(lidar_name, SensorBase::SensorType::Lidar));
             if (lidar == nullptr)
@@ -124,7 +124,7 @@ Some methods may not be applicable to specific vehicle in which case an exceptio
         }
 
         // IMU API
-        virtual ImuBase::Output getImuData(const std::string& imu_name) const
+        virtual const ImuBase::Output& getImuData(const std::string& imu_name) const
         {
             auto* imu = static_cast<const ImuBase*>(findSensorByName(imu_name, SensorBase::SensorType::Imu));
             if (imu == nullptr)
@@ -134,7 +134,7 @@ Some methods may not be applicable to specific vehicle in which case an exceptio
         }
 
         // Barometer API
-        virtual BarometerBase::Output getBarometerData(const std::string& barometer_name) const
+        virtual const BarometerBase::Output& getBarometerData(const std::string& barometer_name) const
         {
             auto* barometer = static_cast<const BarometerBase*>(findSensorByName(barometer_name, SensorBase::SensorType::Barometer));
             if (barometer == nullptr)
@@ -144,7 +144,7 @@ Some methods may not be applicable to specific vehicle in which case an exceptio
         }
 
         // Magnetometer API
-        virtual MagnetometerBase::Output getMagnetometerData(const std::string& magnetometer_name) const
+        virtual const MagnetometerBase::Output& getMagnetometerData(const std::string& magnetometer_name) const
         {
             auto* magnetometer = static_cast<const MagnetometerBase*>(findSensorByName(magnetometer_name, SensorBase::SensorType::Magnetometer));
             if (magnetometer == nullptr)
@@ -154,7 +154,7 @@ Some methods may not be applicable to specific vehicle in which case an exceptio
         }
 
         // Gps API
-        virtual GpsBase::Output getGpsData(const std::string& gps_name) const
+        virtual const GpsBase::Output& getGpsData(const std::string& gps_name) const
         {
             auto* gps = static_cast<const GpsBase*>(findSensorByName(gps_name, SensorBase::SensorType::Gps));
             if (gps == nullptr)
@@ -164,7 +164,7 @@ Some methods may not be applicable to specific vehicle in which case an exceptio
         }
 
         // Distance Sensor API
-        virtual DistanceSensorData getDistanceSensorData(const std::string& distance_sensor_name) const
+        virtual const DistanceSensorData& getDistanceSensorData(const std::string& distance_sensor_name) const
         {
             auto* distance_sensor = static_cast<const DistanceBase*>(findSensorByName(distance_sensor_name, SensorBase::SensorType::Distance));
             if (distance_sensor == nullptr)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
This PR changes the sensor data fetch methods to return `const Output&` rather than `Output`. This avoids a copy when the methods are being used, even in the call is like - `const auto& data = getImuData()`, e.g. in [ArduCopterApi.hpp](https://github.com/microsoft/AirSim/blob/0b936af5d76a856f8cc4d5abf9b9f1a61cbeca85/AirLib/include/vehicles/multirotor/firmwares/arducopter/ArduCopterApi.hpp#L346), [MavlinkMultiRotorApi.hpp](https://github.com/microsoft/AirSim/blob/0b936af5d76a856f8cc4d5abf9b9f1a61cbeca85/AirLib/include/vehicles/multirotor/firmwares/mavlink/MavLinkMultirotorApi.hpp#L106). The copy of LidarData in particular will be more expensive

Note that a copy is still created if the method is called like - `auto data = getImuData()`

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
This is supposed to be NFC, but will try to get some testing done later or tomorrow

I wrote a simple test script to check whether copies are occurring -

<details>
<summary> test.cpp </summary>

```cpp
#include <iostream>

using namespace std;

class A {
public:
	int x;

	A() {
		cout << "Normal constructor" << endl;
	}
	
	A(const A& a) {
		cout << "Copy constructor" << endl;
	}
	
	~A() {
		cout << "Destructor" << endl;
	}
};

class B {
public:
	A a;
	
	A getA() {
//	const A& getA() {
		return a;
	}
};

A createA() {
	A a;
	return a;
}

int main() {
//	auto a1 = createA();
	B b;
	const auto& a2 = b.getA();
	return 0;
}
```
</details>

Try playing around with this and see what happens, the behaviour before and after the PR can be tested by modifying the return type of `B::getA()` and the line `const auto& a2 = b.getA();`

Before PR:
`A getA() {`, `const auto& a2 = b.getA();`
Output: 
```
Normal constructor
Copy constructor
Destructor
Destructor
```

After PR:
`const A& getA() {`, `const auto& a2 = b.getA();`
```
Normal constructor
Destructor
```

The `createA()` method shows the effect of Return Value Optimization, where a copy isn't made even when return type and value are both `A` rather than refs. It only kicks in if the data to be returned is to be destroyed at the end.

Update:

Here's a more updated script, which more accurately reflects how things are working -

<details>
<summary> test2.cpp </summary>

```cpp
#include <iostream>

using namespace std;

class A {
public:
	int x;

	A() {
		cout << "Normal constructor" << endl;
	}
	
	A(const A& a) {
		cout << "Copy constructor" << endl;
	}
	
	~A() {
		cout << "Destructor" << endl;
	}
};

class B {
public:
	A a;
	
//	A getA() {
	const A& getA() {
		return a;
	}
};

A createA() {
	A a;
	return a;
}

A getAfromB(B& b) {
	return b.getA();
}

int main() {
//	auto a1 = createA();
	B b;
//	const auto& a2 = b.getA();
	const auto& a3 = getAfromB(b);
	return 0;
}
```

</details>

`a3` is a const ref, `B::getA()` also returns a const ref, but `getAfromB()` returns by value, output -
```
Normal constructor
Copy constructor
Destructor
Destructor
```

Change to `const A& getAfromB(B& b)` -
```
Normal constructor
Destructor
```

## Screenshots (if appropriate):