### PR TITLE
Fix load level for UE editor

### DIFF
--- a/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
+++ b/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
@@ -76,11 +76,20 @@ void UAirBlueprintLib::setSimulatePhysics(AActor* actor, bool simulate_physics)
 
 bool UAirBlueprintLib::loadLevel(UObject* context, const FString& level_name)
 {
-    FString LongPackageName;
-    const bool success = FPackageName::SearchForPackageOnDisk(level_name, &LongPackageName);
-    if (success) {
-        context->GetWorld()->SetNewWorldOrigin(FIntVector(0, 0, 0));
-        UGameplayStatics::OpenLevel(context->GetWorld(), FName(*LongPackageName), true);
+    
+    bool success{false};
+    // Get name of current level
+    auto currMap = context->GetWorld()->GetMapName();
+    currMap.RemoveFromStart(context->GetWorld()->StreamingLevelsPrefix);
+    // Only load new level if different from current level
+    if (!currMap.Equals((level_name)))
+    {
+        FString LongPackageName;
+        success = FPackageName::SearchForPackageOnDisk(level_name, &LongPackageName);
+        if (success) {
+            context->GetWorld()->SetNewWorldOrigin(FIntVector(0, 0, 0));
+            UGameplayStatics::OpenLevel(context->GetWorld(), FName(*LongPackageName), true);
+        }
     }
     return success;
 }

--- a/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
+++ b/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
@@ -77,12 +77,12 @@ void UAirBlueprintLib::setSimulatePhysics(AActor* actor, bool simulate_physics)
 bool UAirBlueprintLib::loadLevel(UObject* context, const FString& level_name)
 {
     
-    bool success{false};
+    bool success{ false };
     // Get name of current level
     auto currMap = context->GetWorld()->GetMapName();
     currMap.RemoveFromStart(context->GetWorld()->StreamingLevelsPrefix);
     // Only load new level if different from current level
-    if (!currMap.Equals((level_name)))
+    if (!currMap.Equals(level_name))
     {
         FString LongPackageName;
         success = FPackageName::SearchForPackageOnDisk(level_name, &LongPackageName);

--- a/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
+++ b/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
@@ -76,14 +76,13 @@ void UAirBlueprintLib::setSimulatePhysics(AActor* actor, bool simulate_physics)
 
 bool UAirBlueprintLib::loadLevel(UObject* context, const FString& level_name)
 {
-    
+
     bool success{ false };
     // Get name of current level
     auto currMap = context->GetWorld()->GetMapName();
     currMap.RemoveFromStart(context->GetWorld()->StreamingLevelsPrefix);
     // Only load new level if different from current level
-    if (!currMap.Equals(level_name))
-    {
+    if (!currMap.Equals(level_name)) {
         FString LongPackageName;
         success = FPackageName::SearchForPackageOnDisk(level_name, &LongPackageName);
         if (success) {

--- a/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
@@ -22,9 +22,9 @@ void ASimHUD::BeginPlay()
 
     try {
         UAirBlueprintLib::OnBeginPlay();
+        initializeSettings();
         loadLevel();
 
-        initializeSettings();
         setUnrealEngineSettings();
         createSimMode();
         createMainWidget();

--- a/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
@@ -25,6 +25,9 @@ void ASimHUD::BeginPlay()
         initializeSettings();
         loadLevel();
 
+        // Prevent a MavLink connection being established if changing levels
+        if (map_changed_) return;
+
         setUnrealEngineSettings();
         createSimMode();
         createMainWidget();
@@ -253,7 +256,7 @@ std::string ASimHUD::getSimModeFromUser()
 
 void ASimHUD::loadLevel()
 {
-    UAirBlueprintLib::RunCommandOnGameThread([&]() { UAirBlueprintLib::loadLevel(this->GetWorld(), FString(AirSimSettings::singleton().level_name.c_str())); }, true);
+    UAirBlueprintLib::RunCommandOnGameThread([&]() { this->map_changed_ = UAirBlueprintLib::loadLevel(this->GetWorld(), FString(AirSimSettings::singleton().level_name.c_str())); }, true);
 }
 
 void ASimHUD::createSimMode()

--- a/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.h
+++ b/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.h
@@ -73,4 +73,5 @@ private:
     ASimModeBase* simmode_;
 
     APIPCamera* subwindow_cameras_[AirSimSettings::kSubwindowCount];
+    bool map_changed_;
 };


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #4551<!-- add this line for each issue your PR solves. -->
Fixes: #4601
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
Current method to load level may work for a packaged binary but does not work in the UE editor where it will infinitely load the requested level. This PR adds a check to make sure the current level is not reloaded.

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
1. Load project in editor.
2. Add a "Default Environment" value in settings.json
3. Launch AirSim.
4. Before fix, editor freezes due to infinitely reloading requested level. After fix, new level is loaded.

## Screenshots (if appropriate):