### PR TITLE
Update build_macos.md to reflect navigation changes to install engine version

### DIFF
--- a/docs/build_macos.md
+++ b/docs/build_macos.md
@@ -15,8 +15,8 @@ Please see instructions [here](docker_ubuntu.md)
 #### Download Unreal Engine
 
 1. [Download](https://www.unrealengine.com/download) the Epic Games Launcher. While the Unreal Engine is open source and free to download, registration is still required.
-2. Run the Epic Games Launcher, open the `Library` tab on the left pane.
-   Click on the `Add Versions` which should show the option to download **Unreal 4.27** as shown below. If you have multiple versions of Unreal installed then **make sure 4.27 is set to `current`** by clicking down arrow next to the Launch button for the version.
+2. Run the Epic Games Launcher, open the `Unreal Engine` tab on the left pane, then the `Library` tab on the top.
+   Click on `Install a new version of the Unreal Engine` (Next to `Engine Versions`) which should show the option to download **Unreal 4.27** as shown below. If you have multiple versions of Unreal installed then **make sure 4.27 is set to `current`** by clicking down arrow next to the Launch button for the version.
 
    **Note**: AirSim also works with UE >= 4.24, however, we recommend 4.27.
    **Note**: If you have UE 4.16 or older projects, please see the [upgrade guide](unreal_upgrade.md) to upgrade your projects.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: Updated docs/build_macos.md to guide users to the right place to download Unreal Engine. <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
This PR fixes instructions on downloading the Unreal Engine 4.27. Originally, it stated that the `Library` pane on the left would have the place to download new engine versions. After checking, the `Library` pane on the top __within__ the `Unreal Engine` tab on the left pane contains the area to download engine versions.

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
Checked that the Markdown file does not have any abnormalities by previewing the changes.

## Screenshots (if appropriate):
<img width="1816" alt="Screenshot 2025-04-15 at 9 31 37 AM" src="https://github.com/user-attachments/assets/e35e900d-6a03-4efa-b77c-24890f63cff4" />