### PR TITLE
Fixed typo

### DIFF
--- a/docs/sensors.md
+++ b/docs/sensors.md
@@ -15,7 +15,7 @@ Each sensor is associated with a integer enum specifying its sensor type.
 
 ## Default sensors
 
-If no sensors are specified in the `settings.json`, the the following sensors are enabled by default based on the sim mode.
+If no sensors are specified in the `settings.json`, then the following sensors are enabled by default based on the sim mode.
 
 ### Multirotor
 * Imu


### PR DESCRIPTION
The word "then” had been misspelt as “the”

<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->

## Screenshots (if appropriate):