### PR TITLE
Use default sensors for default vehicle

### DIFF
--- a/AirLib/include/common/AirSimSettings.hpp
+++ b/AirLib/include/common/AirSimSettings.hpp
@@ -257,6 +257,15 @@ namespace airlib
             std::map<std::string, std::shared_ptr<SensorSetting>> sensors;
 
             RCSettings rc;
+
+            VehicleSetting()
+            {
+            }
+
+            VehicleSetting(const std::string& vehicle_name_val, const std::string& vehicle_type_val)
+                : vehicle_name(vehicle_name_val), vehicle_type(vehicle_type_val)
+            {
+            }
         };
 
         struct MavLinkConnectionInfo
@@ -450,12 +459,12 @@ namespace airlib
         // This is for the case when a new vehicle is made on the fly, at runtime
         void addVehicleSetting(const std::string& vehicle_name, const std::string& vehicle_type, const Pose& pose, const std::string& pawn_path = "")
         {
-            auto vehicle_setting = std::unique_ptr<VehicleSetting>(new VehicleSetting());
-
-            vehicle_setting->vehicle_name = vehicle_name;
-            vehicle_setting->vehicle_type = vehicle_type;
+            // No Mavlink-type vehicles currently
+            auto vehicle_setting = std::unique_ptr<VehicleSetting>(new VehicleSetting(vehicle_name, vehicle_type));
             vehicle_setting->position = pose.position;
             vehicle_setting->pawn_path = pawn_path;
+
+            vehicle_setting->sensors = sensor_defaults;
 
             VectorMath::toEulerianAngle(pose.orientation, vehicle_setting->rotation.pitch, vehicle_setting->rotation.roll, vehicle_setting->rotation.yaw);
 
@@ -819,7 +828,8 @@ namespace airlib
             return vehicle_setting;
         }
 
-        static void initializeVehicleSettings(const std::string& simmode_name, std::map<std::string, std::unique_ptr<VehicleSetting>>& vehicles)
+        static void createDefaultVehicle(const std::string& simmode_name, std::map<std::string, std::unique_ptr<VehicleSetting>>& vehicles,
+                                         const std::map<std::string, std::shared_ptr<SensorSetting>>& sensor_defaults)
         {
             vehicles.clear();
 
@@ -827,26 +837,24 @@ namespace airlib
             //to sync code in createVehicleSetting() as well.
             if (simmode_name == kSimModeTypeMultirotor) {
                 // create simple flight as default multirotor
-                auto simple_flight_setting = std::unique_ptr<VehicleSetting>(new VehicleSetting());
-                simple_flight_setting->vehicle_name = "SimpleFlight";
-                simple_flight_setting->vehicle_type = kVehicleTypeSimpleFlight;
+                auto simple_flight_setting = std::unique_ptr<VehicleSetting>(new VehicleSetting("SimpleFlight",
+                                                                                                kVehicleTypeSimpleFlight));
                 // TODO: we should be selecting remote if available else keyboard
                 // currently keyboard is not supported so use rc as default
                 simple_flight_setting->rc.remote_control_id = 0;
+                simple_flight_setting->sensors = sensor_defaults;
                 vehicles[simple_flight_setting->vehicle_name] = std::move(simple_flight_setting);
             }
             else if (simmode_name == kSimModeTypeCar) {
                 // create PhysX as default car vehicle
-                auto physx_car_setting = std::unique_ptr<VehicleSetting>(new VehicleSetting());
-                physx_car_setting->vehicle_name = "PhysXCar";
-                physx_car_setting->vehicle_type = kVehicleTypePhysXCar;
+                auto physx_car_setting = std::unique_ptr<VehicleSetting>(new VehicleSetting("PhysXCar", kVehicleTypePhysXCar));
+                physx_car_setting->sensors = sensor_defaults;
                 vehicles[physx_car_setting->vehicle_name] = std::move(physx_car_setting);
             }
             else if (simmode_name == kSimModeTypeComputerVision) {
                 // create default computer vision vehicle
-                auto cv_setting = std::unique_ptr<VehicleSetting>(new VehicleSetting());
-                cv_setting->vehicle_name = "ComputerVision";
-                cv_setting->vehicle_type = kVehicleTypeComputerVision;
+                auto cv_setting = std::unique_ptr<VehicleSetting>(new VehicleSetting("ComputerVision", kVehicleTypeComputerVision));
+                cv_setting->sensors = sensor_defaults;
                 vehicles[cv_setting->vehicle_name] = std::move(cv_setting);
             }
             else {
@@ -860,7 +868,7 @@ namespace airlib
                                         std::map<std::string, std::unique_ptr<VehicleSetting>>& vehicles,
                                         std::map<std::string, std::shared_ptr<SensorSetting>>& sensor_defaults)
         {
-            initializeVehicleSettings(simmode_name, vehicles);
+            createDefaultVehicle(simmode_name, vehicles, sensor_defaults);
 
             msr::airlib::Settings vehicles_child;
             if (settings_json.getChild("Vehicles", vehicles_child)) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
This fixes a behavioural change I came across while testing #3719 

Use the settings -
```json
{
    "SettingsVersion": 1.2,
    "SimMode": "Multirotor"
}
```

and try using one of the sensor APIs such as `getImuData()`, etc. It throws an rpc error. Here's the output from `HelloDrone` -

```
Exception raised by the API, something went wrong.
rpclib: function 'getBarometerData' (called with 2 arg(s)) threw an exception. The exception is not derived from std::exception. No further information available.
```

This should work however, and it does work in 1.4.0, I think the change is due to [this](https://github.com/microsoft/AirSim/commit/006d4e2ac54f31e33ed595c6cdfbe2d5483027fd#diff-8ac7352e75eab96519f4de88358272d3b4de89e4b343ff35f228c5d7c3fc79ee). This error won't occur if a vehicle is present, even without any settings

It also adds the default sensors for vehicles created using the `simAddVehicle` API. Earlier, using any sensor APIs for these vehicle results in an error, and succeeds after this PR.

I tried using `make_unique` but that is giving some strange linker errors with the ROS wrapper somehow - `/home/testuser/AirSim/ros/devel/.private/airsim_ros_pkgs/lib/libairsim_settings_parser.so: undefined reference to `msr::airlib::AirSimSettings::kVehicleTypePhysXCar'` so have removed that for now

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
Above settings, and HelloDrone,

 - Works with 1.4.0
 - Doesn't work with 1.5.0, master
 - Works after this PR

`simAddVehicle` - Added `client.getImuData(vehicle_name=vehicle_name)` in `add_drone.py`, doesn't work earlier, works with this PR 

## Screenshots (if appropriate):