### PR TITLE
move line-of-sight APIs to WorldSimApi

### DIFF
--- a/AirLib/include/api/VehicleSimApiBase.hpp
+++ b/AirLib/include/api/VehicleSimApiBase.hpp
@@ -53,8 +53,6 @@ namespace airlib
         virtual std::vector<uint8_t> getImage(const std::string& camera_name, ImageCaptureBase::ImageType image_type) const = 0;
 
         virtual bool testLineOfSightToPoint(GeoPoint& point) const = 0;
-        virtual bool testLineOfSightBetweenPoints(GeoPoint& point1, GeoPoint& point2) const = 0;
-        virtual void getWorldExtents(msr::airlib::GeoPoint& min, msr::airlib::GeoPoint& max) const = 0;
 
         virtual Pose getPose() const = 0;
         virtual void setPose(const Pose& pose, bool ignore_collision) = 0;

--- a/AirLib/include/api/WorldSimApiBase.hpp
+++ b/AirLib/include/api/WorldSimApiBase.hpp
@@ -85,6 +85,9 @@ namespace airlib
         virtual vector<string> listVehicles() const = 0;
 
         virtual std::string getSettingsString() const = 0;
+
+        virtual bool testLineOfSightBetweenPoints(msr::airlib::GeoPoint& point1, msr::airlib::GeoPoint& point2) const = 0;
+        virtual void getWorldExtents(msr::airlib::GeoPoint& min, msr::airlib::GeoPoint& max) const = 0;
     };
 }
 } //namespace

--- a/AirLib/include/api/WorldSimApiBase.hpp
+++ b/AirLib/include/api/WorldSimApiBase.hpp
@@ -87,7 +87,7 @@ namespace airlib
         virtual std::string getSettingsString() const = 0;
 
         virtual bool testLineOfSightBetweenPoints(msr::airlib::GeoPoint& point1, msr::airlib::GeoPoint& point2) const = 0;
-        virtual void getWorldExtents(msr::airlib::GeoPoint& min, msr::airlib::GeoPoint& max) const = 0;
+        virtual vector<msr::airlib::GeoPoint> getWorldExtents() const = 0;
     };
 }
 } //namespace

--- a/AirLib/include/api/WorldSimApiBase.hpp
+++ b/AirLib/include/api/WorldSimApiBase.hpp
@@ -86,7 +86,7 @@ namespace airlib
 
         virtual std::string getSettingsString() const = 0;
 
-        virtual bool testLineOfSightBetweenPoints(msr::airlib::GeoPoint& point1, msr::airlib::GeoPoint& point2) const = 0;
+        virtual bool testLineOfSightBetweenPoints(const msr::airlib::GeoPoint& point1, const msr::airlib::GeoPoint& point2) const = 0;
         virtual vector<msr::airlib::GeoPoint> getWorldExtents() const = 0;
     };
 }

--- a/AirLib/src/api/RpcLibServerBase.cpp
+++ b/AirLib/src/api/RpcLibServerBase.cpp
@@ -163,13 +163,13 @@ namespace airlib
             GeoPoint point1(lat1, lon1, alt1);
             GeoPoint point2(lat2, lon2, alt2);
 
