### PR TITLE
Fix Unreal Engine deprecations

### DIFF
--- a/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
+++ b/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
@@ -455,8 +455,12 @@ std::vector<msr::airlib::MeshPositionVertexBuffersResponse> UAirBlueprintLib::Ge
 
         //Various checks if there is even a valid mesh
         if (!comp->GetStaticMesh()) continue;
-        if (!comp->GetStaticMesh()->RenderData) continue;
-        if (comp->GetStaticMesh()->RenderData->LODResources.Num() == 0) continue;
+        if (!comp->GetStaticMesh()->HasValidRenderData()) continue;
+        #if (ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION > 26)
+            if (comp->GetStaticMesh()->GetRenderData()->LODResources.Num() == 0) continue;
+        #else
+            if (comp->GetStaticMesh()->RenderData->LODResources.Num() == 0) continue;
+        #endif
 
         msr::airlib::MeshPositionVertexBuffersResponse mesh;
         mesh.name = name;
@@ -471,7 +475,11 @@ std::vector<msr::airlib::MeshPositionVertexBuffersResponse> UAirBlueprintLib::Ge
         mesh.orientation.y() = att.Y;
         mesh.orientation.z() = att.Z;
 
-        FPositionVertexBuffer* vertex_buffer = &comp->GetStaticMesh()->RenderData->LODResources[0].VertexBuffers.PositionVertexBuffer;
+        #if (ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION > 26)
+            FPositionVertexBuffer* vertex_buffer = &comp->GetStaticMesh()->GetRenderData()->LODResources[0].VertexBuffers.PositionVertexBuffer;
+        #else
+            FPositionVertexBuffer* vertex_buffer = &comp->GetStaticMesh()->RenderData->LODResources[0].VertexBuffers.PositionVertexBuffer;
+        #endif
         if (vertex_buffer) {
             const int32 vertex_count = vertex_buffer->VertexBufferRHI->GetSize();
             TArray<FVector> vertices;
@@ -486,7 +494,11 @@ std::vector<msr::airlib::MeshPositionVertexBuffersResponse> UAirBlueprintLib::Ge
                     RHIUnlockVertexBuffer(vertex_buffer->VertexBufferRHI);
                 });
 
-            FStaticMeshLODResources& lod = comp->GetStaticMesh()->RenderData->LODResources[0];
+            #if (ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION > 26)
+                FStaticMeshLODResources& lod = comp->GetStaticMesh()->GetRenderData()->LODResources[0];
+            #else
+                FStaticMeshLODResources& lod = comp->GetStaticMesh()->RenderData->LODResources[0];
+            #endif
             FRawStaticIndexBuffer* IndexBuffer = &lod.IndexBuffer;
             int num_indices = IndexBuffer->IndexBufferRHI->GetSize() / IndexBuffer->IndexBufferRHI->GetStride();
 

--- a/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
+++ b/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
@@ -456,11 +456,11 @@ std::vector<msr::airlib::MeshPositionVertexBuffersResponse> UAirBlueprintLib::Ge
         //Various checks if there is even a valid mesh
         if (!comp->GetStaticMesh()) continue;
         if (!comp->GetStaticMesh()->HasValidRenderData()) continue;
-        #if (ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION > 26)
-            if (comp->GetStaticMesh()->GetRenderData()->LODResources.Num() == 0) continue;
-        #else
-            if (comp->GetStaticMesh()->RenderData->LODResources.Num() == 0) continue;
-        #endif
+#if (ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION > 26)
+        if (comp->GetStaticMesh()->GetRenderData()->LODResources.Num() == 0) continue;
+#else
+        if (comp->GetStaticMesh()->RenderData->LODResources.Num() == 0) continue;
+#endif
 
         msr::airlib::MeshPositionVertexBuffersResponse mesh;
         mesh.name = name;
@@ -475,11 +475,11 @@ std::vector<msr::airlib::MeshPositionVertexBuffersResponse> UAirBlueprintLib::Ge
         mesh.orientation.y() = att.Y;
         mesh.orientation.z() = att.Z;
 
-        #if (ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION > 26)
-            FPositionVertexBuffer* vertex_buffer = &comp->GetStaticMesh()->GetRenderData()->LODResources[0].VertexBuffers.PositionVertexBuffer;
-        #else
-            FPositionVertexBuffer* vertex_buffer = &comp->GetStaticMesh()->RenderData->LODResources[0].VertexBuffers.PositionVertexBuffer;
-        #endif
+#if (ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION > 26)
+        FPositionVertexBuffer* vertex_buffer = &comp->GetStaticMesh()->GetRenderData()->LODResources[0].VertexBuffers.PositionVertexBuffer;
+#else
+        FPositionVertexBuffer* vertex_buffer = &comp->GetStaticMesh()->RenderData->LODResources[0].VertexBuffers.PositionVertexBuffer;
+#endif
         if (vertex_buffer) {
             const int32 vertex_count = vertex_buffer->VertexBufferRHI->GetSize();
             TArray<FVector> vertices;
@@ -494,11 +494,11 @@ std::vector<msr::airlib::MeshPositionVertexBuffersResponse> UAirBlueprintLib::Ge
                     RHIUnlockVertexBuffer(vertex_buffer->VertexBufferRHI);
                 });
 
