### PR TITLE
Fix the consistency of H and W defined in function arguments in two scripts

### DIFF
--- a/PythonClient/eventcamera_sim/event_simulator.py
+++ b/PythonClient/eventcamera_sim/event_simulator.py
@@ -67,8 +67,8 @@ def esim(
 
         current_time = last_time
         for i in range(spike_nums):
-            output_events[count].x = x // n_pix_row
-            output_events[count].y = x % n_pix_row
+            output_events[count].x = x % n_pix_row
+            output_events[count].y = x // n_pix_row
             output_events[count].timestamp = np.round(current_time * 1e-6, 6)
             output_events[count].polarity = 1 if pol > 0 else -1
 

--- a/PythonClient/eventcamera_sim/test_event_sim.py
+++ b/PythonClient/eventcamera_sim/test_event_sim.py
@@ -17,10 +17,10 @@ parser.add_argument("--width", type=int, default=256)
 
 
 class AirSimEventGen:
-    def __init__(self, W, H, save=False, debug=False):
-        self.ev_sim = EventSimulator(W, H)
-        self.W = W
+    def __init__(self, H, W, save=False, debug=False):
+        self.ev_sim = EventSimulator(H, W)
         self.H = H
+        self.W = W
 
         self.image_request = airsim.ImageRequest(
             "0", airsim.ImageType.Scene, False, False
@@ -65,7 +65,7 @@ class AirSimEventGen:
 if __name__ == "__main__":
     args = parser.parse_args()
 
-    event_generator = AirSimEventGen(args.width, args.height, save=args.save, debug=args.debug)
+    event_generator = AirSimEventGen(args.height, args.width, save=args.save, debug=args.debug)
     i = 0
     start_time = 0
     t_start = time.time()


### PR DESCRIPTION
Fix the inconsistency of H and W defined in function arguments in two scripts

Fixes: #

## About
The existing event simulator plugin works well when use --debug parameter to visualize events, however, due to the inconsistent order of H and W in two scripts, when use --save parameter, the saved pkl format events is abnormal, this PR fixes the order of H and W to save desired events.

## Screenshots
The left window show the visualization of the events that saved using the fixed code, the right window show the original  visualization of the saved events.

![comparation](https://user-images.githubusercontent.com/42210546/133751631-ddd60a8a-cb51-4c2a-9aec-bc1aa830b7d6.png)
: