### PR TITLE
Add AirSimManager to CarDemo scene in Unity

### DIFF
--- a/Unity/UnityDemo/Assets/Scenes/CarDemo.unity
+++ b/Unity/UnityDemo/Assets/Scenes/CarDemo.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18028334, g: 0.2257134, b: 0.30692226, a: 1}
+  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -11405,6 +11405,62 @@ Transform:
   m_Children: []
   m_Father: {fileID: 150083486}
   m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1857691388
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1857691391}
+  - component: {fileID: 1857691390}
+  - component: {fileID: 1857691389}
+  m_Layer: 0
+  m_Name: AirSimManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1857691389
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1857691388}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ca72950c6b9a95848b5b1bee27e51ff8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1857691390
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1857691388}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9cc58e6de68c02747a4aa12440551a3b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1857691391
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1857691388}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1859598756
 GameObject:


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

## Fixes:     <!-- add this line for each issue your PR solves. -->
The RPC server of CarDemo isn't launched when running CarDemo scene in Unity.
## About
<!-- Describe what your PR is about. -->
Add AirSimManager to CarDemo scene in Unity to launch RPC server when CarDemo scene is started.
## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
``` shell
# when AirSimManager wasn't added to CarDemo, the rpc server was not started.
python .\hello_car.py
WARNING:tornado.general:Connect error on fd 1192: WSAECONNREFUSED
WARNING:tornado.general:Connect error on fd 1192: WSAECONNREFUSED
WARNING:tornado.general:Connect error on fd 1192: WSAECONNREFUSED
WARNING:tornado.general:Connect error on fd 1192: WSAECONNREFUSED
WARNING:tornado.general:Connect error on fd 1192: WSAECONNREFUSED
Traceback (most recent call last):
  File ".\hello_car.py", line 11, in <module>
    client.confirmConnection()
  File "C:\code\AirSim\PythonClient\airsim\client.py", line 139, in confirmConnection
    if self.ping():
  File "C:\code\AirSim\PythonClient\airsim\client.py", line 35, in ping
    return self.client.call('ping')
  File "C:\Users\*\anaconda3\lib\site-packages\msgpackrpc\session.py", line 41, in call
    return self.send_request(method, args).get()
  File "C:\Users\*\anaconda3\lib\site-packages\msgpackrpc\future.py", line 43, in get
    raise self._error
msgpackrpc.error.TransportError: Retry connection over the limit

# when AirSimManager is added to CarDemo, hello_car.py runs correctly.
python .\hello_car.py
Connected!
Client Ver:1 (Min Req: 1), Server Ver:1 (Min Req: 1)

API Control enabled: True
Saving images to C:\Users\*\AppData\Local\Temp\airsim_car
Speed 0, Gear 0
Go Forward
Go Forward, steer right
Go reverse, steer right
Apply brakes
Retrieved images: 4
Type 3, size 23651
Type 2, size 36864
Type 0, size 23596
Type 0, size 110592
Speed 11, Gear 0
Go Forward
Go Forward, steer right
Go reverse, steer right
Apply brakes
Retrieved images: 4
Type 3, size 1698
Type 2, size 36864
Type 0, size 26066
Type 0, size 110592
Speed 9, Gear 0
Go Forward
Go Forward, steer right
Go reverse, steer right
Apply brakes
Retrieved images: 4
Type 3, size 1720
Type 2, size 36864
Type 0, size 22335
Type 0, size 110592
```
## Screenshots (if appropriate):
<img width="269" alt="current hierarchy of DroneDemo" src="https://user-images.githubusercontent.com/23168485/149345564-43dc89e2-d69e-4125-aeea-4a2e456723a5.png"  title="current hierarchy of DroneDemo">
<img width="266" alt="current hierarchy of CarDemo" src="https://user-images.githubusercontent.com/23168485/149345583-3260bc3b-8860-47e2-8d1c-faaa20641037.png" title="current hierarchy of CarDemo">

Compared to DroneDemo, CarDemo lacks AirSimManager.
