### PR TITLE
docs: lowercase microsoft org on issue/contribute entry links

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Quick Start
 - Please read our [short and sweet coding guidelines](coding_guidelines.md).
-- For big changes such as adding new feature or refactoring, [file an issue first](https://github.com/Microsoft/AirSim/issues).
+- For big changes such as adding new feature or refactoring, [file an issue first](https://github.com/microsoft/AirSim/issues).
 - Use our [recommended development workflow](dev_workflow.md) to make changes and test it.
 - Use [usual steps](https://www.dataschool.io/how-to-contribute-on-github/) to make contributions just like other GitHub projects. If you are not familiar with Git Branch-Rebase-Merge workflow, please [read this first](https://git-rebase.io/).
 

--- a/docs/create_issue.md
+++ b/docs/create_issue.md
@@ -4,7 +4,7 @@ AirSim is open source project and contributors like you keeps it going. It is im
 
 ## DOs
 
-* [Search issues](https://github.com/Microsoft/AirSim/issues?utf8=%E2%9C%93&q=is%3Aissue) to see if someone already has asked it.
+* [Search issues](https://github.com/microsoft/AirSim/issues?utf8=%E2%9C%93&q=is%3Aissue) to see if someone already has asked it.
 * Chose title that is short and summarizes well. 
 * Copy and paste full error message.
 * Precisely describe steps you used that produced the error message or symptom.


### PR DESCRIPTION
## Summary
- Lowercase `github.com/microsoft/AirSim` on the Search-issues link in `docs/create_issue.md`.
- Same casing fix on the "file an issue first" link in `docs/CONTRIBUTING.md`.

## Motivation
Contributor entry points should match the canonical org path used in current GitHub UI and other recent docs hypers.

## Test plan
- [x] Microsoft/AirSim empty on those two files
- [x] Docs-only
