### PR TITLE
moveByRollPitchYawThrottleAsync Documentation changed from radians to Degrees

### DIFF
--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -1175,7 +1175,7 @@ class MultirotorClient(VehicleClient, object):
     def moveByRollPitchYawThrottleAsync(self, roll, pitch, yaw, throttle, duration, vehicle_name = ''):
         """
         - Desired throttle is between 0.0 to 1.0
-        - Roll angle, pitch angle, and yaw angle are given in **degrees**, in the body frame.
+        - Roll angle, pitch angle, and yaw angle are given in **degrees** when using PX4 and in **radians** when using SimpleFlight, in the body frame.
         - The body frame follows the Front Left Up (FLU) convention, and right-handedness.
 
         - Frame Convention:
@@ -1195,9 +1195,9 @@ class MultirotorClient(VehicleClient, object):
             | Hence, yawing with a positive angle is equivalent to rotated towards the **left** direction wrt our FLU body frame. Or in an anticlockwise fashion in the body XY / FL plane.
 
         Args:
-            roll (float): Desired roll angle, in degrees.
-            pitch (float): Desired pitch angle, in degrees.
-            yaw (float): Desired yaw angle, in degrees.
+            roll (float): Desired roll angle.
+            pitch (float): Desired pitch angle.
+            yaw (float): Desired yaw angle.
             throttle (float): Desired throttle (between 0.0 to 1.0)
             duration (float): Desired amount of time (seconds), to send this command for
             vehicle_name (str, optional): Name of the multirotor to send this command to

--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -1175,7 +1175,7 @@ class MultirotorClient(VehicleClient, object):
     def moveByRollPitchYawThrottleAsync(self, roll, pitch, yaw, throttle, duration, vehicle_name = ''):
         """
         - Desired throttle is between 0.0 to 1.0
-        - Roll angle, pitch angle, and yaw angle are given in **degrees**, in the body frame.
+        - Roll angle, pitch angle, and yaw angle are given in **degrees** in SimpleFlight and **radians** in PX4, in the body frame.
         - The body frame follows the Front Left Up (FLU) convention, and right-handedness.
 
         - Frame Convention:
@@ -1195,9 +1195,9 @@ class MultirotorClient(VehicleClient, object):
             | Hence, yawing with a positive angle is equivalent to rotated towards the **left** direction wrt our FLU body frame. Or in an anticlockwise fashion in the body XY / FL plane.
 
         Args:
-            roll (float): Desired roll angle, in degrees.
-            pitch (float): Desired pitch angle, in degrees.
-            yaw (float): Desired yaw angle, in degrees.
+            roll (float): Desired roll angle.
+            pitch (float): Desired pitch angle.
+            yaw (float): Desired yaw angle.
             throttle (float): Desired throttle (between 0.0 to 1.0)
             duration (float): Desired amount of time (seconds), to send this command for
             vehicle_name (str, optional): Name of the multirotor to send this command to

--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -1175,7 +1175,7 @@ class MultirotorClient(VehicleClient, object):
     def moveByRollPitchYawThrottleAsync(self, roll, pitch, yaw, throttle, duration, vehicle_name = ''):
         """
         - Desired throttle is between 0.0 to 1.0
-        - Roll angle, pitch angle, and yaw angle are given in **radians**, in the body frame.
+        - Roll angle, pitch angle, and yaw angle are given in **degrees**, in the body frame.
         - The body frame follows the Front Left Up (FLU) convention, and right-handedness.
 
         - Frame Convention:
@@ -1195,9 +1195,9 @@ class MultirotorClient(VehicleClient, object):
             | Hence, yawing with a positive angle is equivalent to rotated towards the **left** direction wrt our FLU body frame. Or in an anticlockwise fashion in the body XY / FL plane.
 
         Args:
-            roll (float): Desired roll angle, in radians.
-            pitch (float): Desired pitch angle, in radians.
-            yaw (float): Desired yaw angle, in radians.
+            roll (float): Desired roll angle, in degrees.
+            pitch (float): Desired pitch angle, in degrees.
+            yaw (float): Desired yaw angle, in .
             throttle (float): Desired throttle (between 0.0 to 1.0)
             duration (float): Desired amount of time (seconds), to send this command for
             vehicle_name (str, optional): Name of the multirotor to send this command to

--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -1197,7 +1197,7 @@ class MultirotorClient(VehicleClient, object):
         Args:
             roll (float): Desired roll angle, in degrees.
             pitch (float): Desired pitch angle, in degrees.
-            yaw (float): Desired yaw angle, in .
+            yaw (float): Desired yaw angle, in degrees.
             throttle (float): Desired throttle (between 0.0 to 1.0)
             duration (float): Desired amount of time (seconds), to send this command for
             vehicle_name (str, optional): Name of the multirotor to send this command to

--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -1175,7 +1175,7 @@ class MultirotorClient(VehicleClient, object):
     def moveByRollPitchYawThrottleAsync(self, roll, pitch, yaw, throttle, duration, vehicle_name = ''):
         """
         - Desired throttle is between 0.0 to 1.0
-        - Roll angle, pitch angle, and yaw angle are given in **degrees** in SimpleFlight and **radians** in PX4, in the body frame.
+        - Roll angle, pitch angle, and yaw angle are given in **degrees**, in the body frame.
         - The body frame follows the Front Left Up (FLU) convention, and right-handedness.
 
         - Frame Convention:
@@ -1195,9 +1195,9 @@ class MultirotorClient(VehicleClient, object):
             | Hence, yawing with a positive angle is equivalent to rotated towards the **left** direction wrt our FLU body frame. Or in an anticlockwise fashion in the body XY / FL plane.
 
         Args:
-            roll (float): Desired roll angle.
-            pitch (float): Desired pitch angle.
-            yaw (float): Desired yaw angle.
+            roll (float): Desired roll angle, in degrees.
+            pitch (float): Desired pitch angle, in degrees.
+            yaw (float): Desired yaw angle, in degrees.
             throttle (float): Desired throttle (between 0.0 to 1.0)
             duration (float): Desired amount of time (seconds), to send this command for
             vehicle_name (str, optional): Name of the multirotor to send this command to


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
Fixed the documentation for moveByRollPitchYawThrottleAsync to reflect that the function uses degrees instead of Radians when operating on a PX4 stack.
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
After some testing, I have found that moveByRollPitchYawThrottleAsync uses degrees instead of radians for the target orientation in the body frame while simulating with HITL. The documentation says it uses radians, so I have updated it.

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
I called the moveByRollPitchYawThrottleAsync function with values in ranges [-pi/2, pi/2] and [-90, 90], and I discovered that only the [-90, 90] range produced the expected changes in the drone's orientation in a PX4 HITL Unreal simulation.

## Screenshots (if appropriate):