### PR TITLE
deprecate moveByAngleZAsync and moveByAngleThrottleAsync

### DIFF
--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -1190,10 +1190,12 @@ class MultirotorClient(VehicleClient, object):
         return self.client.call_async('moveByVelocityZBodyFrame', vx, vy, z, duration, drivetrain, yaw_mode, vehicle_name)
 
     def moveByAngleZAsync(self, pitch, roll, z, yaw, duration, vehicle_name = ''):
-        return self.client.call_async('moveByAngleZ', pitch, roll, z, yaw, duration, vehicle_name)
+        logging.warning("moveByAngleZAsync API is deprecated, use moveByRollPitchYawZAsync() API instead")
+        return self.client.call_async('moveByRollPitchYawZ', roll, -pitch, -yaw, z, duration, vehicle_name)
 
     def moveByAngleThrottleAsync(self, pitch, roll, throttle, yaw_rate, duration, vehicle_name = ''):
-        return self.client.call_async('moveByAngleThrottle', pitch, roll, throttle, yaw_rate, duration, vehicle_name)
+        logging.warning("moveByAngleThrottleAsync API is deprecated, use moveByRollPitchYawrateThrottleAsync() API instead")
+        return self.client.call_async('moveByRollPitchYawrateThrottle', roll, -pitch, -yaw_rate, throttle, duration, vehicle_name)
 
     def moveByVelocityAsync(self, vx, vy, vz, duration, drivetrain = DrivetrainType.MaxDegreeOfFreedom, yaw_mode = YawMode(), vehicle_name = ''):
         """


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #4304    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
This PR deprecates moveByAngleZAsync and moveByAngleThrottleAsync because their server bindings don't exist anymore. These APIs were replaced by moveByRollPitchYawZ and moveByRollPitchYawrateThrottle in #2297<!-- Describe what your PR is about. -->

## How Has This Been Tested?
The test script was run calling each of the deprecated APIs to confirm the correct log message is outputted and the new APIs are called instead.<!-- Please, describe how you have tested your changes to help us incorporate them. -->

## Screenshots (if appropriate):