### PR TITLE
Fix incorrect parsing of CameraDirector settings

### DIFF
--- a/AirLib/include/common/AirSimSettings.hpp
+++ b/AirLib/include/common/AirSimSettings.hpp
@@ -1153,8 +1153,8 @@ namespace airlib
 
             Settings child_json;
             if (settings_json.getChild("CameraDirector", child_json)) {
-                camera_director.position = createVectorSetting(settings_json, camera_director.position);
-                camera_director.rotation = createRotationSetting(settings_json, camera_director.rotation);
+                camera_director.position = createVectorSetting(child_json, camera_director.position);
+                camera_director.rotation = createRotationSetting(child_json, camera_director.rotation);
                 camera_director.follow_distance = child_json.getFloat("FollowDistance", camera_director.follow_distance);
             }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

<!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->

I found an issue in the parsing of the `CameraDirector` settings. It seems to use the wrong JSON object for parsing the position and rotation.

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->

The change compiles and fixes the problem. It now correctly parses the position and rotation.

