### PR TITLE
Fix image saving in HelloDrone

### DIFF
--- a/HelloDrone/main.cpp
+++ b/HelloDrone/main.cpp
@@ -33,7 +33,7 @@ int main()
         const std::vector<ImageResponse>& response = client.simGetImages(request);
         std::cout << "# of images received: " << response.size() << std::endl;
 
-        if (!response.size()) {
+        if (response.size()) {
             std::cout << "Enter path with ending separator to save images (leave empty for no save)" << std::endl;
             std::string path;
             std::getline(std::cin, path);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #HelloDrone never asked to save image.

## About
Fixed HelloDrone/main.cpp code to ask for path and save images. There was a simple bug.

## How Has This Been Tested?
Run locally with AirSim, images saved as expected.

## Screenshots (if appropriate):
After the fix applied: 
```
 % ./main 
Waiting for connection - X

Connected!

Client Ver:1 (Min Req:1), Server Ver:1 (Min Req:1)
Press Enter to get FPV image
# of images received: 2
Enter path with ending separator to save images (leave empty for no save)
./img/
Image uint8 size: 62355
Image float size: 0
Image uint8 size: 0
Image float size: 36864
Press Enter to arm the drone
```