### PR TITLE
Fix typo in GazeboDrone

### DIFF
--- a/GazeboDrone/src/main.cpp
+++ b/GazeboDrone/src/main.cpp
@@ -81,7 +81,7 @@ void cbLocalPose(ConstPosesStampedPtr& msg)
     ++count;
 }
 
-void cbGobalPose(ConstPosesStampedPtr& msg)
+void cbGlobalPose(ConstPosesStampedPtr& msg)
 {
     std::cout << std::fixed;
     std::cout << std::setprecision(4);
@@ -122,7 +122,7 @@ int main(int _argc, char** _argv)
 
     // Listen to Gazebo topics
     gazebo::transport::SubscriberPtr sub_pose1 = node->Subscribe("~/pose/local/info", cbLocalPose);
-    gazebo::transport::SubscriberPtr sub_pose2 = node->Subscribe("~/pose/info", cbGobalPose);
+    gazebo::transport::SubscriberPtr sub_pose2 = node->Subscribe("~/pose/info", cbGlobalPose);
 
     while (true)
         gazebo::common::Time::MSleep(10);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
There seems to be a small typo on the `GazeboDrone` file in the callback.

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
By running the `GazeboDrone` example: [Video](https://youtu.be/Eqbk4HY0utw)

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/5248102/127297087-792e8b32-2534-4ac7-a9b6-639acb62f606.png)
