### PR TITLE
Fixed camera bug when using gimbal stabilization

### DIFF
--- a/Unreal/Plugins/AirSim/Source/PIPCamera.cpp
+++ b/Unreal/Plugins/AirSim/Source/PIPCamera.cpp
@@ -283,7 +283,9 @@ void APIPCamera::setCameraPose(const msr::airlib::Pose& relative_pose)
         gimbald_rotator_.Roll = rotator.Roll;
         gimbald_rotator_.Yaw = rotator.Yaw;
     }
-    this->SetActorRelativeRotation(rotator);
+    else {
+        this->SetActorRelativeRotation(rotator);
+    }
 }
 
 void APIPCamera::setCameraFoV(float fov_degrees)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #    <!-- add this line for each issue your PR solves. -->
Method called when it is not supposed to. Fixed with and else to exclude the call when gimbal stabilization is not set to 1.

## About
It fixes a shaky behavior when using gimbal stabilization as shown in #3852 .

## How Has This Been Tested?
Ubuntu 20 and UE4 4.26
Compiled and used without problems

## Screenshots (if appropriate):