### PR TITLE
docs: use github.com/microsoft casing on README/SUPPORT navigational links

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ Cars in AirSim
 
 ### Windows
 [![Build Status](https://github.com/microsoft/AirSim/actions/workflows/test_windows.yml/badge.svg)](https://github.com/microsoft/AirSim/actions/workflows/test_windows.yml)
-* [Download binaries](https://github.com/Microsoft/AirSim/releases)
+* [Download binaries](https://github.com/microsoft/AirSim/releases)
 * [Build it](https://microsoft.github.io/AirSim/build_windows)
 
 ### Linux
 [![Build Status](https://github.com/microsoft/AirSim/actions/workflows/test_ubuntu.yml/badge.svg)](https://github.com/microsoft/AirSim/actions/workflows/test_ubuntu.yml)
-* [Download binaries](https://github.com/Microsoft/AirSim/releases)
+* [Download binaries](https://github.com/microsoft/AirSim/releases)
 * [Build it](https://microsoft.github.io/AirSim/build_linux)
 
 ### macOS
@@ -145,7 +145,7 @@ For complete list of changes, view our [Changelog](docs/CHANGELOG.md)
 
 ## FAQ
 
-If you run into problems, check the [FAQ](https://microsoft.github.io/AirSim/faq) and feel free to post issues in the  [AirSim](https://github.com/Microsoft/AirSim/issues) repository.
+If you run into problems, check the [FAQ](https://microsoft.github.io/AirSim/faq) and feel free to post issues in the  [AirSim](https://github.com/microsoft/AirSim/issues) repository.
 
 ## Code of Conduct
 

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -3,5 +3,5 @@
 We highly recommend to take a look at source code and contribute to the project. Due to large number of incoming feature request we may not be able to get to your request in your desired timeframe. So please [contribute](CONTRIBUTING.md) :).
 
 * [Ask in Discussions](https://github.com/microsoft/AirSim/discussions) 
-* [File GitHub Issue](https://github.com/Microsoft/AirSim/issues)
+* [File GitHub Issue](https://github.com/microsoft/AirSim/issues)
 * [Join AirSim Facebook Group](https://www.facebook.com/groups/1225832467530667/) 


### PR DESCRIPTION
## About
Micro docs-only: README download/issues and SUPPORT issue links still used legacy `github.com/Microsoft/AirSim` casing. Canonicalized to `github.com/microsoft/AirSim` (matches existing CI badges and open clone-URL hygiene PRs).

## Files
- `README.md` — Windows/Linux binary download links + FAQ issues link
- `docs/SUPPORT.md` — File GitHub Issue link

## How Has This Been Tested?
- `rg -n 'github.com/Microsoft/AirSim' README.md docs/SUPPORT.md` → 0
- CRLF preserved on README
- No code/build changes

## Notes
Aerial campaign micro-PR (tier 4). Orthogonal to open #9774–#9777.