### PR TITLE
(GitHub CI) Bump actions/checkout and actions/setup-python version in workflows

### DIFF
--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -5,7 +5,7 @@ jobs:
     name: Formatting Check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Run clang-format style check for C/C++ programs.
       uses: jidicula/clang-format-action@v4.4.1
       with:

--- a/.github/workflows/test_docs.yml
+++ b/.github/workflows/test_docs.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.7'
           architecture: 'x64'

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -12,7 +12,7 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup
         run: ./setup.sh

--- a/.github/workflows/test_ubuntu.yml
+++ b/.github/workflows/test_ubuntu.yml
@@ -11,7 +11,7 @@ jobs:
         os: [ubuntu-18.04, ubuntu-20.04]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup
         run: ./setup.sh

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -9,7 +9,7 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Enable Developer Command Prompt
         uses: ilammy/msvc-dev-cmd@v1


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->


## About
<!-- Describe what your PR is about. -->

This PR will bump the actions/checkout version in all the files i've edited and in the test_docs workflow my edit will also bump the setup-python version from v2 to v4.

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->

No, just basic changes so it has not been tested from an IDE.

## Screenshots (if appropriate):