### PR TITLE
PythonClient: Add __version__ attribute and use it to indicate version

### DIFF
--- a/PythonClient/airsim/__init__.py
+++ b/PythonClient/airsim/__init__.py
@@ -2,3 +2,4 @@ from .client import *
 from .utils import *
 from .types import *
 
+__version__ = "1.5.0"

--- a/PythonClient/docs/conf.py
+++ b/PythonClient/docs/conf.py
@@ -17,6 +17,7 @@ import sys
 sys.path.insert(0, os.path.abspath('..'))
 
 import sphinx_rtd_theme
+from airsim import __version__
 
 # -- Project information -----------------------------------------------------
 
@@ -25,9 +26,9 @@ copyright = u'2020, Shital Shah, Ratnesh Madaan, Sai Vemprala, Nicholas Gyde'
 author = u'Shital Shah, Ratnesh Madaan, Sai Vemprala, Nicholas Gyde'
 
 # The short X.Y version
-version = u''
+version = __version__
 # The full version, including alpha/beta/rc tags
-release = u'1.2.8'
+release = version
 
 
 # -- General configuration ---------------------------------------------------

--- a/PythonClient/setup.py
+++ b/PythonClient/setup.py
@@ -1,11 +1,12 @@
 import setuptools
+from airsim import __version__
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(
     name="airsim",
-    version="1.5.0",
+    version=__version__,
     author="Shital Shah",
     author_email="shitals@microsoft.com",
     description="Open source simulator based on Unreal Engine for autonomous vehicles from Microsoft AI & Research",


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #3634    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
Adds a `__version__` attribute to the airsim package, and uses it in `setup.py` and Sphinx `conf.py`.

This was done since the [API Reference Docs](https://microsoft.github.io/AirSim/api_docs/html/) title shows the version as 1.2.8. It could be updated in just `conf.py`, but that 2 places to be modified every time. Therefore added the `__version__` attribute which only needs to be modified once.

Idea from https://stackoverflow.com/questions/26141851/let-sphinx-use-version-from-setup-py

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->

Local airsim install -

```
>>> import airsim
>>> airsim.__version__
'1.5.0'
```

Docs with `mkdocs serve` shows the 1.5.0 version in the title as well.  I haven't seen any issues arising from this till now

## Screenshots (if appropriate):