-            return getVehicleSimApi("")->testLineOfSightBetweenPoints(point1, point2);
+            return getWorldSimApi()->testLineOfSightBetweenPoints(point1, point2);
         });
 
         pimpl_->server.bind("simGetWorldExtents", [&]() -> vector<RpcLibAdaptorsBase::GeoPoint> {
             msr::airlib::GeoPoint min;
             msr::airlib::GeoPoint max;
-            getVehicleSimApi("")->getWorldExtents(min, max);
+            getWorldSimApi()->getWorldExtents(min, max);
             vector<RpcLibAdaptorsBase::GeoPoint> result;
             result.push_back(RpcLibAdaptorsBase::GeoPoint(min));
             result.push_back(RpcLibAdaptorsBase::GeoPoint(max));

--- a/AirLib/src/api/RpcLibServerBase.cpp
+++ b/AirLib/src/api/RpcLibServerBase.cpp
@@ -167,14 +167,11 @@ namespace airlib
         });
 
         pimpl_->server.bind("simGetWorldExtents", [&]() -> vector<RpcLibAdaptorsBase::GeoPoint> {
-            msr::airlib::GeoPoint min;
-            msr::airlib::GeoPoint max;
-            getWorldSimApi()->getWorldExtents(min, max);
-            vector<RpcLibAdaptorsBase::GeoPoint> result;
-            result.push_back(RpcLibAdaptorsBase::GeoPoint(min));
-            result.push_back(RpcLibAdaptorsBase::GeoPoint(max));
+            std::vector<msr::airlib::GeoPoint> result = getWorldSimApi()->getWorldExtents(); // Returns vector with min, max
+            std::vector<RpcLibAdaptorsBase::GeoPoint> conv_result;
 
-            return result;
+            RpcLibAdaptorsBase::from(result, conv_result);
+            return conv_result;
         });
 
         pimpl_->server.bind("simGetMeshPositionVertexBuffers", [&]() -> vector<RpcLibAdaptorsBase::MeshPositionVertexBuffersResponse> {

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/PawnSimApi.cpp
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/PawnSimApi.cpp
@@ -114,28 +114,6 @@ bool PawnSimApi::testLineOfSightToPoint(msr::airlib::GeoPoint& point) const
     return false;
 }
 
-bool PawnSimApi::testLineOfSightBetweenPoints(msr::airlib::GeoPoint& point1, msr::airlib::GeoPoint& point2) const
-{
-    unused(point1);
-    unused(point2);
-
-    throw std::invalid_argument(common_utils::Utils::stringf(
-                                    "testLineOfSightBetweenPoints is not supported on unity")
-                                    .c_str());
-
-    return false;
-}
-
-void PawnSimApi::getWorldExtents(msr::airlib::GeoPoint& min, msr::airlib::GeoPoint& max) const
-{
-    unused(min);
-    unused(max);
-
-    throw std::invalid_argument(common_utils::Utils::stringf(
-                                    "getWorldExtents is not supported on unity")
-                                    .c_str());
-}
-
 void PawnSimApi::OnCollision(msr::airlib::CollisionInfo collisionInfo)
 {
     state_.collision_info.has_collided = collisionInfo.has_collided;

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/PawnSimApi.h
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/PawnSimApi.h
@@ -104,8 +104,6 @@ public:
     virtual std::vector<DetectionInfo> getDetections(const std::string& camera_name, ImageCaptureBase::ImageType image_type) const override;
 
     virtual bool testLineOfSightToPoint(GeoPoint& point) const override;
-    virtual bool testLineOfSightBetweenPoints(GeoPoint& point1, GeoPoint& point2) const override;
-    virtual void getWorldExtents(msr::airlib::GeoPoint& min, msr::airlib::GeoPoint& max) const override;
 
 private:
     Params params_;

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.cpp
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.cpp
@@ -243,7 +243,7 @@ std::string WorldSimApi::getSettingsString() const
     return msr::airlib::AirSimSettings::singleton().settings_text_;
 }
 
-bool WorldSimApi::testLineOfSightBetweenPoints(msr::airlib::GeoPoint& point1, msr::airlib::GeoPoint& point2) const
+bool WorldSimApi::testLineOfSightBetweenPoints(const msr::airlib::GeoPoint& point1, const msr::airlib::GeoPoint& point2) const
 {
     unused(point1);
     unused(point2);
@@ -255,14 +255,15 @@ bool WorldSimApi::testLineOfSightBetweenPoints(msr::airlib::GeoPoint& point1, ms
     return false;
 }
 
-void WorldSimApi::getWorldExtents(msr::airlib::GeoPoint& min, msr::airlib::GeoPoint& max) const
+std::vector<msr::airlib::GeoPoint> WorldSimApi::getWorldExtents() const
 {
-    unused(min);
-    unused(max);
+    std::vector<msr::airlib::GeoPoint> result;
 
     throw std::invalid_argument(common_utils::Utils::stringf(
                                     "getWorldExtents is not supported on unity")
                                     .c_str());
+
+    return result;
 }
 
 #pragma endregion

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.cpp
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.cpp
@@ -243,4 +243,26 @@ std::string WorldSimApi::getSettingsString() const
     return msr::airlib::AirSimSettings::singleton().settings_text_;
 }
 
+bool WorldSimApi::testLineOfSightBetweenPoints(msr::airlib::GeoPoint& point1, msr::airlib::GeoPoint& point2) const
+{
+    unused(point1);
+    unused(point2);
+
+    throw std::invalid_argument(common_utils::Utils::stringf(
+                                    "testLineOfSightBetweenPoints is not supported on unity")
+                                    .c_str());
+
+    return false;
+}
+
+void WorldSimApi::getWorldExtents(msr::airlib::GeoPoint& min, msr::airlib::GeoPoint& max) const
+{
+    unused(min);
+    unused(max);
+
+    throw std::invalid_argument(common_utils::Utils::stringf(
+                                    "getWorldExtents is not supported on unity")
+                                    .c_str());
+}
+
 #pragma endregion

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.h
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.h
@@ -69,6 +69,9 @@ public:
 
     virtual std::string getSettingsString() const override;
 
+	virtual bool testLineOfSightBetweenPoints(msr::airlib::GeoPoint& point1, msr::airlib::GeoPoint& point2) const override;
+    virtual void getWorldExtents(msr::airlib::GeoPoint& min, msr::airlib::GeoPoint& max) const override;
+
 private:
     SimModeBase* simmode_;
     std::string vehicle_name_;

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.h
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.h
@@ -69,8 +69,8 @@ public:
 
     virtual std::string getSettingsString() const override;
 
-    virtual bool testLineOfSightBetweenPoints(msr::airlib::GeoPoint& point1, msr::airlib::GeoPoint& point2) const override;
-    virtual void getWorldExtents(msr::airlib::GeoPoint& min, msr::airlib::GeoPoint& max) const override;
+    virtual bool testLineOfSightBetweenPoints(const msr::airlib::GeoPoint& point1, const msr::airlib::GeoPoint& point2) const override;
+    virtual std::vector<msr::airlib::GeoPoint> getWorldExtents() const override;
 
 private:
     SimModeBase* simmode_;

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.h
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/WorldSimApi.h
@@ -69,7 +69,7 @@ public:
 
     virtual std::string getSettingsString() const override;
 
-	virtual bool testLineOfSightBetweenPoints(msr::airlib::GeoPoint& point1, msr::airlib::GeoPoint& point2) const override;
+    virtual bool testLineOfSightBetweenPoints(msr::airlib::GeoPoint& point1, msr::airlib::GeoPoint& point2) const override;
     virtual void getWorldExtents(msr::airlib::GeoPoint& min, msr::airlib::GeoPoint& max) const override;
 
 private:

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
@@ -293,7 +293,7 @@ bool PawnSimApi::testLineOfSightToPoint(GeoPoint& lla) const
     bool hit;
 
     // We need to run this code on the main game thread, since it iterates over actors
-    FGraphEventRef task = FFunctionGraphTask::CreateAndDispatchWhenReady([&]() {
+    UAirBlueprintLib::RunCommandOnGameThread([this, lla, &hit]() {
         // This default NedTransform is part of how we anchor the AirSim primary LLA origin at 0, 0, 0 in Unreal
         NedTransform zero_based_ned_transform(FTransform::Identity, UAirBlueprintLib::GetWorldToMetersScale(params_.pawn));
         FCollisionQueryParams collision_params(SCENE_QUERY_STAT(LineOfSight), true, params_.pawn);
@@ -321,112 +321,9 @@ bool PawnSimApi::testLineOfSightToPoint(GeoPoint& lla) const
             }
         }
     },
-                                                                         TStatId(),
-                                                                         NULL,
-                                                                         ENamedThreads::GameThread);
-
-    // Wait for the result
-    FTaskGraphInterface::Get().WaitUntilTaskCompletes(task);
+                                                                         true);
 
     return !hit;
