### PR TITLE
fix scaling of pause period in car mode

### DIFF
--- a/AirLib/include/common/ClockBase.hpp
+++ b/AirLib/include/common/ClockBase.hpp
@@ -48,6 +48,11 @@ namespace airlib
             return elapsed;
         }
 
+        virtual TTimePoint stepBy(TTimeDelta amount)
+        {
+            return step();
+        }
+
         virtual TTimePoint step()
         {
             //by default step doesn't do anything

--- a/AirLib/include/common/ClockBase.hpp
+++ b/AirLib/include/common/ClockBase.hpp
@@ -50,6 +50,7 @@ namespace airlib
 
         virtual TTimePoint stepBy(TTimeDelta amount)
         {
+            unused(amount);
             return step();
         }
 

--- a/AirLib/include/common/SteppableClock.hpp
+++ b/AirLib/include/common/SteppableClock.hpp
@@ -30,7 +30,7 @@ namespace airlib
 
         virtual ~SteppableClock() {}
 
-        TTimePoint stepBy(TTimeDelta amount)
+        virtual TTimePoint stepBy(TTimeDelta amount) override
         {
             current_ = addTo(current_, amount);
             return current_;

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/SimModeCar.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/SimModeCar.cpp
@@ -28,7 +28,7 @@ void ASimModeCar::initializePauseState()
 void ASimModeCar::continueForTime(double seconds)
 {
     pause_period_start_ = ClockFactory::get()->nowNanos();
-    pause_period_ = seconds;
+    pause_period_ = seconds * current_clockspeed_;
     pause(false);
 }
 
@@ -53,6 +53,9 @@ void ASimModeCar::setupClockSpeed()
 void ASimModeCar::Tick(float DeltaSeconds)
 {
     Super::Tick(DeltaSeconds);
+
+    if (!isPaused())
+        ClockFactory::get()->stepBy(DeltaSeconds);
 
     if (pause_period_start_ > 0) {
         if (ClockFactory::get()->elapsedSince(pause_period_start_) >= pause_period_) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #4350
Fixes: #1719    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
The PR allows for the clock speed to be correctly accounted for during a call to client.simContinueForTime() by scaling the pause period accordingly (faster clockspeed should result in longer period to allow for same wall time to elapse during API call).<!-- Describe what your PR is about. -->

## How Has This Been Tested?
The test script in #4350 was used along with a modified version for multirotor mode to ensure feature parity.<!-- Please, describe how you have tested your changes to help us incorporate them. -->

## Screenshots (if appropriate):