-            #if (ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION > 26)
-                FStaticMeshLODResources& lod = comp->GetStaticMesh()->GetRenderData()->LODResources[0];
-            #else
-                FStaticMeshLODResources& lod = comp->GetStaticMesh()->RenderData->LODResources[0];
-            #endif
+#if (ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION > 26)
+            FStaticMeshLODResources& lod = comp->GetStaticMesh()->GetRenderData()->LODResources[0];
+#else
+            FStaticMeshLODResources& lod = comp->GetStaticMesh()->RenderData->LODResources[0];
+#endif
             FRawStaticIndexBuffer* IndexBuffer = &lod.IndexBuffer;
             int num_indices = IndexBuffer->IndexBufferRHI->GetSize() / IndexBuffer->IndexBufferRHI->GetStride();
 

--- a/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
+++ b/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
@@ -456,7 +456,7 @@ std::vector<msr::airlib::MeshPositionVertexBuffersResponse> UAirBlueprintLib::Ge
         //Various checks if there is even a valid mesh
         if (!comp->GetStaticMesh()) continue;
         if (!comp->GetStaticMesh()->HasValidRenderData()) continue;
-#if (ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION > 26)
+#if ((ENGINE_MAJOR_VERSION > 4) || (ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION >= 27))
         if (comp->GetStaticMesh()->GetRenderData()->LODResources.Num() == 0) continue;
 #else
         if (comp->GetStaticMesh()->RenderData->LODResources.Num() == 0) continue;
@@ -475,7 +475,7 @@ std::vector<msr::airlib::MeshPositionVertexBuffersResponse> UAirBlueprintLib::Ge
         mesh.orientation.y() = att.Y;
         mesh.orientation.z() = att.Z;
 
-#if (ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION > 26)
+#if ((ENGINE_MAJOR_VERSION > 4) || (ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION >= 27))
         FPositionVertexBuffer* vertex_buffer = &comp->GetStaticMesh()->GetRenderData()->LODResources[0].VertexBuffers.PositionVertexBuffer;
 #else
         FPositionVertexBuffer* vertex_buffer = &comp->GetStaticMesh()->RenderData->LODResources[0].VertexBuffers.PositionVertexBuffer;
@@ -494,7 +494,7 @@ std::vector<msr::airlib::MeshPositionVertexBuffersResponse> UAirBlueprintLib::Ge
                     RHIUnlockVertexBuffer(vertex_buffer->VertexBufferRHI);
                 });
 
-#if (ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION > 26)
+#if ((ENGINE_MAJOR_VERSION > 4) || (ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION >= 27))
             FStaticMeshLODResources& lod = comp->GetStaticMesh()->GetRenderData()->LODResources[0];
 #else
             FStaticMeshLODResources& lod = comp->GetStaticMesh()->RenderData->LODResources[0];

--- a/Unreal/Plugins/AirSim/Source/DetectionComponent.cpp
+++ b/Unreal/Plugins/AirSim/Source/DetectionComponent.cpp
@@ -142,7 +142,7 @@ bool UDetectionComponent::calcBoundingFromViewInfo(AActor* actor, FBox2D& box_ou
         for (FVector& point : points) {
             is_world_hit = GetWorld()->LineTraceSingleByChannel(result, GetComponentLocation(), point, ECC_WorldStatic);
             if (is_world_hit) {
-                if (result.Actor == actor) {
+                if (result.GetActor() == actor) {
                     is_visible = true;
                     break;
                 }
@@ -156,7 +156,7 @@ bool UDetectionComponent::calcBoundingFromViewInfo(AActor* actor, FBox2D& box_ou
                 FVector point = UKismetMathLibrary::RandomPointInBoundingBox(origin, extend);
                 is_world_hit = GetWorld()->LineTraceSingleByChannel(result, GetComponentLocation(), point, ECC_WorldStatic);
                 if (is_world_hit) {
-                    if (result.Actor == actor) {
+                    if (result.GetActor() == actor) {
                         is_visible = true;
                         break;
                     }

--- a/Unreal/Plugins/AirSim/Source/Recording/RecordingFile.cpp
+++ b/Unreal/Plugins/AirSim/Source/Recording/RecordingFile.cpp
@@ -1,5 +1,9 @@
 #include "RecordingFile.h"
-#include "HAL/PlatformFilemanager.h"
+#if ENGINE_MAJOR_VERSION > 4
+  #include "HAL/PlatformFileManager.h"
+#elif
+  #include "HAL/PlatformFilemanager.h"
+#endif
 #include "Misc/FileHelper.h"
 #include <sstream>
 #include "ImageUtils.h"

--- a/Unreal/Plugins/AirSim/Source/Recording/RecordingFile.cpp
+++ b/Unreal/Plugins/AirSim/Source/Recording/RecordingFile.cpp
@@ -1,9 +1,5 @@
 #include "RecordingFile.h"
-#if ENGINE_MAJOR_VERSION > 4
-  #include "HAL/PlatformFileManager.h"
-#elif
-  #include "HAL/PlatformFilemanager.h"
-#endif
+#include "HAL/PlatformFilemanager.h"
 #include "Misc/FileHelper.h"
 #include <sstream>
 #include "ImageUtils.h"


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: This doesn't fix all of the issues to upgrading to a newer UE version, particularly the upgrade form physx to chaos in UE 5.

## About
Fixing some of the deprecated features in UE 4.27 and 5. 

## How Has This Been Tested?
Except for physx issues on the car, this builds on UE 5 preview. 
This should be backward compatible with at least UE 4.26. I should go back and test with the current recommended version of 4.25. 

## Screenshots (if appropriate):