-}
-
-bool PawnSimApi::testLineOfSightBetweenPoints(GeoPoint& lla1, GeoPoint& lla2) const
-{
-    bool hit;
-
-    // We need to run this code on the main game thread, since it iterates over actors
-    FGraphEventRef task = FFunctionGraphTask::CreateAndDispatchWhenReady([&]() {
-        // This default NedTransform is part of how we anchor the AirSim primary LLA origin at 0, 0, 0 in Unreal
-        NedTransform zero_based_ned_transform(FTransform::Identity, UAirBlueprintLib::GetWorldToMetersScale(params_.pawn));
-        FCollisionQueryParams collision_params(SCENE_QUERY_STAT(LineOfSight), true);
-
-        const auto& settings = AirSimSettings::singleton();
-        msr::airlib::Vector3r ned = msr::airlib::EarthUtils::GeodeticToNedFast(lla1, settings.origin_geopoint.home_geo_point);
-        FVector point1 = zero_based_ned_transform.fromGlobalNed(ned);
-        ned = msr::airlib::EarthUtils::GeodeticToNedFast(lla2, settings.origin_geopoint.home_geo_point);
-        FVector point2 = zero_based_ned_transform.fromGlobalNed(ned);
-
-        hit = params_.pawn->GetWorld()->LineTraceTestByChannel(point1, point2, ECC_Visibility, collision_params);
-
-        if (AirSimSettings::singleton().show_los_debug_lines_) {
-            FLinearColor color;
-            if (hit) {
-                // No LOS, so draw red line
-                color = FLinearColor{ 1.0f, 0, 0, 0.4f };
-            }
-            else {
-                // Yes LOS, so draw green line
-                color = FLinearColor{ 0, 1.0f, 0, 0.4f };
-            }
-
-            params_.pawn->GetWorld()->PersistentLineBatcher->DrawLine(point1, point2, color, SDPG_World, 4, 999999);
-        }
-    },
-                                                                         TStatId(),
-                                                                         NULL,
-                                                                         ENamedThreads::GameThread);
-
-    // Wait for the result
-    FTaskGraphInterface::Get().WaitUntilTaskCompletes(task);
-
-    return !hit;
-}
-
-void PawnSimApi::getWorldExtents(msr::airlib::GeoPoint& lla_min_out, msr::airlib::GeoPoint& lla_max_out) const
-{
-    // We need to run this code on the main game thread, since it iterates over actors
-    FGraphEventRef task = FFunctionGraphTask::CreateAndDispatchWhenReady([&]() {
-        // This default NedTransform is part of how we anchor the AirSim primary LLA origin at 0, 0, 0 in Unreal
-        NedTransform zero_based_ned_transform(FTransform::Identity, UAirBlueprintLib::GetWorldToMetersScale(params_.pawn));
-
-        // Testing actor enum for world bounds...
-        FVector world_min{ FLT_MAX, FLT_MAX, FLT_MAX };
-        FVector world_max{ FLT_MIN, FLT_MIN, FLT_MIN };
-        for (TActorIterator<AActor> actor_itr(params_.pawn->GetWorld()); actor_itr; ++actor_itr) {
-            // Same as with the Object Iterator, access the subclass instance with the * or -> operators.
-            AActor* actor = *actor_itr;
-            FVector origin;
-            FVector extent;
-            actor->GetActorBounds(false, origin, extent);
-            FString name = actor->GetFullName();
-            std::string stdName = std::string(TCHAR_TO_UTF8(*name));
-
-            if (extent[0] > 20000.0f) {
-                common_utils::Utils::log("In world bounds calculation, skipping gigantic object: " + stdName, common_utils::Utils::kLogLevelWarn);
-                continue;
-            }
-
-            for (int coord = 0; coord < 3; coord++) {
-                float min = origin[coord] - extent[coord];
-                float max = origin[coord] + extent[coord];
-                if (min < world_min[coord]) {
-                    world_min[coord] = min;
-                }
-                if (max > world_max[coord]) {
-                    world_max[coord] = max;
-                }
-            }
-        }
-
-        // TODO think more about how best to determine/indicate ground level, if anyone cares
-
-        // Convert Uvectors to LLAs
-        const auto& settings = AirSimSettings::singleton();
-        msr::airlib::Vector3r ned = zero_based_ned_transform.toGlobalNed(world_min);
-        lla_min_out = msr::airlib::EarthUtils::nedToGeodeticFast(ned, settings.origin_geopoint.home_geo_point);
-
-        ned = zero_based_ned_transform.toGlobalNed(world_max);
-        lla_max_out = msr::airlib::EarthUtils::nedToGeodeticFast(ned, settings.origin_geopoint.home_geo_point);
-    },
-                                                                         TStatId(),
-                                                                         NULL,
-                                                                         ENamedThreads::GameThread);
-
-    // Wait for the result
-    FTaskGraphInterface::Get().WaitUntilTaskCompletes(task);
-
-    common_utils::Utils::log("Extent min: " + lla_min_out.to_string() + ".  Max: " + lla_max_out.to_string(), common_utils::Utils::kLogLevelInfo);
 }
 
 void PawnSimApi::resetImplementation()

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
@@ -321,7 +321,7 @@ bool PawnSimApi::testLineOfSightToPoint(GeoPoint& lla) const
             }
         }
     },
