### PR TITLE
Exit application with unsupported SimMode in Unity

### DIFF
--- a/Unity/UnityDemo/Assets/AirSimAssets/Scripts/InitializeAirSim.cs
+++ b/Unity/UnityDemo/Assets/AirSimAssets/Scripts/InitializeAirSim.cs
@@ -26,6 +26,20 @@ public class InitializeAirSim : MonoBehaviour
                         LoadSceneAsPerSimMode(AirSimSettings.GetSettings().SimMode);
                         break;
                     }
+                    case "":
+                    {
+                        break;
+                    }
+                    default:
+                    {
+                        Debug.LogError("'" + AirSimSettings.GetSettings().SimMode + "' is not a supported SimMode.");
+                        #if UNITY_EDITOR
+                        UnityEditor.EditorApplication.isPlaying = false;
+                        #else
+                        Application.Quit();
+                        #endif
+                        break;
+                    }
 				}
             }
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #4493    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
This PR outputs a log error and exits the application when a SimMode unsupported by the Unity version is specified in the settings. This prevents a crash from occurring.<!-- Describe what your PR is about. -->

## How Has This Been Tested?
Tested in editor and standalone with all SimModes mentioned [here](https://microsoft.github.io/AirSim/settings/#simmode). Note that `ComputerVision` is currently unsupported in Unity, so that should trigger an application exit. <!-- Please, describe how you have tested your changes to help us incorporate them. -->

## Screenshots (if appropriate):