### PR TITLE
Change getRotorStates to return const ref

### DIFF
--- a/AirLib/include/vehicles/multirotor/api/MultirotorApiBase.hpp
+++ b/AirLib/include/vehicles/multirotor/api/MultirotorApiBase.hpp
@@ -126,7 +126,7 @@ namespace airlib
                                float obs_avoidance_vel, const Vector3r& origin, float xy_length, float max_z, float min_z);
 
         /************************* high level status APIs *********************************/
-        RotorStates getRotorStates() const
+        const RotorStates& getRotorStates() const
         {
             return rotor_states_;
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
NFC, just don't see any reason why the internal method should return a copy. If someone wants to use, they can still create a copy and modify

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
Compilation

## Screenshots (if appropriate):