-                                                                         true);
+                                             true);
 
     return !hit;
 }

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
@@ -300,7 +300,12 @@ bool PawnSimApi::testLineOfSightToPoint(const msr::airlib::GeoPoint& lla) const
 
         // Transform from LLA to NED
         const auto& settings = AirSimSettings::singleton();
-        Vector3r ned = msr::airlib::EarthUtils::GeodeticToNedFast(lla, settings.origin_geopoint.home_geo_point);
+        msr::airlib::GeodeticConverter converter(settings.origin_geopoint.home_geo_point.latitude,
+                                                 settings.origin_geopoint.home_geo_point.longitude,
+                                                 settings.origin_geopoint.home_geo_point.altitude);
+        double north, east, down;
+        converter.geodetic2Ned(lla.latitude, lla.longitude, lla.altitude, &north, &east, &down);
+        msr::airlib::Vector3r ned(north, east, down);
         FVector target_location = zero_based_ned_transform.fromGlobalNed(ned);
 
         hit = params_.pawn->GetWorld()->LineTraceTestByChannel(params_.pawn->GetActorLocation(), target_location, ECC_Visibility, collision_params);

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.h
@@ -123,8 +123,6 @@ public: //Unreal specific methods
     int getCameraCount();
 
     virtual bool testLineOfSightToPoint(GeoPoint& point) const;
