### PR TITLE
Improve lidar performance

### DIFF
--- a/AirLib/include/common/AirSimSettings.hpp
+++ b/AirLib/include/common/AirSimSettings.hpp
@@ -249,6 +249,11 @@ namespace airlib
 
         struct LidarSetting : SensorSetting
         {
+            enum class DataFrame
+            {
+                VehicleInertialFrame,
+                SensorLocalFrame
+            };
         };
 
         struct VehicleSetting

--- a/AirLib/include/sensors/lidar/LidarSimpleParams.hpp
+++ b/AirLib/include/sensors/lidar/LidarSimpleParams.hpp
@@ -36,7 +36,7 @@ namespace airlib
         };
 
         bool draw_debug_points = false;
-        std::string data_frame = AirSimSettings::kVehicleInertialFrame;
+        AirSimSettings::LidarSetting::DataFrame data_frame;
 
         bool external_controller = true;
 
@@ -53,7 +53,16 @@ namespace airlib
             points_per_second = settings_json.getInt("PointsPerSecond", points_per_second);
             horizontal_rotation_frequency = settings_json.getInt("RotationsPerSecond", horizontal_rotation_frequency);
             draw_debug_points = settings_json.getBool("DrawDebugPoints", draw_debug_points);
-            data_frame = settings_json.getString("DataFrame", data_frame);
+            std::string frame = settings_json.getString("DataFrame", AirSimSettings::kVehicleInertialFrame);
+            if (frame == AirSimSettings::kVehicleInertialFrame) {
+                data_frame = AirSimSettings::LidarSetting::DataFrame::VehicleInertialFrame;
+            }
+            else if (frame == AirSimSettings::kSensorLocalFrame) {
+                data_frame = AirSimSettings::LidarSetting::DataFrame::SensorLocalFrame;
+            }
+            else {
+                throw std::runtime_error("Unknown requested data frame");
+            }
             external_controller = settings_json.getBool("ExternalController", external_controller);
 
             vertical_FOV_upper = settings_json.getFloat("VerticalFOVUpper", Utils::nan<float>());

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
@@ -838,11 +838,10 @@ void ASimModeBase::drawLidarDebugPoints()
 
                         FVector uu_point;
 
