### PR TITLE
switching location of Eigen3 repository

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -170,13 +170,10 @@ echo "Installing Eigen library..."
 
 if [ ! -d "AirLib/deps/eigen3" ]; then
     echo "Downloading Eigen..."
-    #wget -O eigen3.zip https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.zip
     git clone --depth 1 --branch "3.3.7" https://gitlab.com/libeigen/eigen-backup.git temp_eigen
-    #unzip -q eigen3.zip -d temp_eigen
     mkdir -p AirLib/deps/eigen3
     mv temp_eigen/Eigen AirLib/deps/eigen3
     rm -rf temp_eigen
-    #rm eigen3.zip
 else
     echo "Eigen is already installed."
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -170,12 +170,13 @@ echo "Installing Eigen library..."
 
 if [ ! -d "AirLib/deps/eigen3" ]; then
     echo "Downloading Eigen..."
-    wget -O eigen3.zip https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.zip
-    unzip -q eigen3.zip -d temp_eigen
+    #wget -O eigen3.zip https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.zip
+    git clone --depth 1 --branch "3.3.7" https://gitlab.com/libeigen/eigen-backup.git temp_eigen
+    #unzip -q eigen3.zip -d temp_eigen
     mkdir -p AirLib/deps/eigen3
-    mv temp_eigen/eigen*/Eigen AirLib/deps/eigen3
+    mv temp_eigen/Eigen AirLib/deps/eigen3
     rm -rf temp_eigen
-    rm eigen3.zip
+    #rm eigen3.zip
 else
     echo "Eigen is already installed."
 fi


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #4054    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
Due to https://gitlab.com/libeigen/eigen/-/issues/2336 the current location the build scripts are downloading the Eigen3 library is unavailable. This PR changes the download location to the backup repository.

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
A build was run on Ubuntu 20.04 and the Blocks environment was launched and confirmed to be working.

## Screenshots (if appropriate):