### PR TITLE
 Removed Custom Report Calls for Sim

### DIFF
--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
@@ -532,14 +532,7 @@ void ASimModeBase::updateDebugReport(msr::airlib::StateReporterWrapper& debug_re
 
             reporter.writeHeading(std::string("Vehicle: ").append(vehicle_name == "" ? "(default)" : vehicle_name));
 
-            const msr::airlib::Kinematics::State* kinematics = vehicle_sim_api->getGroundTruthKinematics();
-
-            reporter.writeValue("Position", kinematics->pose.position);
-            reporter.writeValue("Orientation", kinematics->pose.orientation);
-            reporter.writeValue("Lin-Vel", kinematics->twist.linear);
-            reporter.writeValue("Lin-Accl", kinematics->accelerations.linear);
-            reporter.writeValue("Ang-Vel", kinematics->twist.angular);
-            reporter.writeValue("Ang-Accl", kinematics->accelerations.angular);
+            vehicle_sim_api->reportState(reporter);
         }
     }
 }

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnSimApi.cpp
@@ -167,4 +167,11 @@ void CarPawnSimApi::update()
     PawnSimApi::update();
 }
 
+void CarPawnSimApi::reportState(StateReporter& reporter)
+{
+    PawnSimApi::reportState(reporter);
+
+    vehicle_api_->reportState(reporter);
+}
+
 //*** End: UpdatableState implementation ***//

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnSimApi.h
@@ -32,7 +32,7 @@ public:
 
     virtual void update() override;
     virtual void reportState(StateReporter& reporter) override;
-    
+
     virtual std::string getRecordFileLine(bool is_header_line) const override;
 
     virtual void updateRenderedState(float dt) override;

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnSimApi.h
@@ -31,7 +31,8 @@ public:
                   const msr::airlib::CarApiBase::CarControls& keyboard_controls, UWheeledVehicleMovementComponent* movement);
 
     virtual void update() override;
-
+    virtual void reportState(StateReporter& reporter) override;
+    
     virtual std::string getRecordFileLine(bool is_header_line) const override;
 
     virtual void updateRenderedState(float dt) override;


### PR DESCRIPTION
With current method, you cannot view sensor data from vehicle even though within the child classes they are defined, but never called by the sim. It also isn't good practice to define custom calls within updateDebugReport rather than calling vehicle_sim_api->reportState(reporter) which eventually is going to call related child classes which overrides parent reportState function.

<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->


Fixes: #1529
Fixes: #3875

## About
<!-- Describe what your PR is about. -->
#1529
#3875 

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
Tested on LandscapeMountains environment with settings.json attached into #3875. It now automatically adds IMU and GPS data to the reporter without me making changes to the code.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/6889144/125445547-1b7e20fb-a87c-469f-b617-dbb2b4b77965.png)
