### PR TITLE
Sets bCapture* true only while showing subwindow 

### DIFF
--- a/Unreal/Plugins/AirSim/Source/CameraDirector.cpp
+++ b/Unreal/Plugins/AirSim/Source/CameraDirector.cpp
@@ -344,16 +344,8 @@ void ACameraDirector::notifyViewModeChanged()
 {
     bool nodisplay = ECameraDirectorMode::CAMERA_DIRECTOR_MODE_NODISPLAY == mode_;
 
-    //if (fpv_camera_)
-    //    fpv_camera_->onViewModeChanged(nodisplay);
-    //if (backup_camera_)
-    //    backup_camera_->onViewModeChanged(nodisplay);
-    //if (ExternalCamera)
-    //    ExternalCamera->onViewModeChanged(nodisplay);
-    //if (front_camera_)
-    //    front_camera_->onViewModeChanged(nodisplay);
-
     UWorld* world = GetWorld();
     UGameViewportClient* gameViewport = world->GetGameViewport();
-    gameViewport->bDisableWorldRendering = (uint32)mode_;
+    gameViewport->bDisableWorldRendering = nodisplay;
+
 }

--- a/Unreal/Plugins/AirSim/Source/CameraDirector.cpp
+++ b/Unreal/Plugins/AirSim/Source/CameraDirector.cpp
@@ -344,21 +344,16 @@ void ACameraDirector::notifyViewModeChanged()
 {
     bool nodisplay = ECameraDirectorMode::CAMERA_DIRECTOR_MODE_NODISPLAY == mode_;
 
-    if (fpv_camera_)
-        fpv_camera_->onViewModeChanged(nodisplay);
-    if (backup_camera_)
-        backup_camera_->onViewModeChanged(nodisplay);
-    if (ExternalCamera)
-        ExternalCamera->onViewModeChanged(nodisplay);
-    if (front_camera_)
-        front_camera_->onViewModeChanged(nodisplay);
+    //if (fpv_camera_)
+    //    fpv_camera_->onViewModeChanged(nodisplay);
+    //if (backup_camera_)
+    //    backup_camera_->onViewModeChanged(nodisplay);
+    //if (ExternalCamera)
+    //    ExternalCamera->onViewModeChanged(nodisplay);
+    //if (front_camera_)
+    //    front_camera_->onViewModeChanged(nodisplay);
 
     UWorld* world = GetWorld();
     UGameViewportClient* gameViewport = world->GetGameViewport();
-    if (mode_ == ECameraDirectorMode::CAMERA_DIRECTOR_MODE_NODISPLAY) {
-        gameViewport->bDisableWorldRendering = 1;
-    }
-    else {
-        gameViewport->bDisableWorldRendering = 0;
-    }
+    gameViewport->bDisableWorldRendering = (uint32)mode_;
 }

--- a/Unreal/Plugins/AirSim/Source/CameraDirector.cpp
+++ b/Unreal/Plugins/AirSim/Source/CameraDirector.cpp
@@ -347,5 +347,4 @@ void ACameraDirector::notifyViewModeChanged()
     UWorld* world = GetWorld();
     UGameViewportClient* gameViewport = world->GetGameViewport();
     gameViewport->bDisableWorldRendering = nodisplay;
-
 }

--- a/Unreal/Plugins/AirSim/Source/PIPCamera.cpp
+++ b/Unreal/Plugins/AirSim/Source/PIPCamera.cpp
@@ -98,7 +98,7 @@ void APIPCamera::BeginPlay()
         render_targets_[image_type] = NewObject<UTextureRenderTarget2D>();
     }
 
-    onViewModeChanged(false);
+    onViewModeChanged(true);
 
     gimbal_stabilization_ = 0;
     gimbald_rotator_ = this->GetActorRotation();
@@ -268,6 +268,20 @@ bool APIPCamera::getCameraTypeEnabled(ImageType type) const
 void APIPCamera::setCameraTypeEnabled(ImageType type, bool enabled)
 {
     enableCaptureComponent(type, enabled);
+}
+
+void APIPCamera::setCaptureUpdate(USceneCaptureComponent2D* capture, bool nodisplay)
+{
+    capture->bCaptureEveryFrame = !nodisplay;
+    capture->bCaptureOnMovement = !nodisplay;
+    capture->bAlwaysPersistRenderingState = true;
+}
+
+void APIPCamera::setCameraTypeUpdate(ImageType type, bool nodisplay)
+{
+    USceneCaptureComponent2D* capture = getCaptureComponent(type, false);
+    if (capture != nullptr)
+        setCaptureUpdate(capture, nodisplay);
 }
 
 void APIPCamera::setCameraPose(const msr::airlib::Pose& relative_pose)
