### PR TITLE
docs(python): normalize PythonClient README links to microsoft/AirSim

### DIFF
--- a/PythonClient/README.md
+++ b/PythonClient/README.md
@@ -3,7 +3,7 @@
 This package contains Python APIs for [AirSim](https://github.com/microsoft/airsim).
 
 ## How to Use
-See examples at [car/hello_car.py](https://github.com/Microsoft/AirSim/blob/main/PythonClient/car/hello_car.py) or [multirotor/hello_drone.py](https://github.com/microsoft/AirSim/blob/main/PythonClient/multirotor/hello_drone.py).
+See examples at [car/hello_car.py](https://github.com/microsoft/AirSim/blob/main/PythonClient/car/hello_car.py) or [multirotor/hello_drone.py](https://github.com/microsoft/AirSim/blob/main/PythonClient/multirotor/hello_drone.py).
 
 ## Dependencies
 This package depends on `msgpack` and would automatically install `msgpack-rpc-python` (this may need administrator/sudo prompt):
@@ -16,5 +16,5 @@ Some examples also requires opencv.
 ## More Info
 
 More information on AirSim Python APIs can be found at:
-https://github.com/Microsoft/AirSim/blob/main/docs/python.md
+https://github.com/microsoft/AirSim/blob/main/docs/python.md
 


### PR DESCRIPTION
## About
`PythonClient/README.md` mixed `Microsoft` and `microsoft` in absolute GitHub blob links for hello_car/hello_drone and `docs/python.md`. Normalize to `github.com/microsoft/AirSim` for consistency with other 2026–07 docs hygiene PRs.

## Files
- `PythonClient/README.md`

## How Has This Been Tested?
- `rg -n 'Microsoft/AirSim' PythonClient/README.md` → 0
- Docs-only; no Python API changes

## Notes
Aerial campaign micro-PR. Orthogonal to #9774–#9777 and README/SUPPORT PR.