### PR TITLE
Fix actor name conflict for multiple ComputerVision vehicles

### DIFF
--- a/Unreal/Plugins/AirSim/Source/Vehicles/ComputerVision/ComputerVisionPawn.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/ComputerVision/ComputerVisionPawn.cpp
@@ -40,25 +40,25 @@ void AComputerVisionPawn::initializeForBeginPlay()
     FActorSpawnParameters camera_spawn_params;
     camera_spawn_params.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AdjustIfPossibleButAlwaysSpawn;
 
-    camera_spawn_params.Name = "camera_front_center";
+    camera_spawn_params.Name = FName(*(this->GetName() + "_camera_front_center"));
     camera_front_center_ = this->GetWorld()->SpawnActor<APIPCamera>(pip_camera_class_, camera_transform, camera_spawn_params);
     camera_front_center_->AttachToComponent(camera_front_center_base_, FAttachmentTransformRules::KeepRelativeTransform);
 
-    camera_spawn_params.Name = "camera_front_left";
+    camera_spawn_params.Name = FName(*(this->GetName() + "_camera_front_left"));
     camera_front_left_ = this->GetWorld()->SpawnActor<APIPCamera>(pip_camera_class_, camera_transform, camera_spawn_params);
     camera_front_left_->AttachToComponent(camera_front_left_base_, FAttachmentTransformRules::KeepRelativeTransform);
 
-    camera_spawn_params.Name = "camera_front_right";
+    camera_spawn_params.Name = FName(*(this->GetName() + "_camera_front_right"));
     camera_front_right_ = this->GetWorld()->SpawnActor<APIPCamera>(pip_camera_class_, camera_transform, camera_spawn_params);
     camera_front_right_->AttachToComponent(camera_front_right_base_, FAttachmentTransformRules::KeepRelativeTransform);
 
-    camera_spawn_params.Name = "camera_bottom_center";
+    camera_spawn_params.Name = FName(*(this->GetName() + "_camera_bottom_center"));
     camera_bottom_center_ = this->GetWorld()->SpawnActor<APIPCamera>(pip_camera_class_,
                                                                      FTransform(FRotator(-90, 0, 0), FVector::ZeroVector),
                                                                      camera_spawn_params);
     camera_bottom_center_->AttachToComponent(camera_bottom_center_base_, FAttachmentTransformRules::KeepRelativeTransform);
 
-    camera_spawn_params.Name = "camera_back_center";
+    camera_spawn_params.Name = FName(*(this->GetName() + "_camera_back_center"));
     camera_back_center_ = this->GetWorld()->SpawnActor<APIPCamera>(pip_camera_class_,
                                                                    FTransform(FRotator(0, -180, 0), FVector::ZeroVector),
                                                                    camera_spawn_params);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #4092    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
Fixes the name conflict by including the vehicle name

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
With the below settings from #4092 
```json
{
    "SettingsVersion": 1.2,
    "SimMode": "ComputerVision",
    "Vehicles": {
        "Cam1": {
            "VehicleType": "ComputerVision",
            "X": 26,
            "Y": -1,
            "Z": -10
        },
        "Cam2": {
            "VehicleType": "ComputerVision",
            "X": 26,
            "Y": -2,
            "Z": -20
        }
    }
}
```

## Screenshots (if appropriate):