### PR TITLE
Fix bug in UDP socket failing with WSAECONNRESET in the read thread

### DIFF
--- a/AirLib/include/vehicles/multirotor/firmwares/mavlink/MavLinkMultirotorApi.hpp
+++ b/AirLib/include/vehicles/multirotor/firmwares/mavlink/MavLinkMultirotorApi.hpp
@@ -514,6 +514,8 @@ namespace airlib
             unused(lookahead);
             unused(drivetrain);
 
+            checkValidVehicle();
+
             // save current manual, cruise, and max velocity parameters
             bool result = false;
             mavlinkcom::MavLinkParameter manual_velocity_parameter, cruise_velocity_parameter, max_velocity_parameter;

--- a/MavLinkCom/src/serial_com/UdpClientPort.cpp
+++ b/MavLinkCom/src/serial_com/UdpClientPort.cpp
@@ -126,6 +126,9 @@ public:
             remoteaddr.sin_port = 0;
         }
 
+        // This timeout is important as it allows the MavLinkConnection readPackets
+        // thread to iterate and notice the connection is now closed. This allows
+        // AirSim to shutdown properly when drone is not connected.
         struct timeval tv;
         tv.tv_sec = 1;
         tv.tv_usec = 0;

--- a/MavLinkCom/src/serial_com/UdpClientPort.cpp
+++ b/MavLinkCom/src/serial_com/UdpClientPort.cpp
@@ -87,8 +87,8 @@ public:
 
         bool found = false;
         struct addrinfo* result = NULL;
