### PR TITLE
Set bOnlyCollidingComponents to true

### DIFF
--- a/Unreal/Plugins/AirSim/Source/DetectionComponent.cpp
+++ b/Unreal/Plugins/AirSim/Source/DetectionComponent.cpp
@@ -67,7 +67,7 @@ bool UDetectionComponent::calcBoundingFromViewInfo(AActor* actor, FBox2D& box_ou
 {
     FVector origin;
     FVector extend;
-    actor->GetActorBounds(false, origin, extend);
+    actor->GetActorBounds(true, origin, extend);
 
     TArray<FVector> points;
     TArray<FVector2D> points_2D;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: https://github.com/microsoft/AirSim/issues/4263    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
The object detection API returns wrong bounding boxes for the actors belonging the character class. It seems setting `bOnlyCollidingComponents` argument (i.e., the first argument of `GetActorBounds` function in UE4)to `true` solves the problem. See the attached issue for more information.

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
Tested locally with UE4.27 and Ubuntu 20.04. You can add a Character to Blocks environment, and run [detection.py](https://github.com/microsoft/AirSim/blob/master/PythonClient/detection/detection.py).

## Screenshots (if appropriate):
Before:
![image](https://user-images.githubusercontent.com/8015532/148082041-0abdb949-0e7e-4164-a9b1-f111ecfcc14c.png)
After (bounding boxes are more tight now):
![image](https://user-images.githubusercontent.com/8015532/148082180-2d3c0af0-4e2f-4b9b-9518-78f51b9f5ab9.png)

See the issue for more figures