### PR TITLE
Fix simPause for Car

### DIFF
--- a/AirLib/include/vehicles/car/CarApiFactory.hpp
+++ b/AirLib/include/vehicles/car/CarApiFactory.hpp
@@ -17,15 +17,14 @@ namespace airlib
     public:
         static std::unique_ptr<CarApiBase> createApi(const AirSimSettings::VehicleSetting* vehicle_setting,
                                                      std::shared_ptr<SensorFactory> sensor_factory,
-                                                     const Kinematics::State& state, const Environment& environment,
-                                                     const msr::airlib::GeoPoint& home_geopoint)
+                                                     const Kinematics::State& state, const Environment& environment)
         {
             if (vehicle_setting->vehicle_type == AirSimSettings::kVehicleTypeArduRover) {
-                return std::unique_ptr<CarApiBase>(new ArduRoverApi(vehicle_setting, sensor_factory, state, environment, home_geopoint));
+                return std::unique_ptr<CarApiBase>(new ArduRoverApi(vehicle_setting, sensor_factory, state, environment));
             }
             else if (vehicle_setting->vehicle_type == "" || //default config
                      vehicle_setting->vehicle_type == AirSimSettings::kVehicleTypePhysXCar) {
-                return std::unique_ptr<CarApiBase>(new PhysXCarApi(vehicle_setting, sensor_factory, state, environment, home_geopoint));
+                return std::unique_ptr<CarApiBase>(new PhysXCarApi(vehicle_setting, sensor_factory, state, environment));
             }
             else
                 throw std::runtime_error(Utils::stringf(

--- a/AirLib/include/vehicles/car/firmwares/ardurover/ArduRoverApi.hpp
+++ b/AirLib/include/vehicles/car/firmwares/ardurover/ArduRoverApi.hpp
@@ -32,8 +32,8 @@ namespace airlib
 
     public:
         ArduRoverApi(const AirSimSettings::VehicleSetting* vehicle_setting, std::shared_ptr<SensorFactory> sensor_factory,
-                     const Kinematics::State& state, const Environment& environment, const msr::airlib::GeoPoint& home_geopoint)
-            : CarApiBase(vehicle_setting, sensor_factory, state, environment), home_geopoint_(home_geopoint)
+                     const Kinematics::State& state, const Environment& environment)
+            : CarApiBase(vehicle_setting, sensor_factory, state, environment), home_geopoint_(environment.getHomeGeoPoint())
         {
             connection_info_ = static_cast<const AirSimSettings::MavLinkVehicleSetting*>(vehicle_setting)->connection_info;
             sensors_ = &getSensors();

--- a/AirLib/include/vehicles/car/firmwares/physxcar/PhysXCarApi.hpp
+++ b/AirLib/include/vehicles/car/firmwares/physxcar/PhysXCarApi.hpp
@@ -15,8 +15,8 @@ namespace airlib
     {
     public:
         PhysXCarApi(const AirSimSettings::VehicleSetting* vehicle_setting, std::shared_ptr<SensorFactory> sensor_factory,
-                    const Kinematics::State& state, const Environment& environment, const msr::airlib::GeoPoint& home_geopoint)
-            : CarApiBase(vehicle_setting, sensor_factory, state, environment), home_geopoint_(home_geopoint)
+                    const Kinematics::State& state, const Environment& environment)
+            : CarApiBase(vehicle_setting, sensor_factory, state, environment), home_geopoint_(environment.getHomeGeoPoint())
         {
         }
 

--- a/PythonClient/car/pause_test.py
+++ b/PythonClient/car/pause_test.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import airsim
+import time
+import numpy as np
+
+# connect to the AirSim simulator
+client = airsim.CarClient()
+client.confirmConnection()
+client.enableApiControl(True)
+car_controls = airsim.CarControls()
+
+# set the controls for car
+car_controls.throttle = -0.5
+car_controls.is_manual_gear = True
+car_controls.manual_gear = -1
+client.setCarControls(car_controls)
+
+# let car drive a bit
+time.sleep(10)
+
+client.simPause(True)
+car_position1 = client.getCarState().kinematics_estimated.position
+img_position1 = client.simGetImages([airsim.ImageRequest(0, airsim.ImageType.Scene)])[0].camera_position
+print(f"Before pause position: {car_position1}")
+print(f"Before pause diff: {car_position1.x_val - img_position1.x_val}, {car_position1.y_val - img_position1.y_val}, {car_position1.z_val - img_position1.z_val}")
+
+time.sleep(10)
+
+car_position2 = client.getCarState().kinematics_estimated.position
+img_position2 = client.simGetImages([airsim.ImageRequest(0, airsim.ImageType.Scene)])[0].camera_position
+print(f"After pause position: {car_position2}")
+print(f"After pause diff: {car_position2.x_val - img_position2.x_val}, {car_position2.y_val - img_position2.y_val}, {car_position2.z_val - img_position2.z_val}")
+client.simPause(False)

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/Vehicles/Car/CarPawnSimApi.cpp
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/Vehicles/Car/CarPawnSimApi.cpp
@@ -7,7 +7,7 @@
 #include "../../UnitySensors/UnitySensorFactory.h"
 
 CarPawnSimApi::CarPawnSimApi(const Params& params, std::string car_name)
-    : PawnSimApi(params), params_(params), car_name_(car_name)
+    : PawnSimApi(params), car_name_(car_name)
 {
 }
 
@@ -15,18 +15,16 @@ void CarPawnSimApi::initialize()
 {
     PawnSimApi::initialize();
 
-    createVehicleApi(params_.home_geopoint);
+    std::shared_ptr<UnitySensorFactory> sensor_factory = std::make_shared<UnitySensorFactory>(car_name_, &getNedTransform());
+
+    vehicle_api_ = CarApiFactory::createApi(getVehicleSetting(),
+                                            sensor_factory,
+                                            *getGroundTruthKinematics(),
+                                            *getGroundTruthEnvironment());
+    pawn_api_ = std::unique_ptr<CarPawnApi>(new CarPawnApi(getGroundTruthKinematics(), car_name_, vehicle_api_.get()));
 
     //TODO: should do reset() here?
     joystick_controls_ = msr::airlib::CarApiBase::CarControls();
-}
-
-void CarPawnSimApi::createVehicleApi(const msr::airlib::GeoPoint& home_geopoint)
-{
-    std::shared_ptr<UnitySensorFactory> sensor_factory = std::make_shared<UnitySensorFactory>(car_name_, &getNedTransform());
-
-    vehicle_api_ = CarApiFactory::createApi(getVehicleSetting(), sensor_factory, (*getGroundTruthKinematics()), (*getGroundTruthEnvironment()), home_geopoint);
-    pawn_api_ = std::unique_ptr<CarPawnApi>(new CarPawnApi(getGroundTruthKinematics(), car_name_, vehicle_api_.get()));
 }
 
 std::string CarPawnSimApi::getRecordFileLine(bool is_header_line) const

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/Vehicles/Car/CarPawnSimApi.h
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/Vehicles/Car/CarPawnSimApi.h
@@ -14,7 +14,6 @@ public:
     typedef msr::airlib::Pose Pose;
 
 private:
-    void createVehicleApi(const msr::airlib::GeoPoint& home_geopoint);
     void updateCarControls();
 
 public:
@@ -37,8 +36,6 @@ protected:
     virtual void resetImplementation() override;
 
 private:
-    Params params_;
-
     std::unique_ptr<msr::airlib::CarApiBase> vehicle_api_;
     std::unique_ptr<CarPawnApi> pawn_api_;
     std::vector<std::string> vehicle_api_messages_;

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
@@ -22,7 +22,7 @@ PawnSimApi::PawnSimApi(const Params& params)
 void PawnSimApi::initialize()
 {
     Kinematics::State initial_kinematic_state = Kinematics::State::zero();
-    ;
+
     initial_kinematic_state.pose = getPose();
     kinematics_.reset(new Kinematics(initial_kinematic_state));
 

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
@@ -283,14 +283,12 @@ void ASimModeBase::setTimeOfDay(bool is_enabled, const std::string& start_dateti
 
 bool ASimModeBase::isPaused() const
 {
-    return false;
+    return UGameplayStatics::IsGamePaused(this->GetWorld());
 }
 
 void ASimModeBase::pause(bool is_paused)
 {
-    //should be overridden by derived class
-    unused(is_paused);
-    throw std::domain_error("Pause is not implemented by SimMode");
+    UGameplayStatics::SetGamePaused(this->GetWorld(), is_paused);
 }
 
 void ASimModeBase::continueForTime(double seconds)

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeWorldBase.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeWorldBase.cpp
@@ -91,7 +91,7 @@ bool ASimModeWorldBase::isPaused() const
 void ASimModeWorldBase::pause(bool is_paused)
 {
     physics_world_->pause(is_paused);
-    UGameplayStatics::SetGamePaused(this->GetWorld(), is_paused);
+    ASimModeBase::pause(is_paused);
 }
 
 void ASimModeWorldBase::continueForTime(double seconds)

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnSimApi.cpp
@@ -7,8 +7,8 @@
 using namespace msr::airlib;
 
 CarPawnSimApi::CarPawnSimApi(const Params& params,
-                             const msr::airlib::CarApiBase::CarControls& keyboard_controls, UWheeledVehicleMovementComponent* movement)
-    : PawnSimApi(params), params_(params), keyboard_controls_(keyboard_controls)
+                             const msr::airlib::CarApiBase::CarControls& keyboard_controls)
+    : PawnSimApi(params), keyboard_controls_(keyboard_controls)
 {
 }
 
@@ -16,19 +16,17 @@ void CarPawnSimApi::initialize()
 {
     PawnSimApi::initialize();
 
-    createVehicleApi(static_cast<ACarPawn*>(params_.pawn), params_.home_geopoint);
-
-    //TODO: should do reset() here?
-    joystick_controls_ = msr::airlib::CarApiBase::CarControls();
-}
-
-void CarPawnSimApi::createVehicleApi(ACarPawn* pawn, const msr::airlib::GeoPoint& home_geopoint)
-{
     //create vehicle params
     std::shared_ptr<UnrealSensorFactory> sensor_factory = std::make_shared<UnrealSensorFactory>(getPawn(), &getNedTransform());
 
-    vehicle_api_ = CarApiFactory::createApi(getVehicleSetting(), sensor_factory, (*getGroundTruthKinematics()), (*getGroundTruthEnvironment()), home_geopoint);
-    pawn_api_ = std::unique_ptr<CarPawnApi>(new CarPawnApi(pawn, getGroundTruthKinematics(), vehicle_api_.get()));
+    vehicle_api_ = CarApiFactory::createApi(getVehicleSetting(),
+                                            sensor_factory,
+                                            *getGroundTruthKinematics(),
+                                            *getGroundTruthEnvironment());
+    pawn_api_ = std::unique_ptr<CarPawnApi>(new CarPawnApi(static_cast<ACarPawn*>(getPawn()), getGroundTruthKinematics(), vehicle_api_.get()));
+
+    //TODO: should do reset() here?
+    joystick_controls_ = msr::airlib::CarApiBase::CarControls();
 }
 
 std::string CarPawnSimApi::getRecordFileLine(bool is_header_line) const

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnSimApi.h
@@ -28,7 +28,7 @@ public:
     //VehicleSimApiBase interface
     //implements game interface to update pawn
     CarPawnSimApi(const Params& params,
-                  const msr::airlib::CarApiBase::CarControls& keyboard_controls, UWheeledVehicleMovementComponent* movement);
+                  const msr::airlib::CarApiBase::CarControls& keyboard_controls);
 
     virtual void update() override;
     virtual void reportState(StateReporter& reporter) override;
@@ -52,12 +52,9 @@ protected:
     virtual void resetImplementation() override;
 
 private:
-    void createVehicleApi(ACarPawn* pawn, const msr::airlib::GeoPoint& home_geopoint);
     void updateCarControls();
 
 private:
-    Params params_;
-
     std::unique_ptr<msr::airlib::CarApiBase> vehicle_api_;
     std::unique_ptr<CarPawnApi> pawn_api_;
     std::vector<std::string> vehicle_api_messages_;

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/SimModeCar.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/SimModeCar.cpp
@@ -123,8 +123,7 @@ std::unique_ptr<PawnSimApi> ASimModeCar::createVehicleSimApi(
 {
     auto vehicle_pawn = static_cast<TVehiclePawn*>(pawn_sim_api_params.pawn);
     auto vehicle_sim_api = std::unique_ptr<PawnSimApi>(new CarPawnSimApi(pawn_sim_api_params,
-                                                                         vehicle_pawn->getKeyBoardControls(),
-                                                                         vehicle_pawn->getVehicleMovementComponent()));
+                                                                         vehicle_pawn->getKeyBoardControls()));
     vehicle_sim_api->initialize();
     vehicle_sim_api->reset();
     return vehicle_sim_api;

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/SimModeCar.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/SimModeCar.cpp
@@ -25,21 +25,6 @@ void ASimModeCar::initializePauseState()
     pause(false);
 }
 
-bool ASimModeCar::isPaused() const
-{
-    return current_clockspeed_ == 0;
-}
-
-void ASimModeCar::pause(bool is_paused)
-{
-    if (is_paused)
-        current_clockspeed_ = 0;
-    else
-        current_clockspeed_ = getSettings().clock_speed;
-
-    UAirBlueprintLib::setUnrealClockSpeed(this, current_clockspeed_);
-}
-
 void ASimModeCar::continueForTime(double seconds)
 {
     pause_period_start_ = ClockFactory::get()->nowNanos();

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/SimModeCar.h
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/SimModeCar.h
@@ -17,8 +17,6 @@ public:
     virtual void BeginPlay() override;
     virtual void Tick(float DeltaSeconds) override;
 
-    virtual bool isPaused() const override;
-    virtual void pause(bool is_paused) override;
     virtual void continueForTime(double seconds) override;
     virtual void continueForFrames(uint32_t frames) override;
 

--- a/Unreal/Plugins/AirSim/Source/Vehicles/ComputerVision/SimModeComputerVision.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/ComputerVision/SimModeComputerVision.cpp
@@ -75,13 +75,3 @@ msr::airlib::VehicleApiBase* ASimModeComputerVision::getVehicleApi(const PawnSim
     //we don't have real vehicle so no vehicle API
     return nullptr;
 }
-
-bool ASimModeComputerVision::isPaused() const
-{
-    return UGameplayStatics::IsGamePaused(this->GetWorld());
-}
-
-void ASimModeComputerVision::pause(bool is_paused)
-{
-    UGameplayStatics::SetGamePaused(this->GetWorld(), is_paused);
-}

--- a/Unreal/Plugins/AirSim/Source/Vehicles/ComputerVision/SimModeComputerVision.h
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/ComputerVision/SimModeComputerVision.h
@@ -29,6 +29,4 @@ protected:
         const PawnSimApi::Params& pawn_sim_api_params) const override;
     virtual msr::airlib::VehicleApiBase* getVehicleApi(const PawnSimApi::Params& pawn_sim_api_params,
                                                        const PawnSimApi* sim_api) const override;
-    virtual bool isPaused() const override;
-    virtual void pause(bool is_paused) override;
 };


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #4174   <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
Fixes the `simPause` API for Car by using `UGamePlayStatistics::SetGamePaused` (probably missed in #2292). And some refactoring

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
Using the script given in #4174 (thanks to @suresh-guttikonda!) -
Before fix using 1.6.0 release -
```
Connected!
Client Ver:1 (Min Req: 1), Server Ver:1 (Min Req: 1)

Before pause: -1.5656204223632812, 0.7037484645843506, 0.998582124710083
After pause: -1.824690818786621, 0.8202106952667236, 0.9985887110233307
```

After fix -
```
Connected!
Client Ver:1 (Min Req: 1), Server Ver:1 (Min Req: 1)

Before pause position: <Vector3r> {   'x_val': -8.31222915649414,
    'y_val': -0.0024077333509922028,
    'z_val': 0.2384161353111267}
Before pause diff: -1.7417960166931152, -0.00044455076567828655, 0.9980698227882385
After pause position: <Vector3r> {   'x_val': -8.31222915649414,
    'y_val': -0.0024077333509922028,
    'z_val': 0.2384161353111267}
After pause: -1.7417960166931152, -0.00044455076567828655, 0.9980698227882385
```

## Screenshots (if appropriate):