### PR TITLE
docs: lowercase microsoft links in C++ API and distance_sensor guides

### DIFF
--- a/docs/apis_cpp.md
+++ b/docs/apis_cpp.md
@@ -4,7 +4,7 @@ Please read [general API doc](apis.md) first if you haven't already. This docume
 
 ## Quick Start
 
-Fastest way to get started is to open AirSim.sln in Visual Studio 2019. You will see [Hello Car](https://github.com/Microsoft/AirSim/tree/main/HelloCar/) and [Hello Drone](https://github.com/Microsoft/AirSim/tree/main/HelloDrone/) examples in the solution. These examples will show you the include paths and lib paths you will need to setup in your VC++ projects. If you are using Linux then you will specify these paths either in your [cmake file](https://github.com/Microsoft/AirSim/tree/main/cmake//HelloCar/CMakeLists.txt) or on compiler command line.
+Fastest way to get started is to open AirSim.sln in Visual Studio 2019. You will see [Hello Car](https://github.com/microsoft/AirSim/tree/main/HelloCar/) and [Hello Drone](https://github.com/microsoft/AirSim/tree/main/HelloDrone/) examples in the solution. These examples will show you the include paths and lib paths you will need to setup in your VC++ projects. If you are using Linux then you will specify these paths either in your [cmake file](https://github.com/microsoft/AirSim/tree/main/cmake/HelloCar/CMakeLists.txt) or on compiler command line.
 
 #### Include and Lib Folders
 
@@ -19,7 +19,7 @@ Here's how to use AirSim APIs using C++ to control simulated car (see also [Pyth
 
 ```cpp
 
-// ready to run example: https://github.com/Microsoft/AirSim/blob/main/HelloCar/main.cpp
+// ready to run example: https://github.com/microsoft/AirSim/blob/main/HelloCar/main.cpp
 
 #include <iostream>
 #include "vehicles/car/api/CarRpcLibClient.hpp"
@@ -57,7 +57,7 @@ Here's how to use AirSim APIs using C++ to control simulated quadrotor (see also
 
 ```cpp
 
-// ready to run example: https://github.com/Microsoft/AirSim/blob/main/HelloDrone/main.cpp
+// ready to run example: https://github.com/microsoft/AirSim/blob/main/HelloDrone/main.cpp
 
 #include <iostream>
 #include "vehicles/multirotor/api/MultirotorRpcLibClient.hpp"

--- a/docs/distance_sensor.md
+++ b/docs/distance_sensor.md
@@ -22,4 +22,4 @@ For example, to make the sensor point towards the ground (for altitude measureme
 }
 ```
 
-**Note:** For Cars, the sensor is placed 1 meter above the vehicle center by default. This is required since otherwise the sensor gives strange data due it being inside the vehicle. This doesn't affect the sensor values say when measuring the distance between 2 cars. See [`PythonClient/car/distance_sensor_multi.py`](https://github.com/Microsoft/AirSim/blob/main/PythonClient/car/distance_sensor_multi.py) for an example usage.
+**Note:** For Cars, the sensor is placed 1 meter above the vehicle center by default. This is required since otherwise the sensor gives strange data due it being inside the vehicle. This doesn't affect the sensor values say when measuring the distance between 2 cars. See [`PythonClient/car/distance_sensor_multi.py`](https://github.com/microsoft/AirSim/blob/main/PythonClient/car/distance_sensor_multi.py) for an example usage.


### PR DESCRIPTION
## Why
C++ API guide and distance sensor notes still pointed examples at `Microsoft/AirSim` and one `cmake//HelloCar` double-slash tree URL.

## What's in
- `docs/apis_cpp.md` — microsoft casing + `cmake/HelloCar`
- `docs/distance_sensor.md` — example blob link casing

Docs-only, orthogonal to the Python APIs guide PR.

## Checks
- Visual review of the four link lines
- No code/runtime changes

AI-assisted; human-reviewed.
