### PR TITLE
salvage: fix ROS distance max_range mapping (credit @1aal #4908)

### DIFF
--- a/docs/airsim_ros_pkgs.md
+++ b/docs/airsim_ros_pkgs.md
@@ -102,7 +102,8 @@ IMU sensor data
   Meausrement of magnetic field vector/compass
 
 - `/airsim_node/VEHICLE_NAME/distance/SENSOR_NAME` [sensor_msgs::Range](http://docs.ros.org/api/sensor_msgs/html/msg/Range.html)
-  Meausrement of distance from an active ranger, such as infrared or IR
+  Measurement of distance from an active ranger, such as infrared or ultrasonic.
+  `min_range` / `max_range` mirror AirSim `min_distance` / `max_distance` (not a copy of min into max).
 
 - `/airsim_node/VEHICLE_NAME/lidar/SENSOR_NAME` [sensor_msgs::PointCloud2](http://docs.ros.org/api/sensor_msgs/html/msg/PointCloud2.html)
   LIDAR pointcloud

--- a/ros/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
+++ b/ros/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
@@ -840,7 +840,7 @@ sensor_msgs::Range AirsimROSWrapper::get_range_from_airsim(const msr::airlib::Di
     dist_msg.header.stamp = airsim_timestamp_to_ros(dist_data.time_stamp);
     dist_msg.range = dist_data.distance;
     dist_msg.min_range = dist_data.min_distance;
-    dist_msg.max_range = dist_data.min_distance;
+    dist_msg.max_range = dist_data.max_distance;
 
     return dist_msg;
 }


### PR DESCRIPTION
## About
**Salvage of #4908** by @1aal — credit to the original author.

ROS1 `get_range_from_airsim` set `sensor_msgs::Range::max_range` from `dist_data.min_distance`, so max equalled min. Correct mapping is `max_distance`.

Enhancements beyond the original:
- Rebased cleanly on current `main`
- Documented Range min/max field mapping in `docs/airsim_ros_pkgs.md`
- Fixed typo “Meausrement” → “Measurement”

ROS2 wrapper already used `max_distance` (left unchanged).

## Fixes
- Salvage path for #4908 (please close that PR as superseded if this lands)

## Files
- `ros/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp`
- `docs/airsim_ros_pkgs.md`

## How Has This Been Tested?
- Reviewed third call site pattern; ROS2 twin already correct
- Docs markdown visual check
- Full ROS1 stack not run in this environment (micro one-liner semantics)

## Notes
Aerial / drone agent campaign salvage slot for `microsoft/AirSim`.