### PR TITLE
Fix ros reset service crash

### DIFF
--- a/ros/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
+++ b/ros/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
@@ -442,7 +442,7 @@ bool AirsimROSWrapper::reset_srv_cb(airsim_ros_pkgs::Reset::Request& request, ai
 {
     std::lock_guard<std::mutex> guard(drone_control_mutex_);
 
-    airsim_client_.reset();
+    airsim_client_->reset();
 
     response.success = true;
     return response.success; //todo

--- a/ros2/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
+++ b/ros2/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
@@ -439,7 +439,7 @@ bool AirsimROSWrapper::reset_srv_cb(std::shared_ptr<airsim_interfaces::srv::Rese
     unused(response);
     std::lock_guard<std::mutex> guard(control_mutex_);
 
-    airsim_client_.reset();
+    airsim_client_->reset();
     return true; //todo
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
Calling to ros service reset caused airsim node to crash.
This PR fix it for both ros1/2

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
Run blocks, run airsim node and call ros reset from the terminal.

## Screenshots (if appropriate):