### PR TITLE
update pixel format of UTextureRenderTarget2D instances

### DIFF
--- a/Unreal/Plugins/AirSim/Source/PIPCamera.cpp
+++ b/Unreal/Plugins/AirSim/Source/PIPCamera.cpp
@@ -36,16 +36,16 @@ APIPCamera::APIPCamera(const FObjectInitializer& ObjectInitializer)
 
     PrimaryActorTick.bCanEverTick = true;
 
-    image_type_to_pixel_format_map_.Add(0, EPixelFormat::PF_B8G8R8A8);
+    image_type_to_pixel_format_map_.Add(0, EPixelFormat::PF_FloatRGBA);
     image_type_to_pixel_format_map_.Add(1, EPixelFormat::PF_DepthStencil); // not used. init_auto_format is called in setupCameraFromSettings()
     image_type_to_pixel_format_map_.Add(2, EPixelFormat::PF_DepthStencil); // not used for same reason as above
     image_type_to_pixel_format_map_.Add(3, EPixelFormat::PF_DepthStencil); // not used for same reason as above
     image_type_to_pixel_format_map_.Add(4, EPixelFormat::PF_DepthStencil); // not used for same reason as above
-    image_type_to_pixel_format_map_.Add(5, EPixelFormat::PF_B8G8R8A8);
-    image_type_to_pixel_format_map_.Add(6, EPixelFormat::PF_B8G8R8A8);
-    image_type_to_pixel_format_map_.Add(7, EPixelFormat::PF_B8G8R8A8);
-    image_type_to_pixel_format_map_.Add(8, EPixelFormat::PF_B8G8R8A8);
-    image_type_to_pixel_format_map_.Add(9, EPixelFormat::PF_B8G8R8A8);
+    image_type_to_pixel_format_map_.Add(5, EPixelFormat::PF_FloatRGBA);
+    image_type_to_pixel_format_map_.Add(6, EPixelFormat::PF_FloatRGBA);
+    image_type_to_pixel_format_map_.Add(7, EPixelFormat::PF_FloatRGBA);
+    image_type_to_pixel_format_map_.Add(8, EPixelFormat::PF_FloatRGBA);
+    image_type_to_pixel_format_map_.Add(9, EPixelFormat::PF_FloatRGBA);
 
     object_filter_ = FObjectFilter();
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #4120    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
This PR switches the pixel format inside the UTextureRenderTarget2D for various image types from EPixelFormat::PF_B8G8R8A8 to EPixelFormat::PF_FloatRGBA to enable compatibility with FD3D11DynamicRHI::RHIReadSurfaceFloatData. There is a check inside FD3D11DynamicRHI::RHIReadSurfaceFloatData that ensures the pixel format of the inputted FRHITexture is EPixelFormat::PF_FloatRGBA.
<!-- Describe what your PR is about. -->

## How Has This Been Tested?
The scenario described in the repro steps of #4120 was confirmed to be working with this fix. Basic movement of a drone with a controller was tested with subwindows for each ImageType enabled to confirm each ImageType renders correctly. hello_drone.py was also run to confirm scene captures can still be taken and look correct.
<!-- Please, describe how you have tested your changes to help us incorporate them. -->

## Screenshots (if appropriate):