-                        if (lidar->getParams().data_frame == AirSimSettings::kVehicleInertialFrame) {
+                        if (lidar->getParams().data_frame == AirSimSettings::LidarSetting::DataFrame::VehicleInertialFrame) {
                             uu_point = pawn_sim_api->getNedTransform().fromLocalNed(point);
                         }
-                        else if (lidar->getParams().data_frame == AirSimSettings::kSensorLocalFrame) {
-
+                        else if (lidar->getParams().data_frame == AirSimSettings::LidarSetting::DataFrame::SensorLocalFrame) {
                             Vector3r point_w = VectorMath::transformToWorldFrame(point, lidar_data.pose, true);
                             uu_point = pawn_sim_api->getNedTransform().fromLocalNed(point_w);
                         }

--- a/Unreal/Plugins/AirSim/Source/UnrealSensors/UnrealLidarSensor.cpp
+++ b/Unreal/Plugins/AirSim/Source/UnrealSensors/UnrealLidarSensor.cpp
@@ -108,7 +108,7 @@ void UnrealLidarSensor::getPointCloud(const msr::airlib::Pose& lidar_pose, const
 // simulate shooting a laser via Unreal ray-tracing.
 bool UnrealLidarSensor::shootLaser(const msr::airlib::Pose& lidar_pose, const msr::airlib::Pose& vehicle_pose,
                                    const float horizontal_angle, const float vertical_angle,
-                                   const msr::airlib::LidarSimpleParams params, Vector3r& point, int& segmentationID)
+                                   const msr::airlib::LidarSimpleParams& params, Vector3r& point, int& segmentationID)
 {
     // start position
     Vector3r start = VectorMath::add(lidar_pose, vehicle_pose).position;

--- a/Unreal/Plugins/AirSim/Source/UnrealSensors/UnrealLidarSensor.cpp
+++ b/Unreal/Plugins/AirSim/Source/UnrealSensors/UnrealLidarSensor.cpp
@@ -78,7 +78,8 @@ void UnrealLidarSensor::getPointCloud(const msr::airlib::Pose& lidar_pose, const
     segmentation_cloud.assign(total_points_to_scan, NULL);
 
     ParallelFor(total_points_to_scan, [&](int32 idx) {
-        const float vertical_angle = laser_angles_[idx % number_of_lasers];
+        int32 laser_idx = idx % number_of_lasers;
+        const float vertical_angle = laser_angles_[laser_idx];
         const float horizontal_angle = std::fmod(current_horizontal_angle_ + angle_distance_of_laser_measure * idx, 360.0f);
 
         // check if the laser is outside the requested horizontal FOV
@@ -86,7 +87,7 @@ void UnrealLidarSensor::getPointCloud(const msr::airlib::Pose& lidar_pose, const
             Vector3r point;
             int segmentationID = -1;
             // shoot laser and get the impact point, if any
-            if (shootLaser(lidar_pose, vehicle_pose, idx % number_of_lasers, horizontal_angle, vertical_angle, params, point, segmentationID)) {
+            if (shootLaser(lidar_pose, vehicle_pose, laser_idx, horizontal_angle, vertical_angle, params, point, segmentationID)) {
                 point_cloud[idx * 3] = point.x();
                 point_cloud[idx * 3 + 1] = point.y();
                 point_cloud[idx * 3 + 2] = point.z();

--- a/Unreal/Plugins/AirSim/Source/UnrealSensors/UnrealLidarSensor.cpp
+++ b/Unreal/Plugins/AirSim/Source/UnrealSensors/UnrealLidarSensor.cpp
@@ -74,8 +74,8 @@ void UnrealLidarSensor::getPointCloud(const msr::airlib::Pose& lidar_pose, const
     const float laser_start = std::fmod(360.0f + params.horizontal_FOV_start, 360.0f);
     const float laser_end = std::fmod(360.0f + params.horizontal_FOV_end, 360.0f);
 
-    point_cloud.assign(total_points_to_scan * 3, NULL);
-    segmentation_cloud.assign(total_points_to_scan, NULL);
+    point_cloud.assign(total_points_to_scan * 3, -1);
+    segmentation_cloud.assign(total_points_to_scan, -1);
 
     ParallelFor(total_points_to_scan, [&](int32 idx) {
         int32 laser_idx = idx % number_of_lasers;
@@ -97,8 +97,8 @@ void UnrealLidarSensor::getPointCloud(const msr::airlib::Pose& lidar_pose, const
     });
 
     // erase–remove idiom to handle non-valid elements
-    point_cloud.erase(std::remove(point_cloud.begin(), point_cloud.end(), NULL), point_cloud.end());
-    segmentation_cloud.erase(std::remove(segmentation_cloud.begin(), segmentation_cloud.end(), NULL), segmentation_cloud.end());
+    point_cloud.erase(std::remove(point_cloud.begin(), point_cloud.end(), -1), point_cloud.end());
+    segmentation_cloud.erase(std::remove(segmentation_cloud.begin(), segmentation_cloud.end(), -1), segmentation_cloud.end());
 
     current_horizontal_angle_ = std::fmod(current_horizontal_angle_ + angle_distance_of_tick, 360.0f);
 

--- a/Unreal/Plugins/AirSim/Source/UnrealSensors/UnrealLidarSensor.cpp
+++ b/Unreal/Plugins/AirSim/Source/UnrealSensors/UnrealLidarSensor.cpp
@@ -19,7 +19,7 @@ UnrealLidarSensor::UnrealLidarSensor(const AirSimSettings::LidarSetting& setting
 // initializes information based on lidar configuration
 void UnrealLidarSensor::createLasers()
 {
-    msr::airlib::LidarSimpleParams params = getParams();
+    const msr::airlib::LidarSimpleParams params = getParams();
 
     const auto number_of_lasers = params.number_of_channels;
 
@@ -47,7 +47,7 @@ void UnrealLidarSensor::getPointCloud(const msr::airlib::Pose& lidar_pose, const
     point_cloud.clear();
     segmentation_cloud.clear();
 
-    msr::airlib::LidarSimpleParams params = getParams();
+    const msr::airlib::LidarSimpleParams params = getParams();
     const auto number_of_lasers = params.number_of_channels;
 
     // cap the points to scan via ray-tracing; this is currently needed for car/Unreal tick scenarios
@@ -87,7 +87,7 @@ void UnrealLidarSensor::getPointCloud(const msr::airlib::Pose& lidar_pose, const
             Vector3r point;
             int segmentationID = -1;
             // shoot laser and get the impact point, if any
-            if (shootLaser(lidar_pose, vehicle_pose, laser_idx, horizontal_angle, vertical_angle, params, point, segmentationID)) {
+            if (shootLaser(lidar_pose, vehicle_pose, horizontal_angle, vertical_angle, params, point, segmentationID)) {
                 point_cloud[idx * 3] = point.x();
                 point_cloud[idx * 3 + 1] = point.y();
                 point_cloud[idx * 3 + 2] = point.z();
@@ -107,7 +107,7 @@ void UnrealLidarSensor::getPointCloud(const msr::airlib::Pose& lidar_pose, const
 
 // simulate shooting a laser via Unreal ray-tracing.
 bool UnrealLidarSensor::shootLaser(const msr::airlib::Pose& lidar_pose, const msr::airlib::Pose& vehicle_pose,
-                                   const uint32 laser, const float horizontal_angle, const float vertical_angle,
+                                   const float horizontal_angle, const float vertical_angle,
                                    const msr::airlib::LidarSimpleParams params, Vector3r& point, int& segmentationID)
 {
     // start position

--- a/Unreal/Plugins/AirSim/Source/UnrealSensors/UnrealLidarSensor.cpp
+++ b/Unreal/Plugins/AirSim/Source/UnrealSensors/UnrealLidarSensor.cpp
@@ -161,12 +161,13 @@ bool UnrealLidarSensor::shootLaser(const msr::airlib::Pose& lidar_pose, const ms
         }
 
         // decide the frame for the point-cloud
-        if (params.data_frame == AirSimSettings::kVehicleInertialFrame) {
+        switch (params.data_frame) {
+        case AirSimSettings::LidarSetting::DataFrame::VehicleInertialFrame:
             // current detault behavior; though it is probably not very useful.
             // not changing the default for now to maintain backwards-compat.
             point = ned_transform_->toLocalNed(hit_result.ImpactPoint);
-        }
-        else if (params.data_frame == AirSimSettings::kSensorLocalFrame) {
+            break;
+        case AirSimSettings::LidarSetting::DataFrame::SensorLocalFrame:
             // point in vehicle intertial frame
             Vector3r point_v_i = ned_transform_->toLocalNed(hit_result.ImpactPoint);
 
@@ -184,9 +185,8 @@ bool UnrealLidarSensor::shootLaser(const msr::airlib::Pose& lidar_pose, const ms
 
             // TODO: Optimization -- instead of doing this for every point, it should be possible to do this
             // for the point-cloud together? Need to look into matrix operations to do this together for all points.
+            break;
         }
-        else
-            throw std::runtime_error("Unknown requested data frame");
 
         return true;
     }

--- a/Unreal/Plugins/AirSim/Source/UnrealSensors/UnrealLidarSensor.cpp
+++ b/Unreal/Plugins/AirSim/Source/UnrealSensors/UnrealLidarSensor.cpp
@@ -68,7 +68,7 @@ void UnrealLidarSensor::getPointCloud(const msr::airlib::Pose& lidar_pose, const
 
     // calculate needed angle/distance between each point
     const float angle_distance_of_tick = params.horizontal_rotation_frequency * 360.0f * delta_time;
-    const float angle_distance_of_laser_measure = angle_distance_of_tick / points_to_scan_with_one_laser;
+    const float angle_distance_of_laser_measure = angle_distance_of_tick / total_points_to_scan;
 
     // normalize FOV start/end
     const float laser_start = std::fmod(360.0f + params.horizontal_FOV_start, 360.0f);

--- a/Unreal/Plugins/AirSim/Source/UnrealSensors/UnrealLidarSensor.cpp
+++ b/Unreal/Plugins/AirSim/Source/UnrealSensors/UnrealLidarSensor.cpp
@@ -140,8 +140,10 @@ bool UnrealLidarSensor::shootLaser(const msr::airlib::Pose& lidar_pose, const ms
         if (hitActor != nullptr) {
             TArray<UMeshComponent*> meshComponents;
             hitActor->GetComponents<UMeshComponent>(meshComponents);
-            for (int i = 0; i < meshComponents.Num(); i++) {
-                segmentationID = segmentationID == -1 ? meshComponents[i]->CustomDepthStencilValue : segmentationID;
+            for (auto* comp : meshComponents) {
+                segmentationID = comp->CustomDepthStencilValue;
+                if (segmentationID != -1)
+                    break;
             }
         }
 

--- a/Unreal/Plugins/AirSim/Source/UnrealSensors/UnrealLidarSensor.h
+++ b/Unreal/Plugins/AirSim/Source/UnrealSensors/UnrealLidarSensor.h
@@ -31,7 +31,7 @@ private:
     void createLasers();
     bool shootLaser(const msr::airlib::Pose& lidar_pose, const msr::airlib::Pose& vehicle_pose,
                     const float horizontal_angle, const float vertical_angle,
-                    const msr::airlib::LidarSimpleParams params, Vector3r& point, int& segmentationID);
+                    const msr::airlib::LidarSimpleParams& params, Vector3r& point, int& segmentationID);
 
 private:
     AActor* actor_;

--- a/Unreal/Plugins/AirSim/Source/UnrealSensors/UnrealLidarSensor.h
+++ b/Unreal/Plugins/AirSim/Source/UnrealSensors/UnrealLidarSensor.h
@@ -30,7 +30,7 @@ private:
 
     void createLasers();
     bool shootLaser(const msr::airlib::Pose& lidar_pose, const msr::airlib::Pose& vehicle_pose,
-                    const uint32 channel, const float horizontal_angle, const float vertical_angle,
+                    const float horizontal_angle, const float vertical_angle,
                     const msr::airlib::LidarSimpleParams params, Vector3r& point, int& segmentationID);
 
 private:


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

## Fixes
Fixes: https://github.com/microsoft/AirSim/issues/4474

## About
<!-- Describe what your PR is about. -->
Lidar raycast make the calculation using line trace on single thread.
This PR take advantage of `ParallelFor` to improve the performance.

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
<details>
<summary>Lidar config tested</summary>

```

{
  "SettingsVersion": 1.2,
  "SimMode": "Car",
  "EnableRpc": true,
  "ViewMode": "Fpv",
  "LogMessagesVisible": true,
  "EngineSound": false,

  "Vehicles": {
    "PhysXCar": {
      "VehicleType": "PhysXCar",
      "DefaultVehicleState": "",
      "AutoCreate": true,
      "PawnPath": "",
      "EnableCollisionPassthrogh": false,
      "EnableCollisions": true,
      "RC": {
        "RemoteControlID": 0
      },
      "Sensors": {
        "LidarCustom": {
            "SensorType": 6,
            "Enabled" : true,
            "NumberOfChannels": 16,
            "PointsPerSecond": 32000,
            "Range": 40.0,
            "X": 2.0, "Y": 0, "Z": -0.7657162547111511,
            "Pitch": 0.0, "Roll": 0.0, "Yaw": 0.0,
            "HorizontalFOVStart": -180.0,
            "HorizontalFOVEnd": 180.0,
            "VerticalFOVUpper": 45.0,
            "VerticalFOVLower": -10.0,     
            "DrawDebugPoints": true
        }
      }
    }
  }
}

```
</details>

**Benchmark:**
<details>
<summary>Before:</summary>

```
LogTemp: Warning: code executed in 0.023679 seconds.
LogTemp: Warning: code executed in 0.007037 seconds.
LogTemp: Warning: code executed in 0.007560 seconds.
LogTemp: Warning: code executed in 0.007134 seconds.
LogTemp: Warning: code executed in 0.008667 seconds.
LogTemp: Warning: code executed in 0.007389 seconds.
LogTemp: Warning: code executed in 0.007219 seconds.
LogTemp: Warning: code executed in 0.008543 seconds.
LogTemp: Warning: code executed in 0.007057 seconds.
LogTemp: Warning: code executed in 0.009526 seconds.
LogTemp: Warning: code executed in 0.008571 seconds.
LogTemp: Warning: code executed in 0.007375 seconds.
LogTemp: Warning: code executed in 0.007126 seconds.
LogTemp: Warning: code executed in 0.008792 seconds.
LogTemp: Warning: code executed in 0.006901 seconds.
LogTemp: Warning: code executed in 0.007225 seconds.
LogTemp: Warning: code executed in 0.008875 seconds.
LogTemp: Warning: code executed in 0.007040 seconds.
LogTemp: Warning: code executed in 0.007565 seconds.
LogTemp: Warning: code executed in 0.008645 seconds.
LogTemp: Warning: code executed in 0.008770 seconds.
LogTemp: Warning: code executed in 0.007121 seconds.
LogTemp: Warning: code executed in 0.008888 seconds.
LogTemp: Warning: code executed in 0.009491 seconds.
LogTemp: Warning: code executed in 0.008847 seconds.
LogTemp: Warning: code executed in 0.008941 seconds.
LogTemp: Warning: code executed in 0.007436 seconds.
LogTemp: Warning: code executed in 0.009542 seconds.
LogTemp: Warning: code executed in 0.009030 seconds.
LogTemp: Warning: code executed in 0.008122 seconds.
LogTemp: Warning: code executed in 0.009491 seconds.
LogTemp: Warning: code executed in 0.008235 seconds.
LogTemp: Warning: code executed in 0.010218 seconds.
LogTemp: Warning: code executed in 0.008488 seconds.
LogTemp: Warning: code executed in 0.010495 seconds.
LogTemp: Warning: code executed in 0.009934 seconds.
LogTemp: Warning: code executed in 0.014051 seconds.

```
</details>

<details>
<summary>After:</summary>

```
LogTemp: Warning: code executed in 0.002308 seconds.
LogTemp: Warning: code executed in 0.001656 seconds.
LogTemp: Warning: code executed in 0.001599 seconds.
LogTemp: Warning: code executed in 0.001483 seconds.
LogTemp: Warning: code executed in 0.001626 seconds.
LogTemp: Warning: code executed in 0.001331 seconds.
LogTemp: Warning: code executed in 0.001581 seconds.
LogTemp: Warning: code executed in 0.001809 seconds.
LogTemp: Warning: code executed in 0.001552 seconds.
LogTemp: Warning: code executed in 0.001292 seconds.
LogTemp: Warning: code executed in 0.001149 seconds.
LogTemp: Warning: code executed in 0.002029 seconds.
LogTemp: Warning: code executed in 0.001522 seconds.
LogTemp: Warning: code executed in 0.001314 seconds.
LogTemp: Warning: code executed in 0.001266 seconds.
LogTemp: Warning: code executed in 0.001196 seconds.
LogTemp: Warning: code executed in 0.002130 seconds.
LogTemp: Warning: code executed in 0.001464 seconds.
LogTemp: Warning: code executed in 0.001435 seconds.
LogTemp: Warning: code executed in 0.001353 seconds.
LogTemp: Warning: code executed in 0.001157 seconds.
LogTemp: Warning: code executed in 0.002004 seconds.
LogTemp: Warning: code executed in 0.001739 seconds.
LogTemp: Warning: code executed in 0.001274 seconds.
LogTemp: Warning: code executed in 0.001429 seconds.
LogTemp: Warning: code executed in 0.002372 seconds.
LogTemp: Warning: code executed in 0.002305 seconds.
LogTemp: Warning: code executed in 0.001499 seconds.
LogTemp: Warning: code executed in 0.001063 seconds.
LogTemp: Warning: code executed in 0.001904 seconds.
LogTemp: Warning: code executed in 0.001390 seconds.
LogTemp: Warning: code executed in 0.001310 seconds.
LogTemp: Warning: code executed in 0.001293 seconds.
LogTemp: Warning: code executed in 0.001710 seconds.
LogTemp: Warning: code executed in 0.001767 seconds.
LogTemp: Warning: code executed in 0.001296 seconds.
LogTemp: Warning: code executed in 0.001814 seconds.
LogTemp: Warning: code executed in 0.001432 seconds.
LogTemp: Warning: code executed in 0.001237 seconds.
LogTemp: Warning: code executed in 0.001295 seconds.
LogTemp: Warning: code executed in 0.001241 seconds.
LogTemp: Warning: code executed in 0.001401 seconds.
LogTemp: Warning: code executed in 0.001784 seconds.
LogTemp: Warning: code executed in 0.001396 seconds.

```
</details>

You can see the execution time is about 8 times faster, which obviously depends on your CPU.

**UPDATE:**
After some tests, I have found the point cloud generated by the multithread method is not the same as the original.  
Fixed here https://github.com/microsoft/AirSim/pull/4505/commits/497cf065159f86703c3abd04bf188366aa025b6d

Also, it's pretty complicated to verify that the clouds are exactly the same so I have added a test to check they are identical.
I ran both the original method the and new method, compared the point cloud arrays and made sure I didn't hit the breakpoint in case they are different.

To test it yourself, you can override the `UnrealLidarSensor::getPointCloud` method with the following

<details>
<summary>UnrealLidarSensor::getPointCloud</summary>

```

// returns a point-cloud for the tick
void UnrealLidarSensor::getPointCloud(const msr::airlib::Pose& lidar_pose, const msr::airlib::Pose& vehicle_pose,
                                      const msr::airlib::TTimeDelta delta_time, msr::airlib::vector<msr::airlib::real_T>& point_cloud, msr::airlib::vector<int>& segmentation_cloud)
{
    point_cloud.clear();
    segmentation_cloud.clear();

    const msr::airlib::LidarSimpleParams params = getParams();
    const auto number_of_lasers = params.number_of_channels;

    // cap the points to scan via ray-tracing; this is currently needed for car/Unreal tick scenarios
    // since SensorBase mechanism uses the elapsed clock time instead of the tick delta-time.
    constexpr float MAX_POINTS_IN_SCAN = 1e+5f;
    uint32 total_points_to_scan = FMath::RoundHalfFromZero(params.points_per_second * delta_time);
    if (total_points_to_scan > MAX_POINTS_IN_SCAN) {
        total_points_to_scan = MAX_POINTS_IN_SCAN;
        UAirBlueprintLib::LogMessageString("Lidar: ", "Capping number of points to scan", LogDebugLevel::Failure);
    }

    // calculate number of points needed for each laser/channel
    const uint32 points_to_scan_with_one_laser = FMath::RoundHalfFromZero(total_points_to_scan / float(number_of_lasers));
    if (points_to_scan_with_one_laser <= 0) {
        //UAirBlueprintLib::LogMessageString("Lidar: ", "No points requested this frame", LogDebugLevel::Failure);
        return;
    }

    // calculate needed angle/distance between each point
    const float angle_distance_of_tick = params.horizontal_rotation_frequency * 360.0f * delta_time;
    const float angle_distance_of_laser_measure = angle_distance_of_tick / points_to_scan_with_one_laser;

    // normalize FOV start/end
    const float laser_start = std::fmod(360.0f + params.horizontal_FOV_start, 360.0f);
    const float laser_end = std::fmod(360.0f + params.horizontal_FOV_end, 360.0f);

    std::vector<float> point_cloud_single_thread;
    // Single threaded
    {
        // shoot lasers
        for (auto laser = 0u; laser < number_of_lasers; ++laser) {
            const float vertical_angle = laser_angles_[laser];

            for (auto i = 0u; i < points_to_scan_with_one_laser; ++i) {
                const float horizontal_angle = std::fmod(current_horizontal_angle_ + angle_distance_of_laser_measure * i, 360.0f);

                // check if the laser is outside the requested horizontal FOV
                if (!VectorMath::isAngleBetweenAngles(horizontal_angle, laser_start, laser_end))
                    continue;

                Vector3r point;
                int segmentationID = -1;
                // shoot laser and get the impact point, if any
                if (shootLaser(lidar_pose, vehicle_pose, horizontal_angle, vertical_angle, params, point, segmentationID)) {
                    point_cloud_single_thread.emplace_back(point.x());
                    point_cloud_single_thread.emplace_back(point.y());
                    point_cloud_single_thread.emplace_back(point.z());
                    //segmentation_cloud.emplace_back(segmentationID);
                }
            }
        }
    }

    // Multi threaded
    const uint32 total_jobs = number_of_lasers * points_to_scan_with_one_laser;

    point_cloud.assign(total_jobs * 3, FLT_MAX);
    segmentation_cloud.assign(total_jobs, -1);
    {
        ParallelFor(total_jobs, [&](int32 idx) {
            int32 laser_idx = (idx / points_to_scan_with_one_laser) % number_of_lasers;
            const float vertical_angle = laser_angles_[laser_idx];
            const float horizontal_angle = std::fmod(current_horizontal_angle_ + angle_distance_of_laser_measure * (idx % points_to_scan_with_one_laser), 360.0f);

            // check if the laser is outside the requested horizontal FOV
            if (VectorMath::isAngleBetweenAngles(horizontal_angle, laser_start, laser_end)) {
                Vector3r point;
                int segmentationID = -1;
                // shoot laser and get the impact point, if any
                if (shootLaser(lidar_pose, vehicle_pose, horizontal_angle, vertical_angle, params, point, segmentationID)) {
                    point_cloud[idx * 3] = point.x();
                    point_cloud[idx * 3 + 1] = point.y();
                    point_cloud[idx * 3 + 2] = point.z();
                    segmentation_cloud[idx] = segmentationID;
                }
            }
        });
    }

    // erase–remove idiom to handle non-valid elements
    point_cloud.erase(std::remove(point_cloud.begin(), point_cloud.end(), FLT_MAX), point_cloud.end());
    segmentation_cloud.erase(std::remove(segmentation_cloud.begin(), segmentation_cloud.end(), -1), segmentation_cloud.end());

    // compare
    if (point_cloud_single_thread != point_cloud) {
        UAirBlueprintLib::LogMessageString("Lidar test not equal ", "", LogDebugLevel::Failure);
    }

    current_horizontal_angle_ = std::fmod(current_horizontal_angle_ + angle_distance_of_tick, 360.0f);

    return;
}
```
</details>