### PR TITLE
docs(px4): note AirSim SITL example needs PX4 ≥ v1.12

### DIFF
--- a/docs/px4_sitl.md
+++ b/docs/px4_sitl.md
@@ -26,9 +26,11 @@ instructions](px4_sitl_wsl2.md).
     cd PX4-Autopilot
     ```
     And find the latest stable release from [https://github.com/PX4/PX4-Autopilot/releases](https://github.com/PX4/PX4-Autopilot/releases)
-    and checkout the source code matching that release, for example:
+    and checkout the source code matching that release. Prefer a tag at or above **v1.12** — AirSim’s vehicle
+    configuration in the PX4 tree tracks that line (earlier tags such as v1.11.x often fail to connect).
+    Example:
     ```
-    git checkout v1.11.3
+    git checkout v1.12.3
     ```
 
 3. Use following command to build and start PX4 firmware in SITL mode:


### PR DESCRIPTION
## About
Docs-only update to `docs/px4_sitl.md`: the SITL walkthrough still gave `git checkout v1.11.3` as the worked example. AirSim vehicle configuration in the PX4 tree tracks roughly **≥ v1.12**, so v1.11.x often fails to connect.

- Example pin → `v1.12.3`
- One-sentence guidance to prefer ≥ v1.12 / check latest stable on PX4 releases

Does **not** rework PX4 doc host URLs (see open [#9774](https://github.com/microsoft/AirSim/pull/9774)).

## Credit / prior art
Intent supersedes the long-stale one-line fix in [#4695](https://github.com/microsoft/AirSim/pull/4695) by **@jhchance** (`v1.11.3` → `v1.12.3`). Prefer this self-contained docs note over a separate salvage PR on the same file while #9774 is also open (path-overlap hygiene).

## How Has This Been Tested?
- Diff review of `docs/px4_sitl.md`
- No sim/binaries run in this micro

## Notes
Aerial nightly tier-4; specs under `specs/airsim/2026-07-14-2.md`.