### PR TITLE
docs: refresh PX4 links to docs.px4.io/main

### DIFF
--- a/docs/px4_build.md
+++ b/docs/px4_build.md
@@ -14,7 +14,7 @@ Now to build it you will need the right tools.
 
 ## PX4 Build tools
 
-The full instructions are available on the [dev.px4.io](https://docs.px4.io/master/en/dev_setup/building_px4.html) website,
+The full instructions are available on the [dev.px4.io](https://docs.px4.io/main/en/dev_setup/building_px4.html) website,
 but we've copied the relevant subset of those instructions here for your convenience.
 
 (Note that [BashOnWindows](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide)) can be used to build
@@ -139,4 +139,4 @@ param set SYS_LOGGER 1
 
 ## Using BashOnWindows
 
-See [Bash on Windows Toolchain](https://dev.px4.io/en/setup/dev_env_windows_bash_on_win.html).
+See [Bash on Windows Toolchain](https://docs.px4.io/main/en/dev_setup/dev_env_windows.html).

--- a/docs/px4_lockstep.md
+++ b/docs/px4_lockstep.md
@@ -1,7 +1,7 @@
 # LockStep
 
 The latest version of PX4 supports a new [lockstep
-feature](https://docs.px4.io/master/en/simulation/#lockstep-simulation) when communicating with the
+feature](https://docs.px4.io/main/en/simulation/#lockstep-simulation) when communicating with the
 simulator over TCP.  Lockstep is an important feature because it synchronizes PX4 and the simulator
 so they essentially use the same clock time.  This makes PX4 behave normally even during unusually
 long delays in Simulator performance.
@@ -42,7 +42,7 @@ in the simulated flight if you look at the updates on screen in realtime.
 If you are running PX4 in cygwin, there is an [open issue with 
 lockstep](https://github.com/microsoft/AirSim/issues/3415). PX4 is configured to use lockstep by 
 default. To disable this feature, first [disable it in 
-PX4](https://docs.px4.io/master/en/simulation/#disable-lockstep-simulation):
+PX4](https://docs.px4.io/main/en/simulation/#disable-lockstep-simulation):
 
 1. Navigate to `boards/px4/sitl/` in your local PX4 repository
 1. Edit `default.cmake` and find the following line:

--- a/docs/px4_setup.md
+++ b/docs/px4_setup.md
@@ -24,7 +24,7 @@ For this you will need one of the supported device listed above. For manual flig
 1. Make sure your RC receiver is bound with its RC transmitter. Connect the RC transmitter to the flight controller's RC port. Refer to your RC manual and [PX4 docs](https://docs.px4.io/en/getting_started/rc_transmitter_receiver.html) for more information.
 2. Download [QGroundControl](http://qgroundcontrol.com/), launch it and connect your flight controller to the USB port.
 3. Use QGroundControl to flash the latest PX4 Flight Stack.
-See also [initial firmware setup video](https://docs.px4.io/master/en/config/).
+See also [initial firmware setup video](https://docs.px4.io/main/en/config/).
 4. In QGroundControl, configure your Pixhawk for HIL simulation by selecting the HIL Quadrocopter X airframe.  After PX4 reboots, check that "HIL Quadrocopter X" is indeed selected.
 5. In QGroundControl, go to Radio tab and calibrate (make sure the remote control is on and the receiver is showing the indicator for the binding).
 6. Go to the Flight Mode tab and chose one of the remote control switches as "Mode Channel". Then set (for example) Stabilized and Attitude flight modes for two positions of the switch.
@@ -64,7 +64,7 @@ are also enabling `LockStep`, see [PX4 LockStep](px4_lockstep.md) for more infor
 `Barometer` setting keeps PX4 happy because the default AirSim barometer has a bit too much noise
 generation.  This setting clamps that down a bit which allows PX4 to achieve GPS lock more quickly.
 
-After above setup you should be able to use a remote control (RC) to fly with AirSim. You can usually arm the vehicle by lowering and bringing two sticks of RC together down and in-wards. You don't need QGroundControl after the initial setup. Typically the Stabilized (instead of Manual) mode gives better experience for beginners.  See [PX4 Basic Flying Guide](https://docs.px4.io/master/en/flying/basic_flying.html).
+After above setup you should be able to use a remote control (RC) to fly with AirSim. You can usually arm the vehicle by lowering and bringing two sticks of RC together down and in-wards. You don't need QGroundControl after the initial setup. Typically the Stabilized (instead of Manual) mode gives better experience for beginners.  See [PX4 Basic Flying Guide](https://docs.px4.io/main/en/flying/basic_flying.html).
 
 You can also control the drone from [Python APIs](apis.md).
 

--- a/docs/px4_sitl.md
+++ b/docs/px4_sitl.md
@@ -1,8 +1,8 @@
 # Setting up PX4 Software-in-Loop
 
-The [PX4](http://dev.px4.io) software provides a "software-in-loop" simulation (SITL) version of
+The [PX4](https://docs.px4.io) software provides a "software-in-loop" simulation (SITL) version of
 their stack that runs in Linux. If you are on Windows then you can use the [Cygwin
-Toolchain](https://dev.px4.io/master/en/setup/dev_env_windows_cygwin.html) or you can use the
+Toolchain](https://docs.px4.io/main/en/dev_setup/dev_env_windows_cygwin.html) or you can use the
 [Windows subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10) and follow
 the PX4 Linux toolchain setup.
 
@@ -12,7 +12,7 @@ instructions](px4_sitl_wsl2.md).
 **Note** that every time you stop the unreal app you have to restart the `px4` app.
 
 1. From your bash terminal follow [these steps for
-   Linux](https://docs.px4.io/master/en/dev_setup/dev_env_linux.html) and follow **all** the
+   Linux](https://docs.px4.io/main/en/dev_setup/dev_env_linux.html) and follow **all** the
    instructions under `NuttX based hardware` to install prerequisites. We've also included our own
    copy of the [PX4 build instructions](px4_build.md) which is a bit more concise about what we need
    exactly.

--- a/docs/remote_control.md
+++ b/docs/remote_control.md
@@ -27,7 +27,7 @@ AirSim supports PX4 flight controller however it requires different setup. There
 2. For Hardware-in-Loop mode, you connect transmitter to Pixhawk. Usually you can find online doc or YouTube video tutorial on how to do that.
 3. [Calibrate your RC in QGroundControl](https://docs.qgroundcontrol.com/en/SetupView/Radio.html).
 
-See [PX4 RC configuration](https://docs.px4.io/en/getting_started/rc_transmitter_receiver.html) and Please see [this guide](https://docs.px4.io/master/en/getting_started/rc_transmitter_receiver.html#px4-compatible-receivers) for more information. 
+See [PX4 RC configuration](https://docs.px4.io/en/getting_started/rc_transmitter_receiver.html) and Please see [this guide](https://docs.px4.io/main/en/getting_started/rc_transmitter_receiver.html#px4-compatible-receivers) for more information. 
 
 ### Using XBox 360 USB Gamepad
 


### PR DESCRIPTION
## About
Micros doc-only: PX4 documentation URLs still pointed at deprecated `/master/` trees and bare `dev.px4.io`. Updated operational guides to `https://docs.px4.io/main/...` and modernised two `dev.px4.io` paths (Cygwin / Windows env).

## Files
- docs/px4_sitl.md
- docs/px4_build.md
- docs/px4_lockstep.md
- docs/px4_setup.md
- docs/remote_control.md

## How Has This Been Tested?
- rg before/after for docs.px4.io/master and http://dev.px4.io in docs
- No simulation/code changes

## Notes
Complementary docs-only for mergeability on dormancy-risk AirSim.