### PR TITLE
add support for external physics engine in Unity

### DIFF
--- a/Unity/AirLibWrapper/AirsimWrapper/Source/SimMode/SimModeWorldBase.cpp
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/SimMode/SimModeWorldBase.cpp
@@ -68,6 +68,9 @@ std::unique_ptr<SimModeWorldBase::PhysicsEngineBase> SimModeWorldBase::createPhy
             physics_engine.reset(new msr::airlib::FastPhysicsEngine());
         }
     }
+    else if (physics_engine_name == "ExternalPhysicsEngine") {        
+        physics_engine.reset(new msr::airlib::ExternalPhysicsEngine());
+    }
     else {
         physics_engine.reset();
         PrintLogMessage("Unrecognized physics engine name: ", physics_engine_name.c_str(), "", ErrorLogSeverity::Warnning);

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/SimMode/SimModeWorldBase.cpp
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/SimMode/SimModeWorldBase.cpp
@@ -68,7 +68,7 @@ std::unique_ptr<SimModeWorldBase::PhysicsEngineBase> SimModeWorldBase::createPhy
             physics_engine.reset(new msr::airlib::FastPhysicsEngine());
         }
     }
-    else if (physics_engine_name == "ExternalPhysicsEngine") {        
+    else if (physics_engine_name == "ExternalPhysicsEngine") {
         physics_engine.reset(new msr::airlib::ExternalPhysicsEngine());
     }
     else {

--- a/Unity/AirLibWrapper/AirsimWrapper/Source/SimMode/SimModeWorldBase.h
+++ b/Unity/AirLibWrapper/AirsimWrapper/Source/SimMode/SimModeWorldBase.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "SimModeBase.h"
+#include "physics/ExternalPhysicsEngine.hpp"
 #include "physics/FastPhysicsEngine.hpp"
 #include "physics/PhysicsWorld.hpp"
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #4285    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
This PR enables support for the "PhysicsEngineName":"ExternalPhysicsEngine" setting in the Unity project.<!-- Describe what your PR is about. -->

## How Has This Been Tested?
The [external_physics_engine.py](https://github.com/microsoft/AirSim/blob/master/PythonClient/multirotor/external_physics_engine.py) script was run with the Unity project to confirm the external physics engine operates correctly.<!-- Please, describe how you have tested your changes to help us incorporate them. -->

## Screenshots (if appropriate):