### PR TITLE
Update build_windows.md

### DIFF
--- a/docs/build_windows.md
+++ b/docs/build_windows.md
@@ -14,7 +14,7 @@ Click on the `Install` button on the top right, which should show the option to 
 
 ## Build AirSim
 * Install Visual Studio 2019.
-**Make sure** to select **Desktop Development with C++** and **Windows 10 SDK 10.0.18362** (should be selected by default) while installing VS 2019.
+**Make sure** to select **Desktop Development with C++** and **Windows 10 SDK 10.0.18362** (should be selected by default) and select the latest .NET Framework SDK under the 'Individual Components' tab while installing VS 2019.
 * Start `Developer Command Prompt for VS 2019`.
 * Clone the repo: `git clone https://github.com/Microsoft/AirSim.git`, and go the AirSim directory by `cd AirSim`.
 


### PR DESCRIPTION
Fixes: Fixed issue with installation instructions.  If .NET Framework is not installed when setting up Visual Studio, an error may be thrown when building an environment.

## About
Fixed issue with installation instructions.  If .NET Framework is not installed when setting up Visual Studio, an error may be thrown when building an environment.

## How Has This Been Tested?
Tested on my own machine.

## Screenshots (if appropriate):

When building the blocks environment I got this error:

Running C:/Program Files/Epic Games/UE_4.27/Engine/Binaries/DotNET/UnrealBuildTool.exe  -projectfiles -project="C:/Users/Nic/source/repos/AirSim/Unreal/Environments/Blocks/Blocks.uproject" -game -rocket -progress -log="C:\Users\Nic\source\repos\AirSim\Unreal\Environments\Blocks/Saved/Logs/UnrealVersionSelector-2021.09.02-12.54.29.log"
Discovering modules, targets and source code for project...
ERROR: Could not find NetFxSDK install dir; this will prevent SwarmInterface from installing.  Install a version of .NET Framework SDK at 4.6.0 or higher.