### PR TITLE
docs(infrared): normalize Microsoft→microsoft GitHub org links

### DIFF
--- a/docs/InfraredCamera.md
+++ b/docs/InfraredCamera.md
@@ -1,14 +1,14 @@
 This is a tutorial for generating simulated thermal infrared (IR) images using AirSim and the AirSim Africa environment. 
 
 Pre-compiled Africa Environment can be downloaded from the Releases tab of this Github repo: 
-[Windows Pre-compiled binary](https://github.com/Microsoft/AirSim/releases/tag/v1.2.1)
+[Windows Pre-compiled binary](https://github.com/microsoft/AirSim/releases/tag/v1.2.1)
 
-To generate your own data, you may use two python files: [create_ir_segmentation_map.py](https://github.com/Microsoft/AirSim/tree/main/PythonClient//computer_vision/create_ir_segmentation_map.py) and 
-[capture_ir_segmentation.py](https://github.com/Microsoft/AirSim/tree/main/PythonClient//computer_vision/capture_ir_segmentation.py).
+To generate your own data, you may use two python files: [create_ir_segmentation_map.py](https://github.com/microsoft/AirSim/tree/main/PythonClient/computer_vision/create_ir_segmentation_map.py) and 
+[capture_ir_segmentation.py](https://github.com/microsoft/AirSim/tree/main/PythonClient/computer_vision/capture_ir_segmentation.py).
 
-[create_ir_segmentation_map.py](https://github.com/Microsoft/AirSim/tree/main/PythonClient//computer_vision/create_ir_segmentation_map.py) uses temperature, emissivity, and camera response information to estimate the thermal digital count that could be expected for the objects in the environment, and then reassigns the segmentation IDs in AirSim to match these digital counts. It should be run before starting to capture thermal IR data. Otherwise, digital counts in the IR images will be incorrect. The camera response, temperature, and emissivity data are all included for the Africa environment.
+[create_ir_segmentation_map.py](https://github.com/microsoft/AirSim/tree/main/PythonClient/computer_vision/create_ir_segmentation_map.py) uses temperature, emissivity, and camera response information to estimate the thermal digital count that could be expected for the objects in the environment, and then reassigns the segmentation IDs in AirSim to match these digital counts. It should be run before starting to capture thermal IR data. Otherwise, digital counts in the IR images will be incorrect. The camera response, temperature, and emissivity data are all included for the Africa environment.
 
-[capture_ir_segmentation.py](https://github.com/Microsoft/AirSim/tree/main/PythonClient//computer_vision/capture_ir_segmentation.py) is run after the segmentation IDs have been reassigned. It tracks objects of interest and records the infrared and scene images from the multirotor. It uses Computer Vision mode.
+[capture_ir_segmentation.py](https://github.com/microsoft/AirSim/tree/main/PythonClient/computer_vision/capture_ir_segmentation.py) is run after the segmentation IDs have been reassigned. It tracks objects of interest and records the infrared and scene images from the multirotor. It uses Computer Vision mode.
 
 Finally, the details about how temperatures were estimated for plants and animals in the Africa environment, etc. can be found in this paper:
 


### PR DESCRIPTION
## Summary
- Point `docs/InfraredCamera.md` release + PythonClient tutorial links at `github.com/microsoft/AirSim` (org casing consistency).
- Collapse accidental `PythonClient//computer_vision` double-slash segments in those same links.

## Motivation
Same navigational hygiene as recent clone/README docs PRs; fewer confusing URL variants for newcomers following the IR tutorial.

## Test plan
- [x] Microsoft/AirSim and PythonClient// empty on file
- [x] Docs-only; no runtime/sim behavior change
