### PR TITLE
Add small helper methods for GeodeticConverter

### DIFF
--- a/AirLib/include/common/GeodeticConverter.hpp
+++ b/AirLib/include/common/GeodeticConverter.hpp
@@ -20,6 +20,11 @@ namespace airlib
             setHome(home_latitude, home_longitude, home_altitude);
         }
 
+        GeodeticConverter(const GeoPoint& home_geopoint)
+        {
+            setHome(home_geopoint);
+        }
+
         void setHome(double home_latitude, double home_longitude, float home_altitude)
         {
             home_latitude_ = home_latitude;
@@ -38,6 +43,11 @@ namespace airlib
 
             ecef_to_ned_matrix_ = nRe(phiP, home_longitude_rad_);
             ned_to_ecef_matrix_ = nRe(home_latitude_rad_, home_longitude_rad_).transpose();
+        }
+
+        void setHome(const GeoPoint& home_geopoint)
+        {
+            setHome(home_geopoint.latitude, home_geopoint.longitude, home_geopoint.altitude);
         }
 
         void getHome(double* latitude, double* longitude, float* altitude)
@@ -137,6 +147,11 @@ namespace airlib
             //TODO: above returns wrong altitude if down was positive. This is because sqrt return value would be -ve
             //but normal sqrt only return +ve. For now we just override it.
             *altitude = home_altitude_ - down;
+        }
+
+        void ned2Geodetic(const Vector3r& ned_pos, GeoPoint& geopoint)
+        {
+            ned2Geodetic(ned_pos[0], ned_pos[1], ned_pos[2], &geopoint.latitude, &geopoint.longitude, &geopoint.altitude);
         }
 
         void geodetic2Enu(const double latitude, const double longitude, const double altitude,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
Related to #3829, might be useful for #3810
Ping @zimmy87

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
Hasn't been explicitly tested for this PR apart from compilation, extracted out of some earlier work. In that, it was tested by replacing the currently being used EarthUtils with GeodeticConverter which might be interesting as well, will try to open a PR for that as well later

I haven't currently added a `geodetic2Ned` method since it will cause a narrowing of NED data from `double` to `float`. If that is allowable then I'll add that method as well

## Screenshots (if appropriate):