### PR TITLE
keep CollisionInfo.has_collided flag set until simGetCollisionInfo called

### DIFF
--- a/AirLib/include/api/VehicleSimApiBase.hpp
+++ b/AirLib/include/api/VehicleSimApiBase.hpp
@@ -58,6 +58,7 @@ namespace airlib
         virtual const msr::airlib::Environment* getGroundTruthEnvironment() const = 0;
 
         virtual CollisionInfo getCollisionInfo() const = 0;
+        virtual CollisionInfo getCollisionInfoAndReset() = 0;
         virtual int getRemoteControlID() const = 0; //which RC to use, 0 is first one, -1 means disable RC (use keyborad)
         virtual RCData getRCData() const = 0; //get reading from RC from simulator's host OS
         virtual std::string getVehicleName() const = 0;

--- a/AirLib/src/api/RpcLibServerBase.cpp
+++ b/AirLib/src/api/RpcLibServerBase.cpp
@@ -357,7 +357,7 @@ namespace airlib
         });
 
         pimpl_->server.bind("simGetCollisionInfo", [&](const std::string& vehicle_name) -> RpcLibAdaptorsBase::CollisionInfo {
-            const auto& collision_info = getVehicleSimApi(vehicle_name)->getCollisionInfo();
+            const auto& collision_info = getVehicleSimApi(vehicle_name)->getCollisionInfoAndReset();
             return RpcLibAdaptorsBase::CollisionInfo(collision_info);
         });
 

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/PawnSimApi.cpp
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/PawnSimApi.cpp
@@ -168,6 +168,13 @@ PawnSimApi::CollisionInfo PawnSimApi::getCollisionInfo() const
     return state_.collision_info;
 }
 
+PawnSimApi::CollisionInfo PawnSimApi::getCollisionInfoAndReset()
+{
+    CollisionInfo collision_info = getCollisionInfo();
+    state_.collision_info.has_collided = false;
+    return collision_info;
+}
+
 void PawnSimApi::toggleTrace()
 {
     state_.tracing_enabled = !state_.tracing_enabled;

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/PawnSimApi.h
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/PawnSimApi.h
@@ -74,6 +74,7 @@ public:
     virtual void setPose(const Pose& pose, bool ignore_collision) override;
 
     virtual CollisionInfo getCollisionInfo() const override;
+    virtual CollisionInfo getCollisionInfoAndReset() override;
     virtual int getRemoteControlID() const override;
     virtual msr::airlib::RCData getRCData() const override;
     virtual std::string getVehicleName() const override

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
@@ -360,6 +360,13 @@ PawnSimApi::CollisionInfo PawnSimApi::getCollisionInfo() const
     return state_.collision_info;
 }
 
+PawnSimApi::CollisionInfo PawnSimApi::getCollisionInfoAndReset()
+{
+    CollisionInfo collision_info = getCollisionInfo();
+    state_.collision_info.has_collided = false;
+    return collision_info;
+}
+
 FVector PawnSimApi::getUUPosition() const
 {
     return params_.pawn->GetActorLocation(); // - state_.mesh_origin
@@ -447,10 +454,6 @@ void PawnSimApi::setPoseInternal(const Pose& pose, bool ignore_collision)
 
     bool enable_teleport = ignore_collision || canTeleportWhileMove();
 
-    //must reset collision before we set pose. Setting pose will immediately call NotifyHit if there was collision
-    //if there was no collision than has_collided would remain false, else it will be set so its value can be
-    //checked at the start of next tick
-    state_.collision_info.has_collided = false;
     state_.was_last_move_teleport = enable_teleport;
 
     if (enable_teleport)

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.h
@@ -81,6 +81,7 @@ public: //implementation of VehicleSimApiBase
     virtual void setPose(const Pose& pose, bool ignore_collision) override;
 
     virtual CollisionInfo getCollisionInfo() const override;
+    virtual CollisionInfo getCollisionInfoAndReset() override;
     virtual int getRemoteControlID() const override;
     virtual msr::airlib::RCData getRCData() const override;
     virtual std::string getVehicleName() const override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #1004    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
This adds a new method to PawnSimApi called getCollisionInfoAndReset() which both returns collision info as well as reset the has_collided flag. The old behavior for resetting CollisionInfo.has_collided after every clock tick has been removed and simGetCollisionInfo now calls getCollisionInfoAndReset(), which means this method will return whether any collision has occurred since last call to simGetCollisionInfo instead of only within the last clock tick.

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
Collisions were tested in the Blocks environment with the EnableCollisionPassthrogh parameter set to both true and false.

## Screenshots (if appropriate):