### PR TITLE
remove waitOnLastTask method from Python API

### DIFF
--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -794,20 +794,6 @@ class VehicleClient:
         """
         self.client.call('cancelLastTask', vehicle_name)
 
-    def waitOnLastTask(self, timeout_sec = float('nan')):
-        """
-        Wait for the last Async task to complete
-
-        Args:
-            timeout_sec (float, optional): Time for the task to complete
-
-        Returns:
-            bool: Result of the last task
-
-                  True if the task completed without cancellation or timeout
-        """
-        return self.client.call('waitOnLastTask', timeout_sec)
-
     # Recording APIs
     def startRecording(self):
         """


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
Remove waitOnLastTask method from Python client API. It's not actually implemented on the server side (ie: the method currently throws an error) and most of the functionality can be obtained from the futures that the async methods provide. 

## How Has This Been Tested?
The python API still seems to be functional? Since this is just removing an already broken method, this change is hopefully low risk.

## Screenshots (if appropriate):