### PR TITLE
Use location instead of GPS for GazeboDrone

### DIFF
--- a/GazeboDrone/src/main.cpp
+++ b/GazeboDrone/src/main.cpp
@@ -67,7 +67,7 @@ void cbLocalPose(ConstPosesStampedPtr& msg)
             std::cout << " oz: " << std::right << std::setw(NWIDTH) << oz;
             std::cout << std::endl;
         }
-        if (i == msg->pose_size() - 1) {
+        if (i == 0) {
             msr::airlib::Vector3r p(x, -y, -z);
             msr::airlib::Quaternionr o(ow, ox, -oy, -oz);
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #3894    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
GazeboDrone was using GPS location instead of local frame.

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
GazeboDrone+PX4+QGroundControl

## Screenshots (if appropriate):