### PR TITLE
add setting for overriding pixel format in capture component

### DIFF
--- a/AirLib/include/common/AirSimSettings.hpp
+++ b/AirLib/include/common/AirSimSettings.hpp
@@ -1051,7 +1051,7 @@ namespace airlib
                         if (pixel_format_override_settings_json.getChild(child_index, pixel_format_child_json)) {
                             int image_type = pixel_format_child_json.getInt("ImageType", 0);
                             PixelFormatOverrideSetting& pixel_format_setting = ue_setting.pixel_format_override_settings.at(image_type);
-                            pixel_format_setting.pixel_format = pixel_format_child_json.getInt("PixelFormat", 0);
+                            pixel_format_setting.pixel_format = pixel_format_child_json.getInt("PixelFormat", 0); // default to EXPixelformat::PF_Unknown
                         }
                     }
                 }

--- a/AirLib/include/common/AirSimSettings.hpp
+++ b/AirLib/include/common/AirSimSettings.hpp
@@ -361,6 +361,17 @@ namespace airlib
             float update_interval_secs = 60;
             bool move_sun = true;
         };
+        
+        struct PixelFormatOverrideSetting
+        {
+            int image_type = 0;
+            int pixel_format = 0;
+        };
+        
+        struct UnrealEngineSetting
+        {
+            std::map<int, PixelFormatOverrideSetting> pixel_format_override_settings;
+        };
 
     private: //fields
         float settings_version_actual;
@@ -374,6 +385,7 @@ namespace airlib
         RecordingSetting recording_setting;
         SegmentationSetting segmentation_setting;
         TimeOfDaySetting tod_setting;
+        UnrealEngineSetting ue_setting;
 
         std::vector<std::string> warning_messages;
         std::vector<std::string> error_messages;
@@ -1145,6 +1157,33 @@ namespace airlib
                     tod_setting.is_start_datetime_dst = tod_settings_json.getBool("StartDateTimeDst", tod_setting.is_start_datetime_dst);
                     tod_setting.update_interval_secs = tod_settings_json.getFloat("UpdateIntervalSecs", tod_setting.update_interval_secs);
                     tod_setting.move_sun = tod_settings_json.getBool("MoveSun", tod_setting.move_sun);
+                }
+            }
+            
+            { //unreal engine settings
+                Settings ue_settings_json;
+                if (settings_json.getChild("UnrealEngine", ue_settings_json)) {
+                    Settings pixel_format_override_settings_json;
+                    ue_setting.pixel_format_override_settings.clear();
+                    
+                    for (int i = 0; i < 10; i++) {
+                        PixelFormatOverrideSetting pixel_format_setting;
+                        pixel_format_setting.image_type = i;
+                        pixel_format_setting.pixel_format = 0;
+                        ue_setting.pixel_format_override_settings[i] = pixel_format_setting;
+                    }
+                    
+                    if (ue_settings_json.getChild("PixelFormatOverride", pixel_format_override_settings_json)) {
+                        for (size_t child_index = 0; child_index < pixel_format_override_settings_json.size(); ++child_index) {
+                            Settings pixel_format_child_json;
+                            if (pixel_format_override_settings_json.getChild(child_index, pixel_format_child_json)) {
+                                int image_type = pixel_format_child_json.getInt("ImageType", 0);
+                                PixelFormatOverrideSetting& pixel_format_setting = ue_setting.pixel_format_override_settings.at(image_type);
+                                pixel_format_setting.image_type = image_type;
+                                pixel_format_setting.pixel_format = pixel_format_child_json.getInt("PixelFormat", 0);
+                            }
+                        }
+                    }
                 }
             }
 

--- a/AirLib/include/common/AirSimSettings.hpp
+++ b/AirLib/include/common/AirSimSettings.hpp
@@ -361,13 +361,13 @@ namespace airlib
             float update_interval_secs = 60;
             bool move_sun = true;
         };
-        
+
         struct PixelFormatOverrideSetting
         {
             int image_type = 0;
             int pixel_format = 0;
         };
-        
+
         struct UnrealEngineSetting
         {
             std::map<int, PixelFormatOverrideSetting> pixel_format_override_settings;
@@ -1159,20 +1159,20 @@ namespace airlib
                     tod_setting.move_sun = tod_settings_json.getBool("MoveSun", tod_setting.move_sun);
                 }
             }