-    virtual bool testLineOfSightBetweenPoints(GeoPoint& point1, GeoPoint& point2) const;
-    virtual void getWorldExtents(msr::airlib::GeoPoint& min, msr::airlib::GeoPoint& max) const;
 
     //if enabled, this would show some flares
     void displayCollisionEffect(FVector hit_location, const FHitResult& hit);

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.h
@@ -10,6 +10,7 @@
 #include "common/Common.hpp"
 #include "common/common_utils/Signal.hpp"
 #include "common/CommonStructs.hpp"
+#include "common/GeodeticConverter.hpp"
 #include "PIPCamera.h"
 #include "physics/Kinematics.hpp"
 #include "NedTransform.h"

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
@@ -629,7 +629,7 @@ std::string WorldSimApi::getSettingsString() const
     return msr::airlib::AirSimSettings::singleton().settings_text_;
 }
 
-bool WorldSimApi::testLineOfSightBetweenPoints(msr::airlib::GeoPoint& lla1, msr::airlib::GeoPoint& lla2) const
+bool WorldSimApi::testLineOfSightBetweenPoints(const msr::airlib::GeoPoint& lla1, const msr::airlib::GeoPoint& lla2) const
 {
     bool hit;
 

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
@@ -640,9 +640,15 @@ bool WorldSimApi::testLineOfSightBetweenPoints(const msr::airlib::GeoPoint& lla1
         FCollisionQueryParams collision_params(SCENE_QUERY_STAT(LineOfSight), true);
 
         const auto& settings = msr::airlib::AirSimSettings::singleton();
-        msr::airlib::Vector3r ned = msr::airlib::EarthUtils::GeodeticToNedFast(lla1, settings.origin_geopoint.home_geo_point);
+        msr::airlib::GeodeticConverter converter(settings.origin_geopoint.home_geo_point.latitude,
+                                                 settings.origin_geopoint.home_geo_point.longitude,
+                                                 settings.origin_geopoint.home_geo_point.altitude);
+        double north, east, down;
+        converter.geodetic2Ned(lla1.latitude, lla1.longitude, lla1.altitude, &north, &east, &down);
+        msr::airlib::Vector3r ned(north, east, down);
         FVector point1 = zero_based_ned_transform.fromGlobalNed(ned);
-        ned = msr::airlib::EarthUtils::GeodeticToNedFast(lla2, settings.origin_geopoint.home_geo_point);
+        converter.geodetic2Ned(lla2.latitude, lla2.longitude, lla2.altitude, &north, &east, &down);
+        ned = msr::airlib::Vector3r(north, east, down);
         FVector point2 = zero_based_ned_transform.fromGlobalNed(ned);
 
         hit = simmode_->GetWorld()->LineTraceTestByChannel(point1, point2, ECC_Visibility, collision_params);

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
@@ -668,8 +668,8 @@ bool WorldSimApi::testLineOfSightBetweenPoints(const msr::airlib::GeoPoint& lla1
 
 std::vector<msr::airlib::GeoPoint> WorldSimApi::getWorldExtents() const
 {
-    msr::airlib::GeoPoint& lla_min_out;
-    msr::airlib::GeoPoint& lla_max_out;
+    msr::airlib::GeoPoint lla_min_out;
+    msr::airlib::GeoPoint lla_max_out;
     // We need to run this code on the main game thread, since it iterates over actors
     UAirBlueprintLib::RunCommandOnGameThread([this, &lla_min_out, &lla_max_out]() {
         // This default NedTransform is part of how we anchor the AirSim primary LLA origin at 0, 0, 0 in Unreal

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.h
@@ -74,7 +74,7 @@ public:
 
     virtual std::string getSettingsString() const override;
 
-    virtual bool testLineOfSightBetweenPoints(msr::airlib::GeoPoint& point1, msr::airlib::GeoPoint& point2) const;
+    virtual bool testLineOfSightBetweenPoints(const msr::airlib::GeoPoint& point1, const msr::airlib::GeoPoint& point2) const;
     virtual std::vector<msr::airlib::GeoPoint> getWorldExtents() const;
 
 private:

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.h
@@ -75,7 +75,7 @@ public:
     virtual std::string getSettingsString() const override;
 
     virtual bool testLineOfSightBetweenPoints(msr::airlib::GeoPoint& point1, msr::airlib::GeoPoint& point2) const;
-    virtual void getWorldExtents(msr::airlib::GeoPoint& min, msr::airlib::GeoPoint& max) const;
+    virtual std::vector<msr::airlib::GeoPoint> getWorldExtents() const;
 
 private:
     AActor* createNewActor(const FActorSpawnParameters& spawn_params, const FTransform& actor_transform, const Vector3r& scale, UStaticMesh* static_mesh);

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.h
@@ -74,8 +74,8 @@ public:
 
     virtual std::string getSettingsString() const override;
 
-    virtual bool testLineOfSightBetweenPoints(const msr::airlib::GeoPoint& point1, const msr::airlib::GeoPoint& point2) const;
-    virtual std::vector<msr::airlib::GeoPoint> getWorldExtents() const;
+    virtual bool testLineOfSightBetweenPoints(const msr::airlib::GeoPoint& point1, const msr::airlib::GeoPoint& point2) const override;
+    virtual std::vector<msr::airlib::GeoPoint> getWorldExtents() const override;
 
 private:
     AActor* createNewActor(const FActorSpawnParameters& spawn_params, const FTransform& actor_transform, const Vector3r& scale, UStaticMesh* static_mesh);

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.h
@@ -74,6 +74,9 @@ public:
 
     virtual std::string getSettingsString() const override;
 
+    virtual bool testLineOfSightBetweenPoints(msr::airlib::GeoPoint& point1, msr::airlib::GeoPoint& point2) const;
+    virtual void getWorldExtents(msr::airlib::GeoPoint& min, msr::airlib::GeoPoint& max) const;
+
 private:
     AActor* createNewActor(const FActorSpawnParameters& spawn_params, const FTransform& actor_transform, const Vector3r& scale, UStaticMesh* static_mesh);
     void spawnPlayer();

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.h
@@ -2,6 +2,7 @@
 
 #include "CoreMinimal.h"
 #include "common/CommonStructs.hpp"
+#include "common/GeodeticConverter.hpp"
 #include "api/WorldSimApiBase.hpp"
 #include "SimMode/SimModeBase.h"
 #include "Components/StaticMeshComponent.h"


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
moving testLineOfSightBetweenPoints and getWorldExtents to WorldSimApi which is a more appropriate location for these APIs

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
built and launched with SimpleFlight for sanity check

## Screenshots (if appropriate):