@@ -579,14 +593,7 @@ void APIPCamera::onViewModeChanged(bool nodisplay)
     for (unsigned int image_type = 0; image_type < imageTypeCount(); ++image_type) {
         USceneCaptureComponent2D* capture = getCaptureComponent(static_cast<ImageType>(image_type), false);
         if (capture) {
-            if (nodisplay) {
-                capture->bCaptureEveryFrame = false;
-                capture->bCaptureOnMovement = false;
-            }
-            else {
-                capture->bCaptureEveryFrame = true;
-                capture->bCaptureOnMovement = true;
-            }
+            setCaptureUpdate(capture, nodisplay);
         }
     }
 }

--- a/Unreal/Plugins/AirSim/Source/PIPCamera.cpp
+++ b/Unreal/Plugins/AirSim/Source/PIPCamera.cpp
@@ -98,6 +98,8 @@ void APIPCamera::BeginPlay()
         render_targets_[image_type] = NewObject<UTextureRenderTarget2D>();
     }
 
+    //We set all cameras to start as nodisplay
+    //This improves performance because the capture components are no longer updating every frame and only update while requesting an image
     onViewModeChanged(true);
 
     gimbal_stabilization_ = 0;

--- a/Unreal/Plugins/AirSim/Source/PIPCamera.h
+++ b/Unreal/Plugins/AirSim/Source/PIPCamera.h
@@ -41,6 +41,9 @@ public:
 
     void setCameraTypeEnabled(ImageType type, bool enabled);
     bool getCameraTypeEnabled(ImageType type) const;
+    void setCaptureUpdate(USceneCaptureComponent2D* capture, bool nodisplay);
+    void setCameraTypeUpdate(ImageType type, bool nodisplay);
+
     void setupCameraFromSettings(const CameraSetting& camera_setting, const NedTransform& ned_transform);
     void setCameraPose(const msr::airlib::Pose& relative_pose);
     void setCameraFoV(float fov_degrees);

--- a/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
@@ -133,8 +133,10 @@ void ASimHUD::updateWidgetSubwindowVisibility()
 
         bool is_visible = getSubWindowSettings().at(window_index).visible && camera != nullptr;
 
