### PR TITLE
docs: normalize git clone URLs to github.com/microsoft/AirSim

### DIFF
--- a/docs/Unity.md
+++ b/docs/Unity.md
@@ -19,7 +19,7 @@ This project is still in early development, expect some rough edges. We are work
 **Make sure** to select **Desktop Development with C++** and **Windows 10 SDK 10.0.18362** (should be selected by default) while installing VS 2019. 
 
 * Start `x64 Native Tools Command Prompt for VS 2019`. 
-* Clone the repo: `git clone https://github.com/Microsoft/AirSim.git`, and go the AirSim directory by `cd AirSim`. 
+* Clone the repo: `git clone https://github.com/microsoft/AirSim.git`, and go the AirSim directory by `cd AirSim`. 
 * Run `build.cmd` from the command line. 
 
 #### Build Unity Project
@@ -42,7 +42,7 @@ sudo apt-get install libboost-all-dev
 
 #### Build Airsim
 ```
-git clone https://github.com/Microsoft/AirSim.git;
+git clone https://github.com/microsoft/AirSim.git;
 cd AirSim;
 ./setup.sh;
 ./build.sh

--- a/docs/build_linux.md
+++ b/docs/build_linux.md
@@ -33,7 +33,7 @@ make
 
 ```bash
 # go to the folder where you clone GitHub projects
-git clone https://github.com/Microsoft/AirSim.git
+git clone https://github.com/microsoft/AirSim.git
 cd AirSim
 ```
 

--- a/docs/build_windows.md
+++ b/docs/build_windows.md
@@ -16,7 +16,7 @@ Click on the `Install` button on the top right, which should show the option to 
 * Install Visual Studio 2022.
 **Make sure** to select **Desktop Development with C++** and **Windows 10 SDK 10.0.19041** (should be selected by default) and select the latest .NET Framework SDK under the 'Individual Components' tab while installing VS 2022.
 * Start `Developer Command Prompt for VS 2022`.
-* Clone the repo: `git clone https://github.com/Microsoft/AirSim.git`, and go the AirSim directory by `cd AirSim`.
+* Clone the repo: `git clone https://github.com/microsoft/AirSim.git`, and go the AirSim directory by `cd AirSim`.
 
     **Note:** It's generally not a good idea to install AirSim in C drive. This can cause scripts to fail, and requires running VS in Admin mode. Instead clone in a different drive such as D or E.
 


### PR DESCRIPTION
## About
Docs-only: primary build guides still show legacy `github.com/Microsoft/AirSim` clone URLs. Align Linux, Windows, and Unity clone instructions with the canonical org path `github.com/microsoft/AirSim` (GitHub accepts both, but mixed casing confuses copy-paste and ops checks).

Complementary to open [#9775](https://github.com/microsoft/AirSim/pull/9775) (macOS guide). Does **not** mass-rewrite historical blob links in changelogs.

## Files
- `docs/build_linux.md`
- `docs/build_windows.md`
- `docs/Unity.md`

## How Has This Been Tested?
- Diff review only (docs)
- Confirmed three guides no longer use `Microsoft/AirSim.git` in `git clone` lines

## Notes
Tier-4 micro-docs for low merge friction. Spec: aerial campaign `specs/airsim/2026-07-14-1.md` (Composer 2.5 Standard dual-agent path; micro-diff applied after Bartok scope + review).