### PR TITLE
add wrapper for line of sight APIs

### DIFF
--- a/AirLib/include/api/RpcLibClientBase.hpp
+++ b/AirLib/include/api/RpcLibClientBase.hpp
@@ -111,8 +111,8 @@ namespace airlib
         vector<ImageCaptureBase::ImageResponse> simGetImages(vector<ImageCaptureBase::ImageRequest> request, const std::string& vehicle_name = "");
         vector<uint8_t> simGetImage(const std::string& camera_name, ImageCaptureBase::ImageType type, const std::string& vehicle_name = "");
 
-        bool simTestLineOfSightToPoint(double lat, double lon, float alt, const std::string& vehicle_name = "");
-        bool simTestLineOfSightBetweenPoints(double lat1, double lon1, float alt1, double lat2, double lon2, float alt2);
+        bool simTestLineOfSightToPoint(const msr::airlib::GeoPoint& point, const std::string& vehicle_name = "");
+        bool simTestLineOfSightBetweenPoints(const msr::airlib::GeoPoint& point1, const msr::airlib::GeoPoint& point2);
         vector<msr::airlib::GeoPoint> simGetWorldExtents();
 
         vector<MeshPositionVertexBuffersResponse> simGetMeshPositionVertexBuffers();

--- a/AirLib/include/api/VehicleSimApiBase.hpp
+++ b/AirLib/include/api/VehicleSimApiBase.hpp
@@ -52,9 +52,9 @@ namespace airlib
         virtual std::vector<ImageCaptureBase::ImageResponse> getImages(const std::vector<ImageCaptureBase::ImageRequest>& request) const = 0;
         virtual std::vector<uint8_t> getImage(const std::string& camera_name, ImageCaptureBase::ImageType image_type) const = 0;
 
-        virtual bool testLineOfSightToPoint(GeoPoint& point) const = 0;
-        virtual bool testLineOfSightBetweenPoints(GeoPoint& point1, GeoPoint& point2) const = 0;
-        virtual void getWorldExtents(msr::airlib::GeoPoint& min, msr::airlib::GeoPoint& max) const = 0;
+        virtual bool testLineOfSightToPoint(const GeoPoint& point) const = 0;
+        virtual bool testLineOfSightBetweenPoints(const GeoPoint& point1, const GeoPoint& point2) const = 0;
+        virtual void getWorldExtents(GeoPoint& min, GeoPoint& max) const = 0;
 
         virtual Pose getPose() const = 0;
         virtual void setPose(const Pose& pose, bool ignore_collision) = 0;

--- a/AirLib/src/api/RpcLibClientBase.cpp
+++ b/AirLib/src/api/RpcLibClientBase.cpp
@@ -271,14 +271,14 @@ __pragma(warning(disable : 4239))
         }
 
         // Minor TODO: consider msgpack magic for GeoPoint, so we can have one arg instead of three
-        bool RpcLibClientBase::simTestLineOfSightToPoint(double lat, double lon, float alt, const std::string& vehicle_name)
+        bool RpcLibClientBase::simTestLineOfSightToPoint(const msr::airlib::GeoPoint& point, const std::string& vehicle_name)
         {
-            return pimpl_->client.call("simTestLineOfSightToPoint", lat, lon, alt, vehicle_name).as<bool>();
+            return pimpl_->client.call("simTestLineOfSightToPoint", RpcLibAdaptorsBase::GeoPoint(point), vehicle_name).as<bool>();
         }
 
-        bool RpcLibClientBase::simTestLineOfSightBetweenPoints(double lat1, double lon1, float alt1, double lat2, double lon2, float alt2)
+        bool RpcLibClientBase::simTestLineOfSightBetweenPoints(const msr::airlib::GeoPoint& point1, const msr::airlib::GeoPoint& point2)
         {
-            return pimpl_->client.call("simTestLineOfSightBetweenPoints", lat1, lon1, alt1, lat2, lon2, alt2).as<bool>();
+            return pimpl_->client.call("simTestLineOfSightBetweenPoints", RpcLibAdaptorsBase::GeoPoint(point1), RpcLibAdaptorsBase::GeoPoint(point2)).as<bool>();
         }
 
         vector<msr::airlib::GeoPoint> RpcLibClientBase::simGetWorldExtents()

