### PR TITLE
Update airsim_ros_pkgs.md

### DIFF
--- a/docs/airsim_ros_pkgs.md
+++ b/docs/airsim_ros_pkgs.md
@@ -174,7 +174,7 @@ Throttle, brake, steering and gear selections for control. Both automatic and ma
 #### Parameters:
 
 - PD controller parameters:
-  * `/pd_position_node/kd_x` [double],
+  * `/pd_position_node/kp_x` [double],
     `/pd_position_node/kp_y` [double],
     `/pd_position_node/kp_z` [double],
     `/pd_position_node/kp_yaw` [double]


### PR DESCRIPTION
PD controller parameters:
first topic name 
 `/pd_position_node/kd_x`  should be  `/pd_position_node/kp_x` instead.

<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->

## Screenshots (if appropriate):