### PR TITLE
Fix crash in ros wrapper on JetsonTX2

### DIFF
--- a/ros/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
+++ b/ros/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
@@ -27,7 +27,8 @@ const std::unordered_map<int, std::string> AirsimROSWrapper::image_type_int_to_s
 
 AirsimROSWrapper::AirsimROSWrapper(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private, const std::string& host_ip)
     : nh_(nh), nh_private_(nh_private), img_async_spinner_(1, &img_timer_cb_queue_), // a thread for image callbacks to be 'spun' by img_async_spinner_
-    lidar_async_spinner_(1, &lidar_timer_cb_queue_), has_gimbal_cmd_(false)
+    lidar_async_spinner_(1, &lidar_timer_cb_queue_)
+    , has_gimbal_cmd_(false)
     , // same as above, but for lidar
     host_ip_(host_ip)
     , airsim_client_images_(host_ip)

--- a/ros/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
+++ b/ros/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
@@ -27,7 +27,7 @@ const std::unordered_map<int, std::string> AirsimROSWrapper::image_type_int_to_s
 
 AirsimROSWrapper::AirsimROSWrapper(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private, const std::string& host_ip)
     : nh_(nh), nh_private_(nh_private), img_async_spinner_(1, &img_timer_cb_queue_), // a thread for image callbacks to be 'spun' by img_async_spinner_
-    lidar_async_spinner_(1, &lidar_timer_cb_queue_)
+    lidar_async_spinner_(1, &lidar_timer_cb_queue_), has_gimbal_cmd_(false)
     , // same as above, but for lidar
     host_ip_(host_ip)
     , airsim_client_images_(host_ip)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #    <!-- add this line for each issue your PR solves. -->

## About
<!-- Describe what your PR is about. -->
ROS wrapper keep crashing on Jetson TX2, after build it in debug mode, turns out `has_gimbal_cmd_` is not initialized which caused a crash when calling `simSetCameraPose`.
It's doesn't reproduce on my VMware under widows host, probably due to difference architectures.

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
Build and run the ros wrapper on Jetson TX2

## Screenshots (if appropriate):