### PR TITLE
salvage: fix HelloDrone image path when getImages empty (credit @webshared #4658)

### DIFF
--- a/HelloDrone/main.cpp
+++ b/HelloDrone/main.cpp
@@ -33,7 +33,7 @@ int main()
         const std::vector<ImageResponse>& response = client.simGetImages(request);
         std::cout << "# of images received: " << response.size() << std::endl;
 
-        if (!response.size()) {
+        if (response.size()) {
             std::cout << "Enter path with ending separator to save images (leave empty for no save)" << std::endl;
             std::string path;
             std::getline(std::cin, path);


### PR DESCRIPTION
## Summary
**salvage:** Fix inverted `response.size()` guard in `HelloDrone/main.cpp` so the image save path prompt runs when images were received.

**credit [@webshared](https://github.com/webshared) [#4658](https://github.com/microsoft/AirSim/pull/4658)** — rebased / re-applied on current `main` (2026-07-16).

## Motivation
Original condition used `if (!response.size())` before prompting to save, so success path was inverted (prompt on empty captures). Small example quality fix for first-run HelloDrone demos.

## Test plan
- [x] Diff matches author intent (+ exchange polarity only)
- [ ] Build HelloDrone when UE toolchain available (docs-level logic review OK offline)

## Notes
Does not change flight, geofences, or arming. Example client only.
