### PR TITLE
change sign of gravity in IMU

### DIFF
--- a/AirLib/include/sensors/imu/ImuSimple.hpp
+++ b/AirLib/include/sensors/imu/ImuSimple.hpp
@@ -55,7 +55,7 @@ namespace airlib
             const GroundTruth& ground_truth = getGroundTruth();
 
             output.angular_velocity = ground_truth.kinematics->twist.angular;
-            output.linear_acceleration = ground_truth.kinematics->accelerations.linear - ground_truth.environment->getState().gravity;
+            output.linear_acceleration = ground_truth.kinematics->accelerations.linear + ground_truth.environment->getState().gravity;
             output.orientation = ground_truth.kinematics->pose.orientation;
 
             //acceleration is in world frame so transform to body frame


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #3074    <!-- add this line for each issue your PR solves. -->
https://github.com/microsoft/AirSim/issues/1154

## About
Since AirSim uses NED coordinates, we should be *adding* gravity to the z acceleration and not substracting it

## How Has This Been Tested?
After changing the sign of gravity, I attempted to use https://github.com/HKUST-Aerial-Robotics/VINS-Fusion on data I collected from AirSim and seem to get reasonable results

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/868618/122302627-59cc1b00-ced0-11eb-8737-9aa193cce711.png)

The dotted grey line is the ground truth and the solid blue line is the prediction