### PR TITLE
Remove outdated LLVM tap in OSX

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -28,7 +28,7 @@ done
 # llvm tools
 if [ "$(uname)" == "Darwin" ]; then # osx
     brew update
-    brew tap llvm-hs/homebrew-llvm
+    # Update below line for newer versions
     brew install llvm@8
 else #linux
     sudo apt-get update


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #3813    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
Removes the `llvm-hs` tap which was causing the failure. Removed since https://formulae.brew.sh/formula/llvm doesn't indicate that the tap is required.

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
Action CI only. Will be best if someone with macOS machine could test it out as well

## Screenshots (if appropriate):