### PR TITLE
UNITY: Fix get images from multiple drones: simGetImages() was only retur…

### DIFF
--- a/Unity/UnityDemo/Assets/AirSimAssets/Scripts/Vehicles/Vehicle.cs
+++ b/Unity/UnityDemo/Assets/AirSimAssets/Scripts/Vehicles/Vehicle.cs
@@ -343,10 +343,25 @@ namespace AirSimUnity {
             captureResetEvent = new AutoResetEvent(false);
         }
 
+        private GameObject FindChildWithTag(GameObject parent, string tag) {
+            GameObject child = null;
+            
+            foreach(Transform transform in parent.transform) {
+                if(transform.CompareTag(tag)) {
+                    child = transform.gameObject;
+                    break;
+                }
+            }
+            
+            return child;
+        }
+
         //Register all the capture cameras in the scene for recording and data capture.
         //Make sure every camera is a child of a gameobject with tag "CaptureCameras"
         private void SetUpCameras() {
-            GameObject camerasParent = GameObject.FindGameObjectWithTag("CaptureCameras");
+            GameObject this_vehicle = GameObject.Find(this.name);
+            GameObject camerasParent = FindChildWithTag(this_vehicle, "CaptureCameras");
+
             if (!camerasParent) {
                 Debug.LogWarning("No Cameras found in the scene to capture data");
                 return;


### PR DESCRIPTION
…ning images for one drone when asking for images from multiple drones

<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
UNITY: The call to the api getSimImages() through Python was returning images only from one drone even in a multi-drone setting. The reason is that when doing SetUpCameras() only the cameras of one drone were added. 

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
Running the example script multi_agent_drone.py it was not that clear from which drone were the images captured coming from. After testing by adding different shapes in front of the capturing cameras (cam "0" and cam "1") I realized that they were coming only from one drone.

## Screenshots (if appropriate):