-        if (camera != nullptr)
+        if (camera != nullptr) {
             camera->setCameraTypeEnabled(camera_type, is_visible);
+            camera->setCameraTypeUpdate(camera_type, false);
+        }
 
         widget_->setSubwindowVisibility(window_index,
                                         is_visible,

--- a/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
@@ -135,6 +135,7 @@ void ASimHUD::updateWidgetSubwindowVisibility()
 
         if (camera != nullptr) {
             camera->setCameraTypeEnabled(camera_type, is_visible);
+            //sub-window captures don’t count as a request, set bCaptureEveryFrame and bCaptureOnMovement to display so we can show correctly the subwindow
             camera->setCameraTypeUpdate(camera_type, false);
         }
 


### PR DESCRIPTION
Sets bAlwaysPersistRenderingState to true. This fixes bugs related to capture while on NoDisplay.
Sets bCaptureOnMovement and bCaptureEveryFrame to true only when they are going to be viewed on a subwindow

<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #1724 
Fixes: #2967
Fixes: #3504
Fixes: #3070

Partially fixes #4112

Should fix most of the FPS while capturing problems.

## About
<!-- Describe what your PR is about. -->
This PR fixes the NoDisplay/Headless bug by setting bAlwaysPersistRenderingState to true.

Setting bCaptureOnMovement and bCaptureEveryFrame to true only while it's on an active subwindow camera improves the performance of image capture/recording and python simGetImages

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
A python script was used to display the captured images to corroborate the accurate capture of the desired captures; the same script was used for all captures using ComputerVision.

```
import airsim
from cv2 import data
import numpy as np
from airsim import *
import cv2 
import datetime

def ImageResponsetoImage(selected):
    isFloat = selected.pixels_as_float
    if isFloat:
        img1d = np.array(selected.image_data_float)
    else:
        img1d = np.frombuffer(selected.image_data_uint8, dtype=np.uint8)

    width = selected.width
    height = selected.height
    channels = int(img1d.size / (height * width))
    img = img1d.reshape(height, width, channels)
    if (isFloat):
        depthinmm = img*1000
        depth_16bit =  np.clip(depthinmm, 0,65535) 
        return depth_16bit.astype(np.uint16)

    else:
        return img.astype(np.uint8)

if __name__ == "__main__":
    client = MultirotorClient()
    client.confirmConnection()

    i = 0
    inc = True
    while True:
        responses = client.simGetImages(
            [
                ImageRequest("front_left", ImageType.Scene, False, False),
                ImageRequest("front_left", ImageType.DepthPerspective, True, False),
                ImageRequest("front_left", ImageType.Segmentation, False, False),
                
                ImageRequest("front_center", ImageType.Scene, False, False),
                ImageRequest("front_center", ImageType.DepthPerspective, True, False),
                ImageRequest("front_center", ImageType.Segmentation, False, False),
                
                ImageRequest("front_right", ImageType.Scene, False, False),
                ImageRequest("front_right", ImageType.DepthPerspective, True, False),
                ImageRequest("front_right", ImageType.Segmentation, False, False),
                
                ImageRequest("bottom_center", ImageType.Scene, False, False),
                ImageRequest("bottom_center", ImageType.DepthPerspective, True, False),
                ImageRequest("bottom_center", ImageType.Segmentation, False, False),

                ImageRequest("back_center", ImageType.Scene, False, False),
                ImageRequest("back_center", ImageType.DepthPerspective, True, False),
                ImageRequest("back_center", ImageType.Segmentation, False, False),
                
            ]
        )
        tm = datetime.datetime.now().second % 10
        
        if tm % 2 == 0 :
            if inc:
                i += 1
            inc = False
        else:
            inc = True   
        if i >= len(responses):
            i = 0
        selected = responses[i]

        cv2.imshow("", ImageResponsetoImage(selected))
        cv2.waitKey(1)

```

Performance goes back up after stopping capture while on NoDisplay, but stays the same after recording or using the python simGetImages, but this can be fixed by displaying and hiding a subwindow.

settings.json

```
{
  "SeeDocsAt": "https://github.com/Microsoft/AirSim/blob/master/docs/settings.md",
  "SettingsVersion": 1.2,
  "ViewMode": "NoDisplay",
  "SimMode": "ComputerVision",
  "Recording": {
    "RecordOnMove": true,
    "RecordInterval": 0.05,
    "Folder": "",
    "Enabled": false,
    "Cameras": [
        { "CameraName": "0", "ImageType": 0, "PixelsAsFloat": false,  "VehicleName": "ComputerVision", "Compress": true },
        { "CameraName": "0", "ImageType": 1, "PixelsAsFloat": false,  "VehicleName": "ComputerVision", "Compress": true },
        { "CameraName": "0", "ImageType": 2, "PixelsAsFloat": false,  "VehicleName": "ComputerVision", "Compress": true },
        { "CameraName": "0", "ImageType": 7, "PixelsAsFloat": false,  "VehicleName": "ComputerVision", "Compress": true }
    ]
  },
  "CameraDefaults": {
    "CaptureSettings": [
      {
        "ImageType": 0,
        "Width": 640,
        "Height": 480
      },
      {
        "ImageType": 2,
        "Width": 640,
        "Height": 480
      },
      {
        "ImageType": 7,
        "Width": 640,
        "Height": 480
      },
      {
        "ImageType": 8,
        "Width": 640,
        "Height": 480
      },
      {
        "ImageType": 9,
        "Width": 640,
        "Height": 480
      },
      {
        "ImageType": 5,
        "Width": 640,
        "Height": 480
      }
    ],
    "NoiseSettings": [
      {
        "Enabled": false,
        "ImageType": 7,

        "RandContrib": 0.2,
        "RandSpeed": 100000.0,
        "RandSize": 500.0,
        "RandDensity": 2,

        "HorzWaveContrib":0.03,
        "HorzWaveStrength": 0.08,
        "HorzWaveVertSize": 1.0,
        "HorzWaveScreenSize": 1.0,

        "HorzNoiseLinesContrib": 1.0,
        "HorzNoiseLinesDensityY": 0.01,
        "HorzNoiseLinesDensityXY": 0.5,

        "HorzDistortionContrib": 1.0,
        "HorzDistortionStrength": 0.002
      }
    ]
  },
  "SegmentationSettings": {
    "InitMethod": "",
    "MeshNamingMethod": "StaticMeshName",
    "OverrideExisting": true
  }
}

```

## Screenshots (if appropriate)

NoDisplay

RGB
Previous:
![PreFixRGB](https://user-images.githubusercontent.com/5291065/140605085-a3ec1f09-e423-4106-8b06-b57120fa5a87.png)

![FixRGB](https://user-images.githubusercontent.com/5291065/140605082-863f01eb-d6cd-4952-a773-2037f3c02476.png)

Depth:
Previous:
![PreFixDepth](https://user-images.githubusercontent.com/5291065/140605084-7d105378-3a78-412d-ad4e-1f1020aae8a6.png)

After:
![FixDepth](https://user-images.githubusercontent.com/5291065/140605081-e8fd9fc5-6692-4f8e-8431-11a08dfa3c8c.png)

Segmentation 
Previous:
![PreFixSegmentation](https://user-images.githubusercontent.com/5291065/140605080-9ee7ad76-286a-40b0-bbdf-6eabc86986fe.png)

After:
![FixSegmentation](https://user-images.githubusercontent.com/5291065/140605083-46730413-62f2-4547-a97d-f8d47abb3c9a.png)

Performance captures

Recording previous to fix
![Recording prefix](https://user-images.githubusercontent.com/5291065/140610499-04d8fd04-3b91-4f2f-b8b5-9daebeaa3b14.png)

After recording and showing and hiding subwindow (small gain)
![Recording preFix aSubwindows](https://user-images.githubusercontent.com/5291065/140610496-6a32ffed-9048-4b8a-bb9e-78fe95f1a959.png)

Recording after fix (Lower timings, )
![Recording after fix](https://user-images.githubusercontent.com/5291065/140610653-d20fb735-f600-4ff0-a3d4-00e1d995e78d.png)

After recording and showing and hiding subwindow (Back to normal)
![Recording after Fix Subwindows](https://user-images.githubusercontent.com/5291065/140610709-613b50e0-631d-43a2-86c5-3cc440524abe.png)

Python capture before fix
![python capture before](https://user-images.githubusercontent.com/5291065/140611029-039b7157-ea96-48b5-bd1b-96c63c4ebb70.png)

Python capture post fix
![python capture](https://user-images.githubusercontent.com/5291065/140610868-50f1a8a5-c65d-4f9b-ace9-9ce68b7c23b3.png)

Python capture before fix (Only front_center)
![python before only front](https://user-images.githubusercontent.com/5291065/140611168-e03e660f-9069-429b-88bf-03009332ffe5.png)

Python capture after fix (Only front_center)
![python after only front](https://user-images.githubusercontent.com/5291065/140611166-fd5e0fe7-abf5-42ab-be18-d17c465880ca.png)

Python capture before fix (Only front_center Scene)
![only RGB](https://user-images.githubusercontent.com/5291065/140611272-f43d2dbd-78d1-42e3-b561-8278c35b0247.png)

Python capture after fix (Only front_center Scene)
![after only RGB](https://user-images.githubusercontent.com/5291065/140611227-dc3e2e62-17f4-40b5-8c3b-ce15e732d909.png)

While capturing with python's simGetImages the performance after the fix are lower, but measurable: 205 ms vs 185ms, 70ms vs 54, single images are within margin error, but fix is still lower

For comparison here are the timings of all cameras and NoDIsplay

While capturing
![capture python ND](https://user-images.githubusercontent.com/5291065/140612125-a93de350-684b-4e07-b3d7-6d56877087f1.png)

After stopping capturing, the levels go back to normal without needing to enable a subwindow.
![After capture python ND](https://user-images.githubusercontent.com/5291065/140612126-365eb920-3e59-4803-96e6-2c50804c5e71.png)


