### PR TITLE
Add support for building (x86_64) on Apple Silicon

### DIFF
--- a/Unreal/Environments/Blocks/GenerateProjectFiles.sh
+++ b/Unreal/Environments/Blocks/GenerateProjectFiles.sh
@@ -6,7 +6,9 @@ set -e
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 pushd "$SCRIPT_DIR" >/dev/null
 
-UnrealDir=$1
+if [[ ! -e "$UnrealDir" ]]; then
+    UnrealDir=$1
+fi
 if [[ ! -e "$UnrealDir" ]]; then
     # UnrealDir variable must be set like '/Users/Shared/Epic\ Games/UE_4.16'
     echo "UnrealDir is not set."

--- a/build.sh
+++ b/build.sh
@@ -60,8 +60,8 @@ if [ "$(uname)" == "Darwin" ]; then
     #export CC=/usr/local/opt/llvm@8/bin/clang
     #export CXX=/usr/local/opt/llvm@8/bin/clang++
     #now pick up whatever setup.sh installs
-    export CC=/usr/local/opt/llvm/bin/clang
-    export CXX=/usr/local/opt/llvm/bin/clang++
+    export CC="$(brew --prefix)/opt/llvm/bin/clang"
+    export CXX="$(brew --prefix)/opt/llvm/bin/clang++"
 else
     if $gcc; then
         export CC="gcc-8"
@@ -94,14 +94,20 @@ if [[ ! -d $build_dir ]]; then
     mkdir -p $build_dir
 fi
 
+# Fix for Unreal/Unity using x86_64 (Rosetta) on Apple Silicon hardware.
+CMAKE_VARS=
+if [ "$(uname)" == "Darwin" ]; then
+    CMAKE_VARS="-DCMAKE_APPLE_SILICON_PROCESSOR=x86_64"
+fi
+
 pushd $build_dir  >/dev/null
 if $debug; then
     folder_name="Debug"
-    "$CMAKE" ../cmake -DCMAKE_BUILD_TYPE=Debug \
+    "$CMAKE" ../cmake -DCMAKE_BUILD_TYPE=Debug $CMAKE_VARS \
         || (popd && rm -r $build_dir && exit 1)   
 else
     folder_name="Release"
-    "$CMAKE" ../cmake -DCMAKE_BUILD_TYPE=Release \
+    "$CMAKE" ../cmake -DCMAKE_BUILD_TYPE=Release $CMAKE_VARS \
         || (popd && rm -r $build_dir && exit 1)
 fi
 popd >/dev/null

--- a/setup.sh
+++ b/setup.sh
@@ -6,7 +6,13 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 pushd "$SCRIPT_DIR" >/dev/null
 
 downloadHighPolySuv=true
+
 MIN_CMAKE_VERSION=3.10.0
+# On macOS, make sure we have a CMake that will support CMAKE_APPLE_SILICON_PROCESSOR.
+if [ "$(uname)" == "Darwin" ]; then
+    MIN_CMAKE_VERSION=3.19.2
+fi
+
 DEBUG="${DEBUG:-false}"
 function version_less_than_equal_to() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" = "$1"; }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: https://github.com/microsoft/AirSim/issues/3696 https://github.com/microsoft/AirSim/issues/3691
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
- This PR adds a solution for the above tickets (which are closed but require out-of-tree script modifications). The goal is for AirSim to compile and run under x84_64 on Apple Silicon machines.
  * Use `brew --prefix` instead of `/usr/local` in case of M1, which resides at `/opt/homebrew`.
  * Specify CMake flag https://cmake.org/cmake/help/latest/variable/CMAKE_APPLE_SILICON_PROCESSOR.html, which basically just tells CMake to use x86_64 (Rosetta) on M1 machines. This allows linking to succeed with the x86 versions of UE and Unity.
- Additionally, in the test project, allow the user to specify `UnrealDir` and have that be used.

## How Has This Been Tested?

This was tested on my local machine, with the following specs:

- M1 MacBook Air
- macOS Monterey
- Unreal Engine 4.27

<!-- Please, describe how you have tested your changes to help us incorporate them. -->

## Screenshots (if appropriate):