### PR TITLE
Fixes for #3691 to get MacOS Big Sur to run Airsim

### DIFF
--- a/Unreal/Environments/Blocks/.gitignore
+++ b/Unreal/Environments/Blocks/.gitignore
@@ -16,3 +16,6 @@ Plugins/
 
 # avoid checking uproject because this is usually just version change
 *.uproject
+
+# avoid checking in MacOS XCode assets
+*.xcworkspace

--- a/build.sh
+++ b/build.sh
@@ -1,11 +1,9 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 # get path of current script: https://stackoverflow.com/a/39340259/207661
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 pushd "$SCRIPT_DIR"  >/dev/null
 
-set -e
-set -x
 
 debug=false
 gcc=false
@@ -26,6 +24,11 @@ do
     esac
 
 done
+
+if $debug; then
+    set -e
+    set -x
+fi 
 
 function version_less_than_equal_to() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" = "$1"; }
 
@@ -55,8 +58,13 @@ else
     build_dir=build_release
 fi 
 if [ "$(uname)" == "Darwin" ]; then
-    export CC=/usr/local/opt/llvm@8/bin/clang
-    export CXX=/usr/local/opt/llvm@8/bin/clang++
+    # llvm v8 is too old for Big Sur see
+    # https://github.com/microsoft/AirSim/issues/3691
+    #export CC=/usr/local/opt/llvm@8/bin/clang
+    #export CXX=/usr/local/opt/llvm@8/bin/clang++
+    #now pick up whatever setup.sh installs
+    export CC=/usr/local/opt/llvm/bin/clang
+    export CXX=/usr/local/opt/llvm/bin/clang++
 else
     if $gcc; then
         export CC="gcc-8"
@@ -68,7 +76,7 @@ else
 fi
 
 #install EIGEN library
-if [[ !(-d "./AirLib/deps/eigen3/Eigen") ]]; then
+if [[ ! -d "./AirLib/deps/eigen3/Eigen" ]]; then
     echo "### Eigen is not installed. Please run setup.sh first."
     exit 1
 fi
@@ -106,7 +114,7 @@ pushd $build_dir  >/dev/null
 # final linking of the binaries can fail due to a missing libc++abi library
 # (happens on Fedora, see https://bugzilla.redhat.com/show_bug.cgi?id=1332306).
 # So we only build the libraries here for now
-make -j`nproc`
+make -j"$(nproc)"
 popd >/dev/null
 
 mkdir -p AirLib/lib/x64/$folder_name

--- a/setup.sh
+++ b/setup.sh
@@ -1,16 +1,16 @@
-#! /bin/bash
-set -x
-set -e
+#!/usr/bin/env bash
+# only for debugging
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 pushd "$SCRIPT_DIR" >/dev/null
 
 downloadHighPolySuv=true
 MIN_CMAKE_VERSION=3.10.0
+DEBUG="${DEBUG:-false}"
 function version_less_than_equal_to() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" = "$1"; }
 
 # brew gives error if package is already installed
-function brew_install() { brew list $1 &>/dev/null || brew install $1; }
+function brew_install() { brew list "$1" &>/dev/null || brew install "$1"; }
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]
@@ -18,18 +18,28 @@ do
 key="$1"
 
 case $key in
+    --debug)
+        DEBUG=true
+        ;;
     --no-full-poly-car)
-    downloadHighPolySuv=false
-    shift # past value
-    ;;
+        downloadHighPolySuv=false
+        shift # past value
+        ;;
 esac
+
 done
+
+if $DEBUG; then
+    set -x
+    set -e
+fi 
 
 # llvm tools
 if [ "$(uname)" == "Darwin" ]; then # osx
     brew update
     # Update below line for newer versions
-    brew install llvm@8
+    #brew install llvm@8
+    brew install llvm
 else #linux
     sudo apt-get update
     sudo apt-get -y install --no-install-recommends \
@@ -62,29 +72,29 @@ fi
 #TODO: figure out how to do below in travis
 # Install additional tools, CMake if required
 if [ "$(uname)" == "Darwin" ]; then # osx
-    if [[ ! -z "${whoami}" ]]; then #this happens when running in travis
-        sudo dseditgroup -o edit -a `whoami` -t user dialout
+    if [[ -n "${whoami}" ]]; then #this happens when running in travis
+        sudo dseditgroup -o edit -a "$(whoami)" -t user dialout
     fi
 
     brew_install wget
     brew_install coreutils
 
-    if version_less_than_equal_to $cmake_ver $MIN_CMAKE_VERSION; then
+    if version_less_than_equal_to "$cmake_ver" "$MIN_CMAKE_VERSION"; then
         brew install cmake  # should get cmake 3.8
     else
         echo "Already have good version of cmake: $cmake_ver"
     fi
 
 else #linux
-    if [[ ! -z "${whoami}" ]]; then #this happens when running in travis
-        sudo /usr/sbin/useradd -G dialout $USER
-        sudo usermod -a -G dialout $USER
+    if [[  -n "${whoami}" ]]; then #this happens when running in travis
+        sudo /usr/sbin/useradd -G dialout "$USER"
+        sudo usermod -a -G dialout "$USER"
     fi
 
     # install additional tools
     sudo apt-get install -y build-essential unzip
 
-    if version_less_than_equal_to $cmake_ver $MIN_CMAKE_VERSION; then
+    if version_less_than_equal_to "$cmake_ver" "$MIN_CMAKE_VERSION"; then
         # in ubuntu 18 docker CI, avoid building cmake from scratch to save time
         # ref: https://apt.kitware.com/
         if [ "$(lsb_release -rs)" == "18.04" ]; then


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
Fixes #3691
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
Allows Airsim to run on MacOS Big Sur 11.5 by changing from LLVM@8 to LLVM@12 (the latest)
and recommending running UE 4.27.

Also cleans up the setup code with a debug flag so you don't just get the full x-ray trace, in normal mode it is silent but --debug cleans dumps more data. Finally, a very small thing, the 
shell script was not safe in a couple of places so ran it through shellcheck and fixed some quotes (which all bash scripts confuse).

Final fix for MacOS was to #!/usr/bin/env bash instead of a hard #!/bin/bash because on MacOS, they ship with an old version of bash 3.x for licensing reasons, this script works wit the brew installed version and bash 5.x

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
Run through on MacBook Pro 2017 with Big Sur validate that AirSim starts.

## Screenshots (if appropriate):