### PR TITLE
AirSim UE5 support

### DIFF
--- a/Unreal/Environments/Blocks/Blocks.uproject
+++ b/Unreal/Environments/Blocks/Blocks.uproject
@@ -1,6 +1,6 @@
 {
 	"FileVersion": 3,
-	"EngineAssociation": "4.27",
+	"EngineAssociation": "5.0",
 	"Category": "",
 	"Description": "",
 	"Modules": [

--- a/Unreal/Plugins/AirSim/AirSim.uplugin
+++ b/Unreal/Plugins/AirSim/AirSim.uplugin
@@ -22,9 +22,9 @@
     }
   ],
   "Plugins": [
-	  {
-		  "Name": "PhysXVehicles",
-		  "Enabled": true
-	  }
+    {
+      "Name": "ChaosVehiclesPlugin",
+      "Enabled": true
+    }
   ]
 }

--- a/Unreal/Plugins/AirSim/Source/AirSim.Build.cs
+++ b/Unreal/Plugins/AirSim/Source/AirSim.Build.cs
@@ -78,7 +78,7 @@ public class AirSim : ModuleRules
 
         bEnableExceptions = true;
 
-        PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "ImageWrapper", "RenderCore", "RHI", "AssetRegistry", "PhysicsCore", "PhysXVehicles", "PhysXVehicleLib", "PhysX", "APEX", "Landscape", "CinematicCamera" });
+        PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "ImageWrapper", "RenderCore", "RHI", "PhysicsCore", "APEX", "AssetRegistry", "ChaosVehicles", "Landscape", "CinematicCamera" });
         PrivateDependencyModuleNames.AddRange(new string[] { "UMG", "Slate", "SlateCore" });
 
         //suppress VC++ proprietary warnings

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
@@ -229,7 +229,7 @@ msr::airlib::RCData PawnSimApi::getRCData() const
 
 void PawnSimApi::displayCollisionEffect(FVector hit_location, const FHitResult& hit)
 {
-    if (params_.collision_display_template != nullptr && Utils::isDefinitelyLessThan(hit.ImpactNormal.Z, 0.0f)) {
+    if (params_.collision_display_template != nullptr && Utils::isDefinitelyLessThan<double>(hit.ImpactNormal.Z, 0.0f)) {
         UParticleSystemComponent* particles = UGameplayStatics::SpawnEmitterAtLocation(params_.pawn->GetWorld(),
                                                                                        params_.collision_display_template,
                                                                                        FTransform(hit_location),

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawn.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawn.cpp
@@ -12,7 +12,6 @@
 #include <vector>
 #include "common/common_utils/Utils.hpp"
 #include "common/ClockFactory.hpp"
-#include <ChaosVehicles/ChaosVehiclesCore/Public/TransmissionSystem.h>
 
 #define LOCTEXT_NAMESPACE "VehiclePawn"
 
@@ -93,19 +92,19 @@ void ACarPawn::setupVehicleMovementComponent()
     // Wheels/Tires
     // Setup the wheels
     movement->WheelSetups[0].WheelClass = UCarWheelFront::StaticClass();
-    movement->WheelSetups[0].BoneName = FName("PhysWheel_FL");
+    movement->WheelSetups[0].BoneName = FName("WheelFL");
     movement->WheelSetups[0].AdditionalOffset = FVector(0.f, -8.f, 0.f);
 
     movement->WheelSetups[1].WheelClass = UCarWheelFront::StaticClass();
-    movement->WheelSetups[1].BoneName = FName("PhysWheel_FR");
+    movement->WheelSetups[1].BoneName = FName("WheelFR");
     movement->WheelSetups[1].AdditionalOffset = FVector(0.f, 8.f, 0.f);
 
     movement->WheelSetups[2].WheelClass = UCarWheelRear::StaticClass();
-    movement->WheelSetups[2].BoneName = FName("PhysWheel_BL");
+    movement->WheelSetups[2].BoneName = FName("WheelBL");
     movement->WheelSetups[2].AdditionalOffset = FVector(0.f, -8.f, 0.f);
 
     movement->WheelSetups[3].WheelClass = UCarWheelRear::StaticClass();
-    movement->WheelSetups[3].BoneName = FName("PhysWheel_BR");
+    movement->WheelSetups[3].BoneName = FName("WheelBR");
     movement->WheelSetups[3].AdditionalOffset = FVector(0.f, 8.f, 0.f);
 
     // Adjust the tire loading
@@ -149,10 +148,11 @@ void ACarPawn::setupVehicleMovementComponent()
     if (primitive) {
         primitive->BodyInstance.COMNudge = FVector(8.0f, 0.0f, 0.0f);
     }
-
+    movement->UpdatedPrimitive = primitive;
     // Set the inertia scale. This controls how the mass of the vehicle is distributed.
     movement->InertiaTensorScale = FVector(1.0f, 1.333f, 1.2f);
     //movement->bDeprecatedSpringOffsetMode = true;
+    movement->bAutoRegisterUpdatedComponent = true;
 }
 
 void ACarPawn::NotifyHit(class UPrimitiveComponent* MyComp, class AActor* Other, class UPrimitiveComponent* OtherComp, bool bSelfMoved, FVector HitLocation,

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawn.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawn.cpp
@@ -285,7 +285,7 @@ void ACarPawn::updateHUDStrings()
     else {
         last_gear_ = (Gear == 0) ? LOCTEXT("N", "N") : FText::AsNumber(Gear);
     }
-    
+
     UChaosWheeledVehicleMovementComponent* movement = CastChecked<UChaosWheeledVehicleMovementComponent>(getVehicleMovementComponent());
     UAirBlueprintLib::LogMessage(TEXT("Speed: "), last_speed_.ToString(), LogDebugLevel::Informational);
     UAirBlueprintLib::LogMessage(TEXT("Gear: "), last_gear_.ToString(), LogDebugLevel::Informational);

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawn.h
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawn.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "WheeledVehicle.h"
+#include "ChaosWheeledVehicleMovementComponent.h"
+#include "WheeledVehiclePawn.h"
 #include "Components/SkeletalMeshComponent.h"
 #include "PhysicalMaterials/PhysicalMaterial.h"
 #include "UObject/ConstructorHelpers.h"
@@ -26,7 +27,7 @@ class UInputComponent;
 class UAudioComponent;
 
 UCLASS(config = Game)
-class ACarPawn : public AWheeledVehicle
+class ACarPawn : public AWheeledVehiclePawn
 {
     GENERATED_BODY()
 
@@ -46,7 +47,7 @@ public:
     {
         return &pawn_events_;
     }
-    UWheeledVehicleMovementComponent* getVehicleMovementComponent() const;
+    UChaosVehicleMovementComponent* getVehicleMovementComponent() const;
     const msr::airlib::CarApiBase::CarControls& getKeyBoardControls() const
     {
         return keyboard_controls_;

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnApi.cpp
@@ -8,7 +8,6 @@ CarPawnApi::CarPawnApi(ACarPawn* pawn, const msr::airlib::Kinematics::State* paw
     : pawn_(pawn), pawn_kinematics_(pawn_kinematics), vehicle_api_(vehicle_api)
 {
     movement_ = CastChecked<UChaosWheeledVehicleMovementComponent>(pawn->GetVehicleMovement());
-    
 }
 
 void CarPawnApi::updateMovement(const msr::airlib::CarApiBase::CarControls& controls)

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnApi.cpp
@@ -1,13 +1,14 @@
 #include "CarPawnApi.h"
 #include "AirBlueprintLib.h"
 
-#include "PhysXVehicleManager.h"
+#include "ChaosVehicleManager.h"
 
 CarPawnApi::CarPawnApi(ACarPawn* pawn, const msr::airlib::Kinematics::State* pawn_kinematics,
                        msr::airlib::CarApiBase* vehicle_api)
     : pawn_(pawn), pawn_kinematics_(pawn_kinematics), vehicle_api_(vehicle_api)
 {
-    movement_ = pawn->GetVehicleMovement();
+    movement_ = CastChecked<UChaosWheeledVehicleMovementComponent>(pawn->GetVehicleMovement());
+    
 }
 
 void CarPawnApi::updateMovement(const msr::airlib::CarApiBase::CarControls& controls)
@@ -23,7 +24,7 @@ void CarPawnApi::updateMovement(const msr::airlib::CarApiBase::CarControls& cont
     movement_->SetSteeringInput(controls.steering);
     movement_->SetBrakeInput(controls.brake);
     movement_->SetHandbrakeInput(controls.handbrake);
-    movement_->SetUseAutoGears(!controls.is_manual_gear);
+    movement_->SetUseAutomaticGears(!controls.is_manual_gear);
 }
 
 msr::airlib::CarApiBase::CarState CarPawnApi::getCarState() const
@@ -56,15 +57,15 @@ void CarPawnApi::reset()
         movement_->SetActive(true, true);
         vehicle_api_->setCarControls(msr::airlib::CarApiBase::CarControls());
         updateMovement(msr::airlib::CarApiBase::CarControls());
-
-        auto pv = movement_->PVehicle;
-        if (pv) {
-            pv->mWheelsDynData.setToRestState();
-        }
-        auto pvd = movement_->PVehicleDrive;
-        if (pvd) {
-            pvd->mDriveDynData.setToRestState();
-        }
+        
+        //auto pv = movement_->PVehicle;
+        //if (pv) {
+        //    pv->mWheelsDynData.setToRestState();
+        //}
+        //auto pvd = movement_->PVehicleDrive;
+        //if (pvd) {
+        //    pvd->mDriveDynData.setToRestState();
+        //}
     },
                                              true);
 

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnApi.cpp
@@ -57,7 +57,7 @@ void CarPawnApi::reset()
         movement_->SetActive(true, true);
         vehicle_api_->setCarControls(msr::airlib::CarApiBase::CarControls());
         updateMovement(msr::airlib::CarApiBase::CarControls());
-        
+        movement_->ResetVehicleState();
         //auto pv = movement_->PVehicle;
         //if (pv) {
         //    pv->mWheelsDynData.setToRestState();

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnApi.h
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnApi.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "vehicles/car/api/CarApiBase.hpp"
-#include "WheeledVehicleMovementComponent4W.h"
+#include "ChaosWheeledVehicleMovementComponent.h"
 #include "physics/Kinematics.hpp"
 #include "CarPawn.h"
 
@@ -23,7 +23,7 @@ public:
     virtual ~CarPawnApi();
 
 private:
-    UWheeledVehicleMovementComponent* movement_;
+    UChaosWheeledVehicleMovementComponent* movement_;
     msr::airlib::CarApiBase::CarControls last_controls_;
     ACarPawn* pawn_;
     const msr::airlib::Kinematics::State* pawn_kinematics_;

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnApi.h
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnApi.h
@@ -28,4 +28,5 @@ private:
     ACarPawn* pawn_;
     const msr::airlib::Kinematics::State* pawn_kinematics_;
     msr::airlib::CarApiBase* vehicle_api_;
+    UChaosWheeledVehicleMovementComponent* movement_;
 };

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnApi.h
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnApi.h
@@ -28,5 +28,4 @@ private:
     ACarPawn* pawn_;
     const msr::airlib::Kinematics::State* pawn_kinematics_;
     msr::airlib::CarApiBase* vehicle_api_;
-    UChaosWheeledVehicleMovementComponent* movement_;
 };

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarPawnSimApi.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "WheeledVehicleMovementComponent4W.h"
+#include "ChaosWheeledVehicleMovementComponent.h"
 
 #include "CarPawn.h"
 #include "CarPawnApi.h"

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarWheelFront.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarWheelFront.cpp
@@ -1,26 +1,27 @@
 // Copyright 1998-2017 Epic Games, Inc. All Rights Reserved.
 
 #include "CarWheelFront.h"
-#include "TireConfig.h"
+//#include "TireConfig.h"
 #include "UObject/ConstructorHelpers.h"
+#include <ChaosVehicles/ChaosVehiclesCore/Public/WheelSystem.h>
 
 UCarWheelFront::UCarWheelFront()
 {
-    ShapeRadius = 18.f;
-    ShapeWidth = 15.0f;
-    Mass = 20.0f;
-    DampingRate = 0.25f;
+    WheelRadius = 18.f;
+    WheelWidth = 15.0f;
+    //WheelMass = 20.0f;
+    SuspensionDampingRatio = 0.25f;
     bAffectedByHandbrake = false;
-    SteerAngle = 40.f;
+    //SteerAngle = 40.f;
 
     // Setup suspension forces
-    SuspensionForceOffset = 0.0f;
+    SuspensionForceOffset = FVector(0.0f, 0.0f, 0.0f);
     SuspensionMaxRaise = 10.0f;
     SuspensionMaxDrop = 10.0f;
-    SuspensionNaturalFrequency = 9.0f;
+    //SuspensionNaturalFrequency = 9.0f;
     SuspensionDampingRatio = 1.05f;
 
     // Find the tire object and set the data for it
-    static ConstructorHelpers::FObjectFinder<UTireConfig> TireData(TEXT("/AirSim/VehicleAdv/Vehicle/WheelData/Vehicle_FrontTireConfig.Vehicle_FrontTireConfig"));
-    TireConfig = TireData.Object;
+    //static ConstructorHelpers::FObjectFinder<UTireConfig> TireData(TEXT("/AirSim/VehicleAdv/Vehicle/WheelData/Vehicle_FrontTireConfig.Vehicle_FrontTireConfig"));
+    //TireConfig = TireData.Object;
 }

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarWheelFront.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarWheelFront.cpp
@@ -1,9 +1,7 @@
 // Copyright 1998-2017 Epic Games, Inc. All Rights Reserved.
 
 #include "CarWheelFront.h"
-//#include "TireConfig.h"
 #include "UObject/ConstructorHelpers.h"
-#include <ChaosVehicles/ChaosVehiclesCore/Public/WheelSystem.h>
 
 UCarWheelFront::UCarWheelFront()
 {
@@ -11,6 +9,7 @@ UCarWheelFront::UCarWheelFront()
     WheelWidth = 17.0f;
     //WheelMass = 20.0f;
     bAffectedByHandbrake = false;
+    bAffectedBySteering = true;
     MaxSteerAngle = 50.f;
     AxleType = EAxleType::Front;
 
@@ -20,8 +19,4 @@ UCarWheelFront::UCarWheelFront()
     SuspensionMaxDrop = 10.0f;
     //SuspensionNaturalFrequency = 9.0f;
     SuspensionDampingRatio = 1.5f;
-
-    // Find the tire object and set the data for it
-    //static ConstructorHelpers::FObjectFinder<UTireConfig> TireData(TEXT("/AirSim/VehicleAdv/Vehicle/WheelData/Vehicle_FrontTireConfig.Vehicle_FrontTireConfig"));
-    //TireConfig = TireData.Object;
 }

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarWheelFront.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarWheelFront.cpp
@@ -7,19 +7,19 @@
 
 UCarWheelFront::UCarWheelFront()
 {
-    WheelRadius = 18.f;
-    WheelWidth = 15.0f;
+    WheelRadius = 38.f;
+    WheelWidth = 17.0f;
     //WheelMass = 20.0f;
-    SuspensionDampingRatio = 0.25f;
     bAffectedByHandbrake = false;
-    //SteerAngle = 40.f;
+    MaxSteerAngle = 50.f;
+    AxleType = EAxleType::Front;
 
     // Setup suspension forces
     SuspensionForceOffset = FVector(0.0f, 0.0f, 0.0f);
     SuspensionMaxRaise = 10.0f;
     SuspensionMaxDrop = 10.0f;
     //SuspensionNaturalFrequency = 9.0f;
-    SuspensionDampingRatio = 1.05f;
+    SuspensionDampingRatio = 1.5f;
 
     // Find the tire object and set the data for it
     //static ConstructorHelpers::FObjectFinder<UTireConfig> TireData(TEXT("/AirSim/VehicleAdv/Vehicle/WheelData/Vehicle_FrontTireConfig.Vehicle_FrontTireConfig"));

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarWheelFront.h
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarWheelFront.h
@@ -3,11 +3,11 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "VehicleWheel.h"
+#include "ChaosVehicleWheel.h"
 #include "CarWheelFront.generated.h"
 
 UCLASS()
-class UCarWheelFront : public UVehicleWheel
+class UCarWheelFront : public UChaosVehicleWheel
 {
     GENERATED_BODY()
 

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarWheelRear.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarWheelRear.cpp
@@ -6,17 +6,18 @@
 
 UCarWheelRear::UCarWheelRear()
 {
-    WheelRadius = 18.f;
-    WheelWidth = 15.0f;
+    WheelRadius = 38.f;
+    WheelWidth = 17.0f;
     bAffectedByHandbrake = true;
-    //SteerAngle = 0.f;
+    MaxSteerAngle = 0.f;
+    AxleType = EAxleType::Rear;
 
     // Setup suspension forces
     SuspensionForceOffset = FVector(0.0f, 0.0f, 0.0f);
     SuspensionMaxRaise = 10.0f;
     SuspensionMaxDrop = 10.0f;
     //SuspensionNaturalFrequency = 9.0f;
-    SuspensionDampingRatio = 1.05f;
+    SuspensionDampingRatio = 1.5f;
 
     // Find the tire object and set the data for it
     //static ConstructorHelpers::FObjectFinder<UTireConfig> TireData(TEXT("/AirSim/VehicleAdv/Vehicle/WheelData/Vehicle_BackTireConfig.Vehicle_BackTireConfig"));

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarWheelRear.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarWheelRear.cpp
@@ -1,24 +1,24 @@
 // Copyright 1998-2017 Epic Games, Inc. All Rights Reserved.
 
 #include "CarWheelRear.h"
-#include "TireConfig.h"
+//#include "TireConfig.h"
 #include "UObject/ConstructorHelpers.h"
 
 UCarWheelRear::UCarWheelRear()
 {
-    ShapeRadius = 18.f;
-    ShapeWidth = 15.0f;
+    WheelRadius = 18.f;
+    WheelWidth = 15.0f;
     bAffectedByHandbrake = true;
-    SteerAngle = 0.f;
+    //SteerAngle = 0.f;
 
     // Setup suspension forces
-    SuspensionForceOffset = -0.0f;
+    SuspensionForceOffset = FVector(0.0f, 0.0f, 0.0f);
     SuspensionMaxRaise = 10.0f;
     SuspensionMaxDrop = 10.0f;
-    SuspensionNaturalFrequency = 9.0f;
+    //SuspensionNaturalFrequency = 9.0f;
     SuspensionDampingRatio = 1.05f;
 
     // Find the tire object and set the data for it
-    static ConstructorHelpers::FObjectFinder<UTireConfig> TireData(TEXT("/AirSim/VehicleAdv/Vehicle/WheelData/Vehicle_BackTireConfig.Vehicle_BackTireConfig"));
-    TireConfig = TireData.Object;
+    //static ConstructorHelpers::FObjectFinder<UTireConfig> TireData(TEXT("/AirSim/VehicleAdv/Vehicle/WheelData/Vehicle_BackTireConfig.Vehicle_BackTireConfig"));
+    //TireConfig = TireData.Object;
 }

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarWheelRear.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarWheelRear.cpp
@@ -18,8 +18,4 @@ UCarWheelRear::UCarWheelRear()
     SuspensionMaxDrop = 10.0f;
     //SuspensionNaturalFrequency = 9.0f;
     SuspensionDampingRatio = 1.5f;
-
-    // Find the tire object and set the data for it
-    //static ConstructorHelpers::FObjectFinder<UTireConfig> TireData(TEXT("/AirSim/VehicleAdv/Vehicle/WheelData/Vehicle_BackTireConfig.Vehicle_BackTireConfig"));
-    //TireConfig = TireData.Object;
 }

--- a/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarWheelRear.h
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/Car/CarWheelRear.h
@@ -3,11 +3,11 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "VehicleWheel.h"
+#include "ChaosVehicleWheel.h"
 #include "CarWheelRear.generated.h"
 
 UCLASS()
-class UCarWheelRear : public UVehicleWheel
+class UCarWheelRear : public UChaosVehicleWheel
 {
     GENERATED_BODY()
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: https://github.com/microsoft/AirSim/issues/4480
Fixes: https://github.com/microsoft/AirSim/issues/4656
Fixes: https://github.com/microsoft/AirSim/discussions/4606
Fixes: https://github.com/microsoft/AirSim/discussions/4462
Fixes: https://github.com/microsoft/AirSim/discussions/3884
Fixes: https://github.com/microsoft/AirSim/discussions/4495

## About
<!-- Describe what your PR is about. -->
Although airsim is no longer maintained, for those who interested - This PR is adding the ability to use AirSim with Unreal Engine 5.
It support multirotor, car (using Chaos instead of PhysX) and CV.

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
 - Tested on windows using ue5 editor
 - Package game didn't tested
 - Only some basic features have been tested
 
 ## How To Use?
Before build the blocks project, download the updated car assets from 
https://drive.google.com/file/d/1YRMZG2Tq9xwPq1fNEwTGvJFd1d11nAnn/view?usp=sharing (~38MB)
and replace the content of 
`Blocks\Plugins\AirSim\Content\VehicleAdv\SUV`
then build like you use to.

## Screenshots (if appropriate):

https://user-images.githubusercontent.com/15960497/186704344-cad87824-ca8b-46f2-bee7-9aa7fc90b89b.mp4

https://user-images.githubusercontent.com/15960497/193445483-030160a0-f1bd-44ff-9d0a-9956be0809b0.mp4

