### PR TITLE
Add dedicated docs page for building on macOS

### DIFF
--- a/docs/build_macos.md
+++ b/docs/build_macos.md
@@ -33,6 +33,8 @@ cd AirSim
 
 By default AirSim uses clang 8 to build for compatibility with UE 4.25. The setup script will install the right version of cmake, llvm, and eigen.
 
+CMake 3.19.2 is required for building on Apple Silicon.
+
 ```bash
 ./setup.sh
 ./build.sh

--- a/docs/build_macos.md
+++ b/docs/build_macos.md
@@ -1,6 +1,6 @@
-# Build AirSim on Linux
+# Build AirSim on macOS
 
-The current recommended and tested environment is **Ubuntu 18.04 LTS**. Theoretically, you can build on other distros as well, but we haven't tested it.
+Only macOS **Catalina (10.15)** has currently been tested. Theoretically, AirSim should work on higher macOS versions and Apple Silicon hardware, but this path is not offically supported.
 
 We've two options - you can either build inside docker containers or your host machine.
 
@@ -12,20 +12,14 @@ Please see instructions [here](docker_ubuntu.md)
 
 ### Pre-build Setup
 
-#### Build Unreal Engine
+#### Download Unreal Engine
 
-- Make sure you are [registered with Epic Games](https://docs.unrealengine.com/en-US/SharingAndReleasing/Linux/BeginnerLinuxDeveloper/SettingUpAnUnrealWorkflow/index.html). This is required to get source code access for Unreal Engine.
+1. [Download](https://www.unrealengine.com/download) the Epic Games Launcher. While the Unreal Engine is open source and free to download, registration is still required.
+2. Run the Epic Games Launcher, open the `Library` tab on the left pane.
+   Click on the `Add Versions` which should show the option to download **Unreal 4.27** as shown below. If you have multiple versions of Unreal installed then **make sure 4.27 is set to `current`** by clicking down arrow next to the Launch button for the version.
 
-- Clone Unreal in your favorite folder and build it (this may take a while!). **Note**: We only support Unreal >= 4.25 at present. We recommend using 4.25.
-
-```bash
-# go to the folder where you clone GitHub projects
-git clone -b 4.25 git@github.com:EpicGames/UnrealEngine.git
-cd UnrealEngine
-./Setup.sh
-./GenerateProjectFiles.sh
-make
-```
+   **Note**: AirSim also works with UE >= 4.24, however, we recommend 4.27.
+   **Note**: If you have UE 4.16 or older projects, please see the [upgrade guide](unreal_upgrade.md) to upgrade your projects.
 
 ### Build AirSim
 
@@ -51,12 +45,9 @@ Finally, you will need an Unreal project that hosts the environment for your veh
 
 ## How to Use AirSim
 
-Once AirSim is setup:
-
-- Go to `UnrealEngine` installation folder and start Unreal by running `./Engine/Binaries/Linux/UE4Editor`.
-- When Unreal Engine prompts for opening or creating project, select Browse and choose `AirSim/Unreal/Environments/Blocks` (or your [custom](unreal_custenv.md) Unreal project).
-- Alternatively, the project file can be passed as a commandline argument. For Blocks: `./Engine/Binaries/Linux/UE4Editor <AirSim_path>/Unreal/Environments/Blocks/Blocks.uproject`
-- If you get prompts to convert project, look for More Options or Convert-In-Place option. If you get prompted to build, choose Yes. If you get prompted to disable AirSim plugin, choose No.
+- Browse to `AirSim/Unreal/Environments/Blocks`.
+- Run `./GenerateProjectFiles.sh <UE_PATH>` from the terminal, where `UE_PATH` is the path to the Unreal installation folder. (By default, this is `/Users/Shared/Epic\ Games/UE_4.27/`) The script creates an XCode workspace by the name Blocks.xcworkspace.
+- Open the XCode workspace, and press the Build and run button in the top left.
 - After Unreal Editor loads, press Play button.
 
 See [Using APIs](apis.md) and [settings.json](settings.md) for various options available for AirSim usage.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ nav:
     - "Download Binaries": 'use_precompiled.md'
     - "Build on Windows": 'build_windows.md'
     - "Build on Linux": 'build_linux.md'
+    - "Build on macOS": 'build_macos.md'
     - "Docker on Linux": 'docker_ubuntu.md'
     - "AirSim on Azure": 'azure.md'
     - "Custom Unreal Environment": 'unreal_custenv.md'


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About

This PR is related to, but does not depend on, https://github.com/microsoft/AirSim/pull/4408.

I helped a friend build AirSim on their M1 machine and found the combined page for Linux & macOS somewhat confusing. This PR treats them as separate pages and platforms.

I also updated the guidance to use UE 4.27, which includes fixes for XCode and PrivateFrameworks changes in macOS Big Sur+.

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->

Following these instructions, along with #4408, led to a successful AirSim installation on the following specs:

M1 MacBook Air
macOS Monterey
Unreal Engine 4.27

## Screenshots (if appropriate):

N/A