### PR TITLE
fix clock speed in car mode

### DIFF
--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnApi.cpp
@@ -35,7 +35,7 @@ msr::airlib::CarApiBase::CarState CarPawnApi::getCarState() const
         movement_->GetEngineMaxRotationSpeed(),
         last_controls_.handbrake,
         *pawn_kinematics_,
-        msr::airlib::ClockFactory::get()->nowNanos());
+        vehicle_api_->clock()->nowNanos());
     return state;
 }
 

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/SimModeCar.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/SimModeCar.cpp
@@ -41,6 +41,8 @@ void ASimModeCar::continueForFrames(uint32_t frames)
 
 void ASimModeCar::setupClockSpeed()
 {
+    Super::setupClockSpeed();
+
     current_clockspeed_ = getSettings().clock_speed;
 
     //setup clock in PhysX


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #4241    <!-- add this line for each issue your PR solves. -->
Fixes: #4232<!-- Fixes: # -->
<!-- Fixes: # -->

## About
The car mode currently utilizes a default clock for returning the CarState's timestamp, so the clock speed from the settings isn't reflected in the timestamp. This change adds logic for initializing the appropriate clock type from settings as well as logic for reading the timestamp from the newly initialized clock. 
<!-- Describe what your PR is about. -->

## How Has This Been Tested?
The following script was used in car mode to confirm the clock was advancing at the proper clock speed. This script outputs the delta of the simulation clock after 1 real-world second elapses. If everything is working correctly, this script should output the same value as the ClockSpeed in the settings:

```
import setup_path 
import airsim

import pprint
import time

# connect to the AirSim simulator 
#client = airsim.MultirotorClient()
client = airsim.CarClient()
client.confirmConnection()
client.enableApiControl(True)

#prev = client.getMultirotorState().timestamp
prev = client.getCarState().timestamp
curr = prev
print(prev)
while True:
    #curr = client.getMultirotorState().timestamp
    curr = client.getCarState().timestamp
    delta = curr - prev
    prev = curr
    print(delta / 1000000000)
    time.sleep(1.0)

client.enableApiControl(False)
```
<!-- Please, describe how you have tested your changes to help us incorporate them. -->

## Screenshots (if appropriate):