### PR TITLE
fix:The configuration and build scripts are compatible with Ubuntu 22…

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -63,12 +63,26 @@ if [ "$(uname)" == "Darwin" ]; then
     export CC="$(brew --prefix)/opt/llvm/bin/clang"
     export CXX="$(brew --prefix)/opt/llvm/bin/clang++"
 else
-    if $gcc; then
-        export CC="gcc-8"
-        export CXX="g++-8"
+    # Ubuntu version
+    VERSION=$(lsb_release -rs | cut -d. -f1)
+    # Ubuntu version < 22, use compiler 8
+    # Ubuntu version >= 22, use compiler 14
+    if [ $"$VERSION" -lt "22" ]; then
+        if $gcc; then
+            export CC="gcc-8"
+            export CXX="g++-8"
+        else
+            export CC="clang-8"
+            export CXX="clang++-8"
+        fi
     else
-        export CC="clang-8"
-        export CXX="clang++-8"
+        if $gcc; then
+            export CC="gcc-14"
+            export CXX="g++-14"
+        else
+            export CC="clang-14"
+            export CXX="clang++-14"
+        fi
     fi
 fi
 

--- a/cmake/cmake-modules/CommonSetup.cmake
+++ b/cmake/cmake-modules/CommonSetup.cmake
@@ -55,13 +55,23 @@ macro(CommonSetup)
                 -Wno-variadic-macros -Wno-unused-function -Wno-unused \
                 -pthread \
                 ${RPC_LIB_DEFINES} ${CMAKE_CXX_FLAGS}")
-
+        
+            # Starting with Clang 9 or 10, the filesystem library has been merged into the main libc++ library
+            find_library(CXXFS_LIBRARY c++fs)
             if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
                 set(CMAKE_CXX_FLAGS "-stdlib=libc++ -Wno-documentation -Wno-unknown-warning-option ${CMAKE_CXX_FLAGS}")
                 find_package(LLVM REQUIRED CONFIG)
-                set(CXX_EXP_LIB "-L${LLVM_LIBRARY_DIRS} -lc++fs -ferror-limit=10")
+                if(CXXFS_LIB)
+                    set(CXX_EXP_LIB "-L${LLVM_LIBRARY_DIRS} -lc++fs -ferror-limit=10")
+                else()
+                    set(CXX_EXP_LIB "-L${LLVM_LIBRARY_DIRS} -ferror-limit=10")
+                endif()
             else()
-                set(CXX_EXP_LIB "-lstdc++fs -fmax-errors=10 -Wnoexcept -Wstrict-null-sentinel")
+                if(CXXFS_LIB)
+                    set(CXX_EXP_LIB "-lstdc++fs -fmax-errors=10 -Wnoexcept -Wstrict-null-sentinel")
+                else()
+                    set(CXX_EXP_LIB "-fmax-errors=10 -Wnoexcept -Wstrict-null-sentinel")
+                endif()
             endif ()
         endif ()
 

--- a/setup.sh
+++ b/setup.sh
@@ -43,24 +43,22 @@ if [ "$(uname)" == "Darwin" ]; then # osx
     #brew install llvm@8
     brew install llvm
 else #linux
-    sudo apt-get update
-    sudo apt-get -y install --no-install-recommends \
-        lsb-release \
-        rsync \
-        software-properties-common \
-        wget \
-        libvulkan1 \
-        vulkan-utils
-
     #install clang and build tools
     VERSION=$(lsb_release -rs | cut -d. -f1)
     # Since Ubuntu 17 clang is part of the core repository
     # See https://packages.ubuntu.com/search?keywords=clang-8
+    PKG_TOOLS="lsb-release rsync software-properties-common wget libvulkan1"
     if [ "$VERSION" -lt "17" ]; then
         wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-        sudo apt-get update
     fi
-    sudo apt-get install -y clang-8 clang++-8 libc++-8-dev libc++abi-8-dev
+    # Since Ubuntu 22 change vulkan-utils  to vulkan-tools
+    # Since Ubuntu 22 change clang-8  to clang-14, compatible 24.04
+    if [ "$VERSION" -lt "22" ]; then
+        PKG_TOOLS="${PKG_TOOLS} vulkan-utils clang-8 clang++-8 libc++-8-dev libc++abi-8-dev"
+    else
+        PKG_TOOLS="${PKG_TOOLS} vulkan-tools clang-14 clang++-14 libc++-14-dev libc++abi-14-dev"
+    fi
+    sudo apt-get -y install --no-install-recommends $PKG_TOOLS
 fi
 
 if ! which cmake; then


### PR DESCRIPTION
… and Ubuntu 24.

<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #5065 

## About
The configuration and build scripts are compatible with Ubuntu 22 and Ubuntu 24.
Also compatible with versions lower than Ubuntu 22

## How Has This Been Tested?
Executing the setup. sh and build. sh scripts on Ubuntu 22 and Ubuntu 24 systems can run normally

## Screenshots (if appropriate):