--- a/AirLib/src/api/RpcLibServerBase.cpp
+++ b/AirLib/src/api/RpcLibServerBase.cpp
@@ -153,17 +153,12 @@ namespace airlib
             return getVehicleSimApi(vehicle_name)->getImage(camera_name, type);
         });
 
-        pimpl_->server.bind("simTestLineOfSightToPoint", [&](double lat, double lon, float alt, const std::string& vehicle_name) -> bool {
-            GeoPoint point(lat, lon, alt);
-
-            return getVehicleSimApi(vehicle_name)->testLineOfSightToPoint(point);
+        pimpl_->server.bind("simTestLineOfSightToPoint", [&](const RpcLibAdaptorsBase::GeoPoint& point, const std::string& vehicle_name) -> bool {
+            return getVehicleSimApi(vehicle_name)->testLineOfSightToPoint(point.to());
         });
 
-        pimpl_->server.bind("simTestLineOfSightBetweenPoints", [&](double lat1, double lon1, float alt1, double lat2, double lon2, float alt2) -> bool {
-            GeoPoint point1(lat1, lon1, alt1);
-            GeoPoint point2(lat2, lon2, alt2);
-
-            return getVehicleSimApi("")->testLineOfSightBetweenPoints(point1, point2);
+        pimpl_->server.bind("simTestLineOfSightBetweenPoints", [&](const RpcLibAdaptorsBase::GeoPoint& point1, const RpcLibAdaptorsBase::GeoPoint& point2) -> bool {
+            return getVehicleSimApi("")->testLineOfSightBetweenPoints(point1.to(), point2.to());
         });
 
         pimpl_->server.bind("simGetWorldExtents", [&]() -> vector<RpcLibAdaptorsBase::GeoPoint> {

--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -263,6 +263,48 @@ class VehicleClient:
         """
         responses_raw = self.client.call('simGetImages', requests, vehicle_name)
         return [ImageResponse.from_msgpack(response_raw) for response_raw in responses_raw]
+        
+    def simTestLineOfSightToPoint(self, lat, lon, alt, vehicle_name = ''):
+        """
+        Returns whether the target point is visible from the perspective of the inputted vehicle
+
+        Args:
+            lat (double): latitude of target point
+            lon (double): longitude of target point
+            alt (float): altitude of target point
+            vehicle_name (str, optional): Name of vehicle
+
+        Returns:
+            [bool]: Success
+        """
+        return self.client.call('simTestLineOfSightToPoint', lat, lon, alt, vehicle_name)
+        
+    def simTestLineOfSightBetweenPoints(self, lat1, lon1, alt1, lat2, lon2, alt2):
+        """
+        Returns whether the target point is visible from the perspective of the source point
+
+        Args:
+            lat1 (double): latitude of source point
+            lon1 (double): longitude of source point
+            alt1 (float): altitude of source point
+            lat2 (double): latitude of target point
+            lon2 (double): longitude of target point
+            alt2 (float): altitude of target point
+
+        Returns:
+            [bool]: Success
+        """
+        return self.client.call('simTestLineOfSightBetweenPoints', lat1, lon1, alt1, lat2, lon2, alt2)
+        
+    def simGetWorldExtents(self):
+        """
+        Returns a list of GeoPoints representing the minimum and maximum extents of the world
+
+        Returns:
+            list[GeoPoint]
+        """
+        responses_raw = self.client.call('simGetWorldExtents')
+        return [GeoPoint.from_msgpack(response_raw) for response_raw in responses_raw]
 
     def simRunConsoleCommand(self, command):
         """

--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -264,37 +264,31 @@ class VehicleClient:
         responses_raw = self.client.call('simGetImages', requests, vehicle_name)
         return [ImageResponse.from_msgpack(response_raw) for response_raw in responses_raw]
         
-    def simTestLineOfSightToPoint(self, lat, lon, alt, vehicle_name = ''):
+    def simTestLineOfSightToPoint(self, point, vehicle_name = ''):
         """
         Returns whether the target point is visible from the perspective of the inputted vehicle
 
         Args:
-            lat (double): latitude of target point
-            lon (double): longitude of target point
-            alt (float): altitude of target point
+            point (GeoPoint): target point
             vehicle_name (str, optional): Name of vehicle
 
         Returns:
             [bool]: Success
         """
-        return self.client.call('simTestLineOfSightToPoint', lat, lon, alt, vehicle_name)
+        return self.client.call('simTestLineOfSightToPoint', point, vehicle_name)
         
-    def simTestLineOfSightBetweenPoints(self, lat1, lon1, alt1, lat2, lon2, alt2):
+    def simTestLineOfSightBetweenPoints(self, point1, point2):
         """
         Returns whether the target point is visible from the perspective of the source point
 
         Args:
-            lat1 (double): latitude of source point
-            lon1 (double): longitude of source point
-            alt1 (float): altitude of source point
-            lat2 (double): latitude of target point
-            lon2 (double): longitude of target point
-            alt2 (float): altitude of target point
+            point1 (GeoPoint): source point
+            point2 (GeoPoint): target point
 
         Returns:
             [bool]: Success
         """
-        return self.client.call('simTestLineOfSightBetweenPoints', lat1, lon1, alt1, lat2, lon2, alt2)
+        return self.client.call('simTestLineOfSightBetweenPoints', point1, point2)
         
     def simGetWorldExtents(self):
         """

--- a/PythonClient/multirotor/line_of_sight.py
+++ b/PythonClient/multirotor/line_of_sight.py
@@ -18,10 +18,10 @@ print("home:\n%s" % home)
 target = home
 target.latitude -= 1
 
-result = client.simTestLineOfSightToPoint(target.latitude, target.longitude, target.altitude)
+result = client.simTestLineOfSightToPoint(target)
 print("test line of sight from vehicle to\n%s\n\t:%s" %(target, result))
 
-result = client.simTestLineOfSightBetweenPoints(home.latitude, home.longitude, home.altitude, target.latitude, target.longitude, target.altitude)
+result = client.simTestLineOfSightBetweenPoints(home, target)
 print("test line of sight from home to\n%s\n\t:%s" %(target, result))
 
 result = client.simGetWorldExtents()

--- a/PythonClient/multirotor/line_of_sight.py
+++ b/PythonClient/multirotor/line_of_sight.py
@@ -1,0 +1,34 @@
+import setup_path
+import airsim
+
+import numpy as np
+import os
+import tempfile
+import pprint
+import cv2
+
+# connect to the AirSim simulator
+client = airsim.MultirotorClient()
+client.confirmConnection()
+client.enableApiControl(True)
+
+home = client.getHomeGeoPoint()
+print("home:\n%s" % home)
+
+target = home
+target.latitude -= 1
+
+result = client.simTestLineOfSightToPoint(target.latitude, target.longitude, target.altitude)
+print("test line of sight from vehicle to\n%s\n\t:%s" %(target, result))
+
+result = client.simTestLineOfSightBetweenPoints(home.latitude, home.longitude, home.altitude, target.latitude, target.longitude, target.altitude)
+print("test line of sight from home to\n%s\n\t:%s" %(target, result))
+
+result = client.simGetWorldExtents()
+print("world extents:\n%s\n\t-\n%s" %(result[0], result[1]))
+
+client.reset()
+client.armDisarm(False)
+
+# that's enough fun for now. let's quit cleanly
+client.enableApiControl(False)

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/PawnSimApi.cpp
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/PawnSimApi.cpp
@@ -103,7 +103,7 @@ std::vector<PawnSimApi::DetectionInfo> PawnSimApi::getDetections(const std::stri
     return std::vector<DetectionInfo>();
 }
 
-bool PawnSimApi::testLineOfSightToPoint(msr::airlib::GeoPoint& point) const
+bool PawnSimApi::testLineOfSightToPoint(const msr::airlib::GeoPoint& point) const
 {
     unused(point);
 
@@ -114,7 +114,7 @@ bool PawnSimApi::testLineOfSightToPoint(msr::airlib::GeoPoint& point) const
     return false;
 }
 
-bool PawnSimApi::testLineOfSightBetweenPoints(msr::airlib::GeoPoint& point1, msr::airlib::GeoPoint& point2) const
+bool PawnSimApi::testLineOfSightBetweenPoints(const msr::airlib::GeoPoint& point1, const msr::airlib::GeoPoint& point2) const
 {
     unused(point1);
     unused(point2);

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/PawnSimApi.h
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/PawnSimApi.h
@@ -103,8 +103,8 @@ public:
     virtual void clearDetectionMeshNames(const std::string& camera_name, ImageCaptureBase::ImageType image_type) override;
     virtual std::vector<DetectionInfo> getDetections(const std::string& camera_name, ImageCaptureBase::ImageType image_type) const override;
 
-    virtual bool testLineOfSightToPoint(GeoPoint& point) const override;
-    virtual bool testLineOfSightBetweenPoints(GeoPoint& point1, GeoPoint& point2) const override;
+    virtual bool testLineOfSightToPoint(const msr::airlib::GeoPoint& point) const override;
+    virtual bool testLineOfSightBetweenPoints(const msr::airlib::GeoPoint& point1, const msr::airlib::GeoPoint& point2) const override;
     virtual void getWorldExtents(msr::airlib::GeoPoint& min, msr::airlib::GeoPoint& max) const override;
 
 private:

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
@@ -288,7 +288,7 @@ int PawnSimApi::getCameraCount()
     return cameras_.valsSize();
 }
 
-bool PawnSimApi::testLineOfSightToPoint(GeoPoint& lla) const
+bool PawnSimApi::testLineOfSightToPoint(const msr::airlib::GeoPoint& lla) const
 {
     bool hit;
 
@@ -331,7 +331,7 @@ bool PawnSimApi::testLineOfSightToPoint(GeoPoint& lla) const
     return !hit;
 }
 
-bool PawnSimApi::testLineOfSightBetweenPoints(GeoPoint& lla1, GeoPoint& lla2) const
+bool PawnSimApi::testLineOfSightBetweenPoints(const msr::airlib::GeoPoint& lla1, const msr::airlib::GeoPoint& lla2) const
 {
     bool hit;
 

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.h
@@ -122,8 +122,8 @@ public: //Unreal specific methods
     APIPCamera* getCamera(const std::string& camera_name);
     int getCameraCount();
 
-    virtual bool testLineOfSightToPoint(GeoPoint& point) const;
-    virtual bool testLineOfSightBetweenPoints(GeoPoint& point1, GeoPoint& point2) const;
+    virtual bool testLineOfSightToPoint(const msr::airlib::GeoPoint& point) const;
+    virtual bool testLineOfSightBetweenPoints(const msr::airlib::GeoPoint& point1, const msr::airlib::GeoPoint& point2) const;
     virtual void getWorldExtents(msr::airlib::GeoPoint& min, msr::airlib::GeoPoint& max) const;
 
     //if enabled, this would show some flares

--- a/docs/apis.md
+++ b/docs/apis.md
@@ -151,7 +151,7 @@ The `is_enabled` parameter must be `True` to enable time of day effect. If it is
 Other parameters are same as in [settings](settings.md#timeofday).
 
 ### Line-of-sight and world extent APIs
-To test line-of-sight in the sim from a vehicle to a point or between two points, see simTestLineOfSightToPoint(lat, lon, alt, vehicle_name) and simTestLineOfSightBetweenPoints(lat1, lon1, alt1, lat2, lon2, alt2), respectively.
+To test line-of-sight in the sim from a vehicle to a point or between two points, see simTestLineOfSightToPoint(point, vehicle_name) and simTestLineOfSightBetweenPoints(point1, point2), respectively.
 Sim world extent, in the form of a vector of two GeoPoints, can be retrieved using simGetWorldExtents().
 
 ### Weather APIs


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: n/a<!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
This PR adds wrappers for simTestLineOfSightToPoint, simTestLineOfSightBetweenPoints, and simGetWorldExtents. It also adds an example script for calling these APIs.<!-- Describe what your PR is about. -->

## How Has This Been Tested?
Example script was called and output was sanity checked.<!-- Please, describe how you have tested your changes to help us incorporate them. -->

## Screenshots (if appropriate):