### PR TITLE
Fix settings FOV not applied

### DIFF
--- a/Unreal/Plugins/AirSim/Source/PIPCamera.cpp
+++ b/Unreal/Plugins/AirSim/Source/PIPCamera.cpp
@@ -778,7 +778,6 @@ void APIPCamera::copyCameraSettingsToSceneCapture(UCameraComponent* src, USceneC
 {
     if (src && dst) {
         dst->SetWorldLocationAndRotation(src->GetComponentLocation(), src->GetComponentRotation());
-        dst->FOVAngle = src->FieldOfView;
 
         FMinimalViewInfo camera_view_info;
         src->GetCameraView(/*DeltaTime =*/0.0f, camera_view_info);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: https://github.com/microsoft/AirSim/issues/4557

## About
With this PR, an issue was fixed that caused the FOV from a setting to be overridden when creating a custom camera.
More details here https://github.com/microsoft/AirSim/issues/4557.

I'm not sure what the original intent of this line is, but it causes the requested FOV to be overridden by the default.
 At this point, `dst` already has set the right FOV while `src` is not.
https://github.com/microsoft/AirSim/blob/caa13182328e866564c09fdeebca89ba024bc323/Unreal/Plugins/AirSim/Source/PIPCamera.cpp#L781 

## How Has This Been Tested?
Run with the original issue settings and make sure the settings actually change the FOV.

## Screenshots (if appropriate):