### PR TITLE
Fix Unreal AirSim settings command line launch argument.

### DIFF
--- a/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
@@ -337,33 +337,27 @@ bool ASimHUD::getSettingsText(std::string& settingsText)
 }
 
 // Attempts to parse the settings file path or the settings text from the command line
-// Looks for the flag "--settings". If it exists, settingsText will be set to the value.
-// Example (Path): AirSim.exe --settings "C:\path\to\settings.json"
-// Example (Text): AirSim.exe -s '{"foo" : "bar"}' -> settingsText will be set to {"foo": "bar"}
+// Looks for the flag "-settings=". If it exists, settingsText will be set to the value.
+// Example (Path): AirSim.exe -settings="C:\path\to\settings.json"
+// Example (Text): AirSim.exe -settings="{"foo" : "bar"}" -> settingsText will be set to {"foo": "bar"}
 // Returns true if the argument is present, false otherwise.
 bool ASimHUD::getSettingsTextFromCommandLine(std::string& settingsText)
 {
-
-    bool found = false;
-    FString settingsTextFString;
     const TCHAR* commandLineArgs = FCommandLine::Get();
+    FString settingsJsonFString;
 
-    if (FParse::Param(commandLineArgs, TEXT("-settings"))) {
-        FString commandLineArgsFString = FString(commandLineArgs);
-        int idx = commandLineArgsFString.Find(TEXT("-settings"));
-        FString settingsJsonFString = commandLineArgsFString.RightChop(idx + 10);
-
-        if (readSettingsTextFromFile(settingsJsonFString.TrimQuotes(), settingsText)) {
+    if (FParse::Value(commandLineArgs, TEXT("-settings="), settingsJsonFString, false)) {
+        if (readSettingsTextFromFile(settingsJsonFString, settingsText)) {
             return true;
         }
-
-        if (FParse::QuotedString(*settingsJsonFString, settingsTextFString)) {
-            settingsText = std::string(TCHAR_TO_UTF8(*settingsTextFString));
-            found = true;
+        else {
+            UAirBlueprintLib::LogMessageString("Loaded settings from commandline: ", TCHAR_TO_UTF8(*settingsJsonFString), LogDebugLevel::Informational);
+            settingsText = TCHAR_TO_UTF8(*settingsJsonFString);
+            return true;
         }
     }
 
-    return found;
+    return false;
 }
 
 bool ASimHUD::readSettingsTextFromFile(const FString& settingsFilepath, std::string& settingsText)

--- a/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
@@ -339,7 +339,7 @@ bool ASimHUD::getSettingsText(std::string& settingsText)
 // Attempts to parse the settings file path or the settings text from the command line
 // Looks for the flag "-settings=". If it exists, settingsText will be set to the value.
 // Example (Path): AirSim.exe -settings="C:\path\to\settings.json"
-// Example (Text): AirSim.exe -settings="{"foo" : "bar"}" -> settingsText will be set to {"foo": "bar"}
+// Example (Text): AirSim.exe -settings={"foo":"bar"} -> settingsText will be set to {"foo":"bar"}
 // Returns true if the argument is present, false otherwise.
 bool ASimHUD::getSettingsTextFromCommandLine(std::string& settingsText)
 {

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -8,8 +8,8 @@ For example, in Windows: `AirSim.exe -settings="C:\path\to\settings.json"`
 In Linux `./Blocks.sh -settings="/home/$USER/path/to/settings.json"`
 
 2. Looking for a json document passed as a command line argument by the `-settings` argument.
-For example, in Windows: `AirSim.exe -settings="{"foo" : "bar"}"`
-In Linux `./Blocks.sh -settings="{"foo" : "bar"}"`
+For example, in Windows: `AirSim.exe -settings={"foo":"bar"}`
+In Linux `./Blocks.sh -settings={"foo":"bar"}`
 
 3. Looking in the folder of the executable for a file called `settings.json`.
 This will be a deep location where the actual executable of the Editor or binary is stored.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -3,13 +3,13 @@
 ## Where are Settings Stored?
 AirSim is searching for the settings definition in the following order. The first match will be used:
 
-1. Looking at the (absolute) path specified by the `--settings` command line argument.
-For example, in Windows: `AirSim.exe --settings 'C:\path\to\settings.json'`
-In Linux `./Blocks.sh --settings '/home/$USER/path/to/settings.json'`
+1. Looking at the (absolute) path specified by the `-settings` command line argument.
+For example, in Windows: `AirSim.exe -settings="C:\path\to\settings.json"`
+In Linux `./Blocks.sh -settings="/home/$USER/path/to/settings.json"`
 
-2. Looking for a json document passed as a command line argument by the `--settings` argument.
-For example, in Windows: `AirSim.exe --settings '{"foo" : "bar"}'`
-In Linux `./Blocks.sh --settings '{"foo" : "bar"}'`
+2. Looking for a json document passed as a command line argument by the `-settings` argument.
+For example, in Windows: `AirSim.exe -settings="{"foo" : "bar"}"`
+In Linux `./Blocks.sh -settings="{"foo" : "bar"}"`
 
 3. Looking in the folder of the executable for a file called `settings.json`.
 This will be a deep location where the actual executable of the Editor or binary is stored.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #3195 "Argument --settings is ineffective for Release v1.3.1-linux Blocks environment"
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
Update the `getSettingsTextFromCommandLine` function in `SimHud.cpp` to properly accommodate commandline launch arguments for loading different AirSim settings.
Allows the user to place the argument anywhere in the command line launch.
Follows Unreal's convention for making command line launch arguments that pass a value.

## How Has This Been Tested?
Tested by passing additional launch argument's to a Standalone Game instance in the "Level Editor - Play" settings of the "Editor Preferences".
`-settings=\"C:\Users\melch\Documents\AirSim\twenty_five_drones.json\"`
`-settings={\"SeeDocsAt\":\"https://github.com/Microsoft/AirSim/blob/master/docs/settings.md\",\"SettingsVersion\":1.2,\"SimMode\":\"Car\"}`
<!-- Please, describe how you have tested your changes to help us incorporate them. -->

If you package the project, you can use launch scripts.
Example windows batch launch script:
`Blocks.exe -settings="C:\Users\melch\Documents\AirSim\twenty_five_drones.json"`

## Screenshots (if appropriate):
![settings json file](https://user-images.githubusercontent.com/83232581/158685112-549b2b86-efbf-487f-a656-cf2ac8ae740e.jpg)
![settings json string](https://user-images.githubusercontent.com/83232581/158685115-d83bcc2d-c5cd-4da5-a61a-6d2c66a60be9.jpg)