### PR TITLE
Fix OverrideExisting implementation for Segmentation settings

### DIFF
--- a/AirLib/include/common/AirSimSettings.hpp
+++ b/AirLib/include/common/AirSimSettings.hpp
@@ -946,7 +946,7 @@ namespace airlib
                     //TODO: below exception doesn't actually get raised right now because of issue in Unreal Engine?
                     throw std::invalid_argument(std::string("SegmentationSetting init_method has invalid value in settings_json ") + init_method);
 
-                segmentation_setting.override_existing = json_parent.getBool("OverrideExisting", false);
+                segmentation_setting.override_existing = json_parent.getBool("OverrideExisting", true);
 
                 std::string mesh_naming_method = Utils::toLower(json_parent.getString("MeshNamingMethod", ""));
                 if (mesh_naming_method == "" || mesh_naming_method == "ownername")

--- a/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
+++ b/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
@@ -354,20 +354,20 @@ std::string UAirBlueprintLib::GetMeshName(ALandscapeProxy* mesh)
     return std::string(TCHAR_TO_UTF8(*(mesh->GetName())));
 }
 
-void UAirBlueprintLib::InitializeMeshStencilIDs(bool ignore_existing)
+void UAirBlueprintLib::InitializeMeshStencilIDs(bool override_existing)
 {
     for (TObjectIterator<UStaticMeshComponent> comp; comp; ++comp) {
-        InitializeObjectStencilID(*comp, ignore_existing);
+        InitializeObjectStencilID(*comp, override_existing);
     }
     for (TObjectIterator<USkinnedMeshComponent> comp; comp; ++comp) {
-        InitializeObjectStencilID(*comp, ignore_existing);
+        InitializeObjectStencilID(*comp, override_existing);
     }
     //for (TObjectIterator<UFoliageType> comp; comp; ++comp)
     //{
     //    InitializeObjectStencilID(*comp);
     //}
     for (TObjectIterator<ALandscapeProxy> comp; comp; ++comp) {
-        InitializeObjectStencilID(*comp, ignore_existing);
+        InitializeObjectStencilID(*comp, override_existing);
     }
 }
 

--- a/Unreal/Plugins/AirSim/Source/AirBlueprintLib.h
+++ b/Unreal/Plugins/AirSim/Source/AirBlueprintLib.h
@@ -101,7 +101,7 @@ public:
     static bool SetMeshStencilID(const std::string& mesh_name, int object_id,
                                  bool is_name_regex = false);
     static int GetMeshStencilID(const std::string& mesh_name);
-    static void InitializeMeshStencilIDs(bool ignore_existing);
+    static void InitializeMeshStencilIDs(bool override_existing);
 
     static bool IsInGameThread();
 
@@ -199,7 +199,7 @@ public:
 
 private:
     template <typename T>
-    static void InitializeObjectStencilID(T* mesh, bool ignore_existing = true)
+    static void InitializeObjectStencilID(T* mesh, bool override_existing = true)
     {
         std::string mesh_name = common_utils::Utils::toLower(GetMeshName(mesh));
         if (mesh_name == "" || common_utils::Utils::startsWith(mesh_name, "default_")) {
@@ -214,7 +214,7 @@ private:
                 continue; //numerics and other punctuations
             hash += char_num;
         }
-        if (ignore_existing || mesh->CustomDepthStencilValue == 0) { //if value is already set then don't bother
+        if (override_existing || mesh->CustomDepthStencilValue == 0) { //if value is already set then don't bother
             SetObjectStencilID(mesh, hash % 256);
         }
     }

--- a/Unreal/Plugins/AirSim/Source/AirBlueprintLib.h
+++ b/Unreal/Plugins/AirSim/Source/AirBlueprintLib.h
@@ -201,6 +201,13 @@ private:
     template <typename T>
     static void InitializeObjectStencilID(T* mesh, bool override_existing = true)
     {
+        SetRenderCustomDepth(mesh, true);
+
+        if (!override_existing && mesh->CustomDepthStencilValue != 0) {
+            // If value is non-zero and don't want to override
+            return;
+        }
+
         std::string mesh_name = common_utils::Utils::toLower(GetMeshName(mesh));
         if (mesh_name == "" || common_utils::Utils::startsWith(mesh_name, "default_")) {
             //common_utils::Utils::DebugBreak();
@@ -214,9 +221,8 @@ private:
                 continue; //numerics and other punctuations
             hash += char_num;
         }
-        if (override_existing || mesh->CustomDepthStencilValue == 0) { //if value is already set then don't bother
-            SetObjectStencilID(mesh, hash % 256);
-        }
+
+        SetObjectStencilID(mesh, hash % 256);
     }
 
     template <typename T>
@@ -268,6 +274,21 @@ private:
                 comp->SetCustomDepthStencilValue(object_id);
                 comp->SetRenderCustomDepth(true);
             }
+        }
+    }
+
+    template <typename T>
+    static void SetRenderCustomDepth(T* mesh, bool enable)
+    {
+        mesh->SetRenderCustomDepth(enable);
+    }
+
+    static void SetRenderCustomDepth(ALandscapeProxy* mesh, bool enable)
+    {
+        mesh->bRenderCustomDepth = enable;
+
+        for (ULandscapeComponent* comp : mesh->LandscapeComponents) {
+            comp->SetRenderCustomDepth(enable);
         }
     }
 

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
@@ -180,7 +180,7 @@ void ASimModeBase::setStencilIDs()
 
     if (getSettings().segmentation_setting.init_method ==
         AirSimSettings::SegmentationSetting::InitMethodType::CommonObjectsRandomIDs) {
-        UAirBlueprintLib::InitializeMeshStencilIDs(!getSettings().segmentation_setting.override_existing);
+        UAirBlueprintLib::InitializeMeshStencilIDs(getSettings().segmentation_setting.override_existing);
     }
     //else don't init
 }

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -139,7 +139,7 @@ Below are complete list of settings available along with their default values. I
   "SegmentationSettings": {
     "InitMethod": "",
     "MeshNamingMethod": "",
-    "OverrideExisting": false
+    "OverrideExisting": true
   },
   "PawnPaths": {
     "BareboneCar": {"PawnBP": "Class'/AirSim/VehicleAdv/Vehicle/VehicleAdvPawn.VehicleAdvPawn_C'"},


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #3710    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->

Override means Ignoring, and not the other way around. This PR fixes the inversion, and changes the variable name to be more clear. The Settings default also gets changed to reflect the behaviour

The second commit fixes the segmentation when override is set to false at beginning

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
If override is true -
![segmentation_override_true](https://user-images.githubusercontent.com/37938604/121796803-65ea7b00-cc39-11eb-8aba-6e8906903066.png)

Override false with custom stencil value -
![final_override_false_working](https://user-images.githubusercontent.com/37938604/121796824-86b2d080-cc39-11eb-9724-eae1c32dc7b2.png)

If override is set to false when running for first time in Editor, the segmentation was blank
![segmentation_override_false](https://user-images.githubusercontent.com/37938604/121796884-1789ac00-cc3a-11eb-8502-d968d3819d8c.png)

Changing the override to true and then false fixed that.

The latest commit fixes that behaviour, and segmentation is correct at startup as well
![override_false_initial_working](https://user-images.githubusercontent.com/37938604/121796899-3be58880-cc3a-11eb-9624-ae6df8de7e54.png)

## Screenshots (if appropriate):

Pasted above