-            
+
             { //unreal engine settings
                 Settings ue_settings_json;
                 if (settings_json.getChild("UnrealEngine", ue_settings_json)) {
                     Settings pixel_format_override_settings_json;
                     ue_setting.pixel_format_override_settings.clear();
-                    
+
                     for (int i = 0; i < 10; i++) {
                         PixelFormatOverrideSetting pixel_format_setting;
                         pixel_format_setting.image_type = i;
                         pixel_format_setting.pixel_format = 0;
                         ue_setting.pixel_format_override_settings[i] = pixel_format_setting;
                     }
-                    
+
                     if (ue_settings_json.getChild("PixelFormatOverride", pixel_format_override_settings_json)) {
                         for (size_t child_index = 0; child_index < pixel_format_override_settings_json.size(); ++child_index) {
                             Settings pixel_format_child_json;

--- a/Unreal/Plugins/AirSim/Source/PIPCamera.cpp
+++ b/Unreal/Plugins/AirSim/Source/PIPCamera.cpp
@@ -36,16 +36,16 @@ APIPCamera::APIPCamera(const FObjectInitializer& ObjectInitializer)
 
     PrimaryActorTick.bCanEverTick = true;
 
-    image_type_to_pixel_format_map_.Add(0, EPixelFormat::PF_B8G8R8A8);
-    image_type_to_pixel_format_map_.Add(1, EPixelFormat::PF_DepthStencil); // not used. init_auto_format is called in setupCameraFromSettings()
-    image_type_to_pixel_format_map_.Add(2, EPixelFormat::PF_DepthStencil); // not used for same reason as above
-    image_type_to_pixel_format_map_.Add(3, EPixelFormat::PF_DepthStencil); // not used for same reason as above
-    image_type_to_pixel_format_map_.Add(4, EPixelFormat::PF_DepthStencil); // not used for same reason as above
-    image_type_to_pixel_format_map_.Add(5, EPixelFormat::PF_B8G8R8A8);
-    image_type_to_pixel_format_map_.Add(6, EPixelFormat::PF_B8G8R8A8);
-    image_type_to_pixel_format_map_.Add(7, EPixelFormat::PF_B8G8R8A8);
-    image_type_to_pixel_format_map_.Add(8, EPixelFormat::PF_B8G8R8A8);
-    image_type_to_pixel_format_map_.Add(9, EPixelFormat::PF_B8G8R8A8);
+    image_type_to_pixel_format_map_.Add(Utils::toNumeric(ImageType::Scene), EPixelFormat::PF_B8G8R8A8);
+    image_type_to_pixel_format_map_.Add(Utils::toNumeric(ImageType::DepthPlanar), EPixelFormat::PF_DepthStencil); // not used. init_auto_format is called in setupCameraFromSettings()
+    image_type_to_pixel_format_map_.Add(Utils::toNumeric(ImageType::DepthPerspective), EPixelFormat::PF_DepthStencil); // not used for same reason as above
+    image_type_to_pixel_format_map_.Add(Utils::toNumeric(ImageType::DepthVis), EPixelFormat::PF_DepthStencil); // not used for same reason as above
+    image_type_to_pixel_format_map_.Add(Utils::toNumeric(ImageType::DisparityNormalized), EPixelFormat::PF_DepthStencil); // not used for same reason as above
+    image_type_to_pixel_format_map_.Add(Utils::toNumeric(ImageType::Segmentation), EPixelFormat::PF_B8G8R8A8);
+    image_type_to_pixel_format_map_.Add(Utils::toNumeric(ImageType::SurfaceNormals), EPixelFormat::PF_B8G8R8A8);
+    image_type_to_pixel_format_map_.Add(Utils::toNumeric(ImageType::Infrared), EPixelFormat::PF_B8G8R8A8);
+    image_type_to_pixel_format_map_.Add(Utils::toNumeric(ImageType::OpticalFlow), EPixelFormat::PF_B8G8R8A8);
+    image_type_to_pixel_format_map_.Add(Utils::toNumeric(ImageType::OpticalFlowVis), EPixelFormat::PF_B8G8R8A8);
 
     object_filter_ = FObjectFilter();
 }
@@ -382,9 +382,9 @@ void APIPCamera::setupCameraFromSettings(const APIPCamera::CameraSetting& camera
         const auto& noise_setting = camera_setting.noise_settings.at(image_type);
 
         if (image_type >= 0) { //scene capture components
-            auto pixel_format_override = AirSimSettings::singleton().ue_setting.pixel_format_override_settings.find(image_type);
+            auto pixel_format_override = camera_setting.ue_setting.pixel_format_override_settings.find(image_type);
             EPixelFormat pixel_format = EPixelFormat::PF_Unknown;
-            if (pixel_format_override != AirSimSettings::singleton().ue_setting.pixel_format_override_settings.end()) {
+            if (pixel_format_override != camera_setting.ue_setting.pixel_format_override_settings.end()) {
                 pixel_format = static_cast<EPixelFormat>(pixel_format_override->second.pixel_format);
             }
             pixel_format = (pixel_format == EPixelFormat::PF_Unknown ? image_type_to_pixel_format_map_[image_type] : pixel_format);

--- a/Unreal/Plugins/AirSim/Source/PIPCamera.cpp
+++ b/Unreal/Plugins/AirSim/Source/PIPCamera.cpp
@@ -36,16 +36,16 @@ APIPCamera::APIPCamera(const FObjectInitializer& ObjectInitializer)
 
     PrimaryActorTick.bCanEverTick = true;
 
-    image_type_to_pixel_format_map_.Add(0, EPixelFormat::PF_FloatRGBA);
+    image_type_to_pixel_format_map_.Add(0, EPixelFormat::PF_B8G8R8A8);
     image_type_to_pixel_format_map_.Add(1, EPixelFormat::PF_DepthStencil); // not used. init_auto_format is called in setupCameraFromSettings()
     image_type_to_pixel_format_map_.Add(2, EPixelFormat::PF_DepthStencil); // not used for same reason as above
     image_type_to_pixel_format_map_.Add(3, EPixelFormat::PF_DepthStencil); // not used for same reason as above
     image_type_to_pixel_format_map_.Add(4, EPixelFormat::PF_DepthStencil); // not used for same reason as above
-    image_type_to_pixel_format_map_.Add(5, EPixelFormat::PF_FloatRGBA);
-    image_type_to_pixel_format_map_.Add(6, EPixelFormat::PF_FloatRGBA);
-    image_type_to_pixel_format_map_.Add(7, EPixelFormat::PF_FloatRGBA);
-    image_type_to_pixel_format_map_.Add(8, EPixelFormat::PF_FloatRGBA);
-    image_type_to_pixel_format_map_.Add(9, EPixelFormat::PF_FloatRGBA);
+    image_type_to_pixel_format_map_.Add(5, EPixelFormat::PF_B8G8R8A8);
+    image_type_to_pixel_format_map_.Add(6, EPixelFormat::PF_B8G8R8A8);
+    image_type_to_pixel_format_map_.Add(7, EPixelFormat::PF_B8G8R8A8);
+    image_type_to_pixel_format_map_.Add(8, EPixelFormat::PF_B8G8R8A8);
+    image_type_to_pixel_format_map_.Add(9, EPixelFormat::PF_B8G8R8A8);
 
     object_filter_ = FObjectFilter();
 }
@@ -382,19 +382,26 @@ void APIPCamera::setupCameraFromSettings(const APIPCamera::CameraSetting& camera
         const auto& noise_setting = camera_setting.noise_settings.at(image_type);
 
         if (image_type >= 0) { //scene capture components
+            auto pixel_format_override = AirSimSettings::singleton().ue_setting.pixel_format_override_settings.find(image_type);
+            EPixelFormat pixel_format = EPixelFormat::PF_Unknown;
+            if (pixel_format_override != AirSimSettings::singleton().ue_setting.pixel_format_override_settings.end()) {
+                pixel_format = static_cast<EPixelFormat>(pixel_format_override->second.pixel_format);
+            }
+            pixel_format = (pixel_format == EPixelFormat::PF_Unknown ? image_type_to_pixel_format_map_[image_type] : pixel_format);
+            
             switch (Utils::toEnum<ImageType>(image_type)) {
             case ImageType::Scene:
             case ImageType::Infrared:
-                updateCaptureComponentSetting(captures_[image_type], render_targets_[image_type], false, image_type_to_pixel_format_map_[image_type], capture_setting, ned_transform, false);
+                updateCaptureComponentSetting(captures_[image_type], render_targets_[image_type], false, pixel_format, capture_setting, ned_transform, false);
                 break;
 
             case ImageType::Segmentation:
             case ImageType::SurfaceNormals:
-                updateCaptureComponentSetting(captures_[image_type], render_targets_[image_type], true, image_type_to_pixel_format_map_[image_type], capture_setting, ned_transform, true);
+                updateCaptureComponentSetting(captures_[image_type], render_targets_[image_type], true, pixel_format, capture_setting, ned_transform, true);
                 break;
 
             default:
-                updateCaptureComponentSetting(captures_[image_type], render_targets_[image_type], true, image_type_to_pixel_format_map_[image_type], capture_setting, ned_transform, false);
+                updateCaptureComponentSetting(captures_[image_type], render_targets_[image_type], true, pixel_format, capture_setting, ned_transform, false);
                 break;
             }
             setDistortionMaterial(image_type, captures_[image_type], captures_[image_type]->PostProcessSettings);

--- a/Unreal/Plugins/AirSim/Source/PIPCamera.cpp
+++ b/Unreal/Plugins/AirSim/Source/PIPCamera.cpp
@@ -388,7 +388,7 @@ void APIPCamera::setupCameraFromSettings(const APIPCamera::CameraSetting& camera
                 pixel_format = static_cast<EPixelFormat>(pixel_format_override->second.pixel_format);
             }
             pixel_format = (pixel_format == EPixelFormat::PF_Unknown ? image_type_to_pixel_format_map_[image_type] : pixel_format);
-            
+
             switch (Utils::toEnum<ImageType>(image_type)) {
             case ImageType::Scene:
             case ImageType::Infrared:

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -117,7 +117,15 @@ Below are complete list of settings available along with their default values. I
       "Pitch": NaN, "Roll": NaN, "Yaw": NaN
     },
     "X": NaN, "Y": NaN, "Z": NaN,
-    "Pitch": NaN, "Roll": NaN, "Yaw": NaN
+    "Pitch": NaN, "Roll": NaN, "Yaw": NaN,
+    "UnrealEngine": {
+      "PixelFormatOverride": [
+        {
+          "ImageType": 0,
+          "PixelFormat": 0
+        }
+      ]
+    }
   },
   "OriginGeopoint": {
     "Latitude": 47.641468,
@@ -346,6 +354,10 @@ This adds fluctuations on horizontal line.
 
 ### Gimbal
 The `Gimbal` element allows to freeze camera orientation for pitch, roll and/or yaw. This setting is ignored unless `ImageType` is -1. The `Stabilization` is defaulted to 0 meaning no gimbal i.e. camera orientation changes with body orientation on all axis. The value of 1 means full stabilization. The value between 0 to 1 acts as a weight for fixed angles specified (in degrees, in world-frame) in `Pitch`, `Roll` and `Yaw` elements and orientation of the vehicle body. When any of the angles is omitted from json or set to NaN, that angle is not stabilized (i.e. it moves along with vehicle body).
+
+### UnrealEngine
+This element contains settings specific to the Unreal Engine. These will be ignored in the Unity project.
+* `PixelFormatOverride`: This contains a list of elements that have both a `ImageType` and `PixelFormat` setting. Each element allows you to override the default pixel format of the UTextureRenderTarget2D object instantiated for the capture specified by the `ImageType` setting. Specifying this element allows you to prevent crashes caused by unexpected pixel formats (see [#4120](https://github.com/microsoft/AirSim/issues/4120) and [#4339](https://github.com/microsoft/AirSim/issues/4339) for examples of these crashes). A full list of pixel formats can be viewed [here](https://docs.unrealengine.com/4.27/en-US/API/Runtime/Core/EPixelFormat/).
 
 ## External Cameras
 This element allows specifying cameras which are separate from the cameras attached to the vehicle, such as a CCTV camera. These are fixed cameras, and don't move along with the vehicles. The key in the element is the name of the camera, and the value i.e. settings are the same as `CameraDefaults` described above. All the camera APIs work with external cameras, including capturing images, changing the pose, etc by passing the parameter `external=True` in the API call.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #4339    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
This PR undoes #4321 and adds a new setting that allows the user to override the pixel format that each capture component in a camera is initialized with. This allows us to support scenarios where pixel format is expected to be either int or float. See #4339, #4120 and  #4321 for more information about various scenarios that are impacted by pixel format selection. The new settings include a "UnrealEngine" setting, which contains a "PixelFormatOverride" setting, which then contains a list of settings that have both a "ImageType" and "PixelFormat" parameter. See test settings used below for an example of these settings being defined.<!-- Describe what your PR is about. -->

## How Has This Been Tested?
The [high_res_camera.py](https://github.com/microsoft/AirSim/blob/master/PythonClient/multirotor/high_res_camera.py) script, both with its original text and with ImageRequest.pixels_as_float = True, was used in conjunction with both the settings detailed in the test script as well as the modified settings below:
```
{
    "SettingsVersion": 1.2,
    "SimMode": "Multirotor",
    "Vehicles" : {
        "Drone1" : {
            "VehicleType" : "SimpleFlight",
            "AutoCreate" : true,
            "Cameras" : {
                "high_res": {
                    "CaptureSettings" : [
                        {
                            "ImageType" : 0,
                            "Width" : 4320,
                            "Height" : 2160
                        }
                    ],
                    "X": 0.50, "Y": 0.00, "Z": 0.10,
                    "Pitch": 0.0, "Roll": 0.0, "Yaw": 0.0
                },
                "low_res": {
                    "CaptureSettings" : [
                        {
                            "ImageType" : 0,
                            "Width" : 256,
                            "Height" : 144
                        }
                    ],
                    "X": 0.50, "Y": 0.00, "Z": 0.10,
                    "Pitch": 0.0, "Roll": 0.0, "Yaw": 0.0
                }
            }
        }
    },
    "UnrealEngine": {
        "PixelFormatOverride": [
            {
                "ImageType": 0,
                "PixelFormat": 10
            }
        ]
    }
}
```
<!-- Please, describe how you have tested your changes to help us incorporate them. -->

## Screenshots (if appropriate):