### PR TITLE
update all environments during build in Windows

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -204,6 +204,13 @@ if NOT exist Unreal\Plugins\AirSim\Source\AirLib mkdir Unreal\Plugins\AirSim\Sou
 robocopy /MIR AirLib Unreal\Plugins\AirSim\Source\AirLib  /XD temp *. /njh /njs /ndl /np
 copy /y AirSim.props Unreal\Plugins\AirSim\Source\AirLib
 
+REM //---------- update all environments ----------
+FOR /D %%E IN (Unreal\Environments\*) DO (
+    cd %%E
+    call .\update_from_git.bat ..\..\..
+    cd ..\..\..
+)
+
 REM //---------- done building ----------
 exit /b 0
 

--- a/docs/unreal_blocks.md
+++ b/docs/unreal_blocks.md
@@ -8,10 +8,9 @@ Here are quick steps to get Blocks environment up and running:
 ## Windows
 
 1. Make sure you have [installed Unreal and built AirSim](build_windows.md).
-2. Navigate to folder `AirSim\Unreal\Environments\Blocks` and run `update_from_git.bat`.
-3. Double click on generated .sln file to open in Visual Studio 2019 or newer.
-4. Make sure `Blocks` project is the startup project, build configuration is set to `DebugGame_Editor` and `Win64`. Hit F5 to run.
-5. Press the Play button in Unreal Editor and you will see something like in below video. Also see [how to use AirSim](https://github.com/Microsoft/AirSim/#how-to-use-it).
+2. Navigate to folder `AirSim\Unreal\Environments\Blocks`, double click on Blocks.sln file to open in Visual Studio. By default, this project is configured for Visual Studio 2019. However, if you want to generate this project for Visual Studio 2022, go to 'Edit->Editor Preferences->Source Code' inside the Unreal Editor and select 'Visual Studio 2022' for the 'Source Code Editor' setting.
+3. Make sure `Blocks` project is the startup project, build configuration is set to `DebugGame_Editor` and `Win64`. Hit F5 to run.
+4. Press the Play button in Unreal Editor and you will see something like in below video. Also see [how to use AirSim](https://github.com/Microsoft/AirSim/#how-to-use-it).
 
 ### Changing Code and Rebuilding
 For Windows, you can just change the code in Visual Studio, press F5 and re-run. There are few batch files available in folder `AirSim\Unreal\Environments\Blocks` that lets you sync code, clean etc.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
This PR applies the same fix in #4526 to the Windows build script (build.cmd). This also updates the documentation to remove an explicit call to update_from_git.bat in the Windows workflow.<!-- Describe what your PR is about. -->

## How Has This Been Tested?
A build was ran with the new build.cmd and two environments: Blocks and a copy of Blocks under another name. Both environments were confirmed to startup and run after the build.<!-- Please, describe how you have tested your changes to help us incorporate them. -->

## Screenshots (if appropriate):