-        std::string serviceName = std::to_string(port);
-        int rc = getaddrinfo(ipAddress.c_str(), serviceName.c_str(), &hints, &result);
+        std::string service_name = std::to_string(port);
+        int rc = getaddrinfo(ipAddress.c_str(), service_name.c_str(), &hints, &result);
         if (rc != 0) {
             auto msg = Utils::stringf("UdpClientPort getaddrinfo failed with error: %d\n", rc);
             throw std::runtime_error(msg);
@@ -165,11 +165,11 @@ public:
     int reconnect()
     {
         // try and reconnect
-        std::string localHost = inet_ntoa(localaddr.sin_addr);
-        std::string remoteHost = remoteAddress();
-        int remotePort = ntohs(remoteaddr.sin_port);
-        int localPort = 0;
-        int rc = connect(localHost, localPort, remoteHost, remotePort);
+        std::string local_host = inet_ntoa(localaddr.sin_addr);
+        std::string remote_host = remoteAddress();
+        int local_port = 0;
+        int remote_port = ntohs(remoteaddr.sin_port);
+        int rc = connect(local_host, local_port, remote_host, remote_port);
         if (rc < 0) {
             GetSocketError();
         }
@@ -231,7 +231,7 @@ public:
     {
         sockaddr_in other;
 
-        int bytesRead = 0;
+        int bytes_read = 0;
         // try and receive something, up until port is closed anyway.
 
         while (!closed_) {

--- a/MavLinkCom/src/serial_com/UdpClientPort.cpp
+++ b/MavLinkCom/src/serial_com/UdpClientPort.cpp
@@ -126,6 +126,11 @@ public:
             remoteaddr.sin_port = 0;
         }
 
+        struct timeval tv;
+        tv.tv_sec = 1;
+        tv.tv_usec = 0;
+        setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<char*>(&tv), sizeof(tv));
+
         // bind socket to local address.
         socklen_t addrlen = sizeof(sockaddr_in);
         int rc = bind(sock, reinterpret_cast<sockaddr*>(&localaddr), addrlen);
@@ -242,6 +247,9 @@ public:
                 else if (hr == WSAEINTR) {
                     // skip this, it is was interrupted, and if user is closing the port closed_ will be true.
                     continue;
+                }
+                else if (hr == WSAETIMEDOUT) {
+                    // skip this, the receive just timed out, no problem, we'll try again later.
                 }
 #else
                 if (hr == EINTR) {

--- a/MavLinkCom/src/serial_com/UdpClientPort.cpp
+++ b/MavLinkCom/src/serial_com/UdpClientPort.cpp
@@ -171,19 +171,23 @@ public:
     int checkerror()
     {
         int hr = GetSocketError();
+        bool retry = false;
 #ifdef _WIN32
         if (hr == WSAECONNRESET) {
+            retry = true;
+        }
+#else
+        if (hr == ECONNREFUSED || hr == ENOTCONN) {
+            retry = true;
+        }
+#endif
+        if (retry) {
             close();
             retries_++;
             if (retries_ < max_retries_) {
                 return reconnect();
             }
         }
-#else
-        if (hr == ECONNREFUSED || hr == ENOTCONN) {
-            close();
-        }
-#endif
         return hr;
     }
 

--- a/MavLinkCom/src/serial_com/UdpClientPort.hpp
+++ b/MavLinkCom/src/serial_com/UdpClientPort.hpp
@@ -36,6 +36,7 @@ public:
     int remotePort();
 
 private:
+    void reconnect();
     class UdpSocketImpl;
     std::unique_ptr<UdpSocketImpl> impl_;
 };

--- a/PythonClient/multirotor/opencv_show.py
+++ b/PythonClient/multirotor/opencv_show.py
@@ -35,7 +35,7 @@ print (cameraTypeMap[cameraType])
 
 client = airsim.MultirotorClient()
 
-print("Connected: now whiled this script is running, you can open another")
+print("Connected: now while this script is running, you can open another")
 print("console and run a script that flies the drone and this script will")
 print("show the depth view while the drone is flying.")
 

--- a/PythonClient/multirotor/opencv_show.py
+++ b/PythonClient/multirotor/opencv_show.py
@@ -1,7 +1,7 @@
-# In settings.json first activate computer vision mode: 
+# In settings.json first activate computer vision mode:
 # https://github.com/Microsoft/AirSim/blob/master/docs/image_apis.md#computer-vision-mode
 
-import setup_path 
+import setup_path
 import airsim
 
 # requires Python 3.5.3 :: Anaconda 4.4.0
@@ -18,7 +18,7 @@ cameraType = "depth"
 for arg in sys.argv[1:]:
   cameraType = arg.lower()
 
-cameraTypeMap = { 
+cameraTypeMap = {
  "depth": airsim.ImageType.DepthVis,
  "segmentation": airsim.ImageType.Segmentation,
  "seg": airsim.ImageType.Segmentation,
@@ -27,17 +27,17 @@ cameraTypeMap = {
  "normals": airsim.ImageType.SurfaceNormals
 }
 
-if (not cameraType in cameraTypeMap):
+if (cameraType not in cameraTypeMap):
   printUsage()
   sys.exit(0)
 
 print (cameraTypeMap[cameraType])
 
 client = airsim.MultirotorClient()
-client.confirmConnection()
-client.enableApiControl(True)
-client.armDisarm(True)
-client.takeoffAsync().join()
+
+print("Connected: now whiled this script is running, you can open another")
+print("console and run a script that flies the drone and this script will")
+print("show the depth view while the drone is flying.")
 
 help = False
 
@@ -45,10 +45,10 @@ fontFace = cv2.FONT_HERSHEY_SIMPLEX
 fontScale = 0.5
 thickness = 2
 textSize, baseline = cv2.getTextSize("FPS", fontFace, fontScale, thickness)
-print (textSize)
+print(textSize)
 textOrg = (10, 10 + textSize[1])
 frameCount = 0
-startTime=time.time()
+startTime = time.time()
 fps = 0
 
 while True:
@@ -62,14 +62,14 @@ while True:
         cv2.putText(png,'FPS ' + str(fps),textOrg, fontFace, fontScale,(255,0,255),thickness)
         cv2.imshow("Depth", png)
 
-    frameCount  = frameCount  + 1
-    endTime=time.time()
+    frameCount = frameCount  + 1
+    endTime = time.time()
     diff = endTime - startTime
     if (diff > 1):
         fps = frameCount
         frameCount = 0
         startTime = endTime
-    
-    key = cv2.waitKey(1) & 0xFF;
+
+    key = cv2.waitKey(1) & 0xFF
     if (key == 27 or key == ord('q') or key == ord('x')):
-        break;
+        break


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #3698    <!-- add this line for each issue your PR solves. -->
Fixes: #2924

## About
Fix bug in UDP socket failing with WSAECONNRESET in the read thread if it tries to read to soon.  The fix is to put a retry count in the UdpClientPort where it automatically reconnects up to 10 times.  Also fixed a null ref crash on mav_vehicle_ that happens in some cases like if you kill px4 process while drone is flying.

## How Has This Been Tested?
Windows with PX4 in WSL2 and in WSL1 with latest PX4 master bits as of today (1.12.0)

## Screenshots (if appropriate):