### PR TITLE
Fix .binvox files being saved with the inverse scale

### DIFF
--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
@@ -226,7 +226,7 @@ bool WorldSimApi::createVoxelGrid(const Vector3r& position, const int& x_size, c
     output << "#binvox 1\n";
     output << "dim " << ncells_x << " " << ncells_z << " " << ncells_y << "\n";
     output << "translate " << -x_size * 0.5 << " " << -y_size * 0.5 << " " << -z_size * 0.5 << "\n";
-    output << "scale " << 1.0f / x_size << "\n";
+    output << "scale " << x_size << "\n";
     output << "data\n";
     bool run_value = voxel_grid_[0];
     unsigned int run_length = 0;


### PR DESCRIPTION
Fixes: no related issue

## About
According to the [binvox specification](https://www.patrickmin.com/binvox/binvox.html) the scale stored in binvox should be what the normalized voxel coordinates (in the interval [0, 1]) should be scaled by.

>binvox now includes two extra lines in the header (which may be omitted, viewvox and thinvox don't need them):
>translate \<t_x> <t_y> <t_z>
>scale \<scale factor>
>First scale (x_n, y_n, z_n) by the scale factor, then translate them by (t_x, t_y, t_z)

This is also how the scale is interpreted in [this](https://github.com/dimatura/binvox-rw-py/blob/public/binvox_rw.py#L79) Python binvox implementation.

## How Has This Been Tested?
Tested by using other implementations to read the resulting `.binvox` files.