### PR TITLE
Added 'ring' field in lidar point cloud generation. Updated ROS and R…

### DIFF
--- a/AirLib/include/sensors/lidar/LidarBase.hpp
+++ b/AirLib/include/sensors/lidar/LidarBase.hpp
@@ -26,7 +26,7 @@ namespace airlib
             UpdatableObject::reportState(reporter);
 
             reporter.writeValue("Lidar-Timestamp", output_.time_stamp);
-            reporter.writeValue("Lidar-NumPoints", static_cast<int>(output_.point_cloud.size() / 3));
+            reporter.writeValue("Lidar-NumPoints", static_cast<int>(output_.point_cloud.size() / 4));
         }
 
         const LidarData& getOutput() const

--- a/Unreal/Plugins/AirSim/Source/UnrealSensors/UnrealLidarSensor.cpp
+++ b/Unreal/Plugins/AirSim/Source/UnrealSensors/UnrealLidarSensor.cpp
@@ -91,6 +91,7 @@ void UnrealLidarSensor::getPointCloud(const msr::airlib::Pose& lidar_pose, const
                 point_cloud.emplace_back(point.x());
                 point_cloud.emplace_back(point.y());
                 point_cloud.emplace_back(point.z());
+                point_cloud.emplace_back(laser);
                 segmentation_cloud.emplace_back(segmentationID);
             }
         }

--- a/ros/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
+++ b/ros/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
@@ -733,14 +733,15 @@ sensor_msgs::PointCloud2 AirsimROSWrapper::get_lidar_msg_from_airsim(const msr::
     lidar_msg.header.stamp = ros::Time::now();
     lidar_msg.header.frame_id = vehicle_name + "/" + sensor_name;
 
-    if (lidar_data.point_cloud.size() > 3) {
+    if (lidar_data.point_cloud.size() > 4) {
         lidar_msg.height = 1;
-        lidar_msg.width = lidar_data.point_cloud.size() / 3;
+        lidar_msg.width = lidar_data.point_cloud.size() / 4;
 
-        lidar_msg.fields.resize(3);
+        lidar_msg.fields.resize(4);
         lidar_msg.fields[0].name = "x";
         lidar_msg.fields[1].name = "y";
         lidar_msg.fields[2].name = "z";
+        lidar_msg.fields[3].name = "ring";
 
         int offset = 0;
 

--- a/ros2/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
+++ b/ros2/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
@@ -651,14 +651,15 @@ sensor_msgs::msg::PointCloud2 AirsimROSWrapper::get_lidar_msg_from_airsim(const 
     lidar_msg.header.stamp = rclcpp::Time(lidar_data.time_stamp);
     lidar_msg.header.frame_id = vehicle_name + "/" + sensor_name;
 
-    if (lidar_data.point_cloud.size() > 3) {
+    if (lidar_data.point_cloud.size() > 4) {
         lidar_msg.height = 1;
-        lidar_msg.width = lidar_data.point_cloud.size() / 3;
+        lidar_msg.width = lidar_data.point_cloud.size() / 4;
 
-        lidar_msg.fields.resize(3);
+        lidar_msg.fields.resize(4);
         lidar_msg.fields[0].name = "x";
         lidar_msg.fields[1].name = "y";
         lidar_msg.fields[2].name = "z";
+        lidar_msg.fields[3].name = "ring";
 
         int offset = 0;
 


### PR DESCRIPTION
…OS2 lidar data processing

<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
LiDAR data must include for each point at least the fields X, Y, Z and ring as most of the commertial LiDARs do. The ring field is the index of laser beam and it is needed to perform LiDAR odometry. This index field has been added in the API and ROS/ROS2 packages has been updated to include that field.

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->

## Screenshots (if appropriate):