### PR TITLE
docs(image): fix double-slash sample paths and microsoft org casing

### DIFF
--- a/docs/InfraredCamera.md
+++ b/docs/InfraredCamera.md
@@ -1,14 +1,14 @@
 This is a tutorial for generating simulated thermal infrared (IR) images using AirSim and the AirSim Africa environment. 
 
 Pre-compiled Africa Environment can be downloaded from the Releases tab of this Github repo: 
-[Windows Pre-compiled binary](https://github.com/Microsoft/AirSim/releases/tag/v1.2.1)
+[Windows Pre-compiled binary](https://github.com/microsoft/AirSim/releases/tag/v1.2.1)
 
-To generate your own data, you may use two python files: [create_ir_segmentation_map.py](https://github.com/Microsoft/AirSim/tree/main/PythonClient//computer_vision/create_ir_segmentation_map.py) and 
-[capture_ir_segmentation.py](https://github.com/Microsoft/AirSim/tree/main/PythonClient//computer_vision/capture_ir_segmentation.py).
+To generate your own data, you may use two python files: [create_ir_segmentation_map.py](https://github.com/microsoft/AirSim/tree/main/PythonClient/computer_vision/create_ir_segmentation_map.py) and 
+[capture_ir_segmentation.py](https://github.com/microsoft/AirSim/tree/main/PythonClient/computer_vision/capture_ir_segmentation.py).
 
-[create_ir_segmentation_map.py](https://github.com/Microsoft/AirSim/tree/main/PythonClient//computer_vision/create_ir_segmentation_map.py) uses temperature, emissivity, and camera response information to estimate the thermal digital count that could be expected for the objects in the environment, and then reassigns the segmentation IDs in AirSim to match these digital counts. It should be run before starting to capture thermal IR data. Otherwise, digital counts in the IR images will be incorrect. The camera response, temperature, and emissivity data are all included for the Africa environment.
+[create_ir_segmentation_map.py](https://github.com/microsoft/AirSim/tree/main/PythonClient/computer_vision/create_ir_segmentation_map.py) uses temperature, emissivity, and camera response information to estimate the thermal digital count that could be expected for the objects in the environment, and then reassigns the segmentation IDs in AirSim to match these digital counts. It should be run before starting to capture thermal IR data. Otherwise, digital counts in the IR images will be incorrect. The camera response, temperature, and emissivity data are all included for the Africa environment.
 
-[capture_ir_segmentation.py](https://github.com/Microsoft/AirSim/tree/main/PythonClient//computer_vision/capture_ir_segmentation.py) is run after the segmentation IDs have been reassigned. It tracks objects of interest and records the infrared and scene images from the multirotor. It uses Computer Vision mode.
+[capture_ir_segmentation.py](https://github.com/microsoft/AirSim/tree/main/PythonClient/computer_vision/capture_ir_segmentation.py) is run after the segmentation IDs have been reassigned. It tracks objects of interest and records the infrared and scene images from the multirotor. It uses Computer Vision mode.
 
 Finally, the details about how temperatures were estimated for plants and animals in the Africa environment, etc. can be found in this paper:
 

--- a/docs/image_apis.md
+++ b/docs/image_apis.md
@@ -124,13 +124,13 @@ int getStereoAndDepthImages()
 
 ### Python
 
-For a more complete ready to run sample code please see [sample code in AirSimClient project](https://github.com/Microsoft/AirSim/tree/main/PythonClient//multirotor/hello_drone.py) for multirotors or [HelloCar sample](https://github.com/Microsoft/AirSim/tree/main/PythonClient//car/hello_car.py). This code also demonstrates simple activities such as saving images in files or using `numpy` to manipulate images.
+For a more complete ready to run sample code please see [sample code in AirSimClient project](https://github.com/microsoft/AirSim/tree/main/PythonClient/multirotor/hello_drone.py) for multirotors or [HelloCar sample](https://github.com/microsoft/AirSim/tree/main/PythonClient/car/hello_car.py). This code also demonstrates simple activities such as saving images in files or using `numpy` to manipulate images.
 
 ### C++
 
-For a more complete ready to run sample code please see [sample code in HelloDrone project](https://github.com/Microsoft/AirSim/tree/main/HelloDrone//main.cpp) for multirotors or [HelloCar project](https://github.com/Microsoft/AirSim/tree/main/HelloCar//main.cpp). 
+For a more complete ready to run sample code please see [sample code in HelloDrone project](https://github.com/microsoft/AirSim/tree/main/HelloDrone/main.cpp) for multirotors or [HelloCar project](https://github.com/microsoft/AirSim/tree/main/HelloCar/main.cpp). 
 
-See also [other example code](https://github.com/Microsoft/AirSim/tree/main/Examples/DataCollection/StereoImageGenerator.hpp) that generates specified number of stereo images along with ground truth depth and disparity and saving it to [pfm format](pfm.md).
+See also [other example code](https://github.com/microsoft/AirSim/tree/main/Examples/DataCollection/StereoImageGenerator.hpp) that generates specified number of stereo images along with ground truth depth and disparity and saving it to [pfm format](pfm.md).
 
 ## Available Cameras
 
@@ -159,7 +159,7 @@ To active this mode, edit [settings.json](settings.md) that you can find in your
 }
 ```
 
-[Here's the Python code example](https://github.com/Microsoft/AirSim/tree/main/PythonClient//computer_vision/cv_mode.py) to move camera around and capture images.
+[Here's the Python code example](https://github.com/microsoft/AirSim/tree/main/PythonClient/computer_vision/cv_mode.py) to move camera around and capture images.
 
 This mode was inspired from [UnrealCV project](http://unrealcv.org/).
 
@@ -167,7 +167,7 @@ This mode was inspired from [UnrealCV project](http://unrealcv.org/).
 To move around the environment using APIs you can use `simSetVehiclePose` API. This API takes position and orientation and sets that on the invisible vehicle where the front-center camera is located. All rest of the cameras move along keeping the relative position. If you don't want to change position (or orientation) then just set components of position (or orientation) to floating point nan values. The `simGetVehiclePose` allows to retrieve the current pose. You can also use `simGetGroundTruthKinematics` to get the quantities kinematics quantities for the movement. Many other non-vehicle specific APIs are also available such as segmentation APIs, collision APIs and camera APIs.
 
 ## Camera APIs
-The `simGetCameraInfo` returns the pose (in world frame, NED coordinates, SI units) and FOV (in degrees) for the specified camera. Please see [example usage](https://github.com/Microsoft/AirSim/tree/main/PythonClient//computer_vision/cv_mode.py).
+The `simGetCameraInfo` returns the pose (in world frame, NED coordinates, SI units) and FOV (in degrees) for the specified camera. Please see [example usage](https://github.com/microsoft/AirSim/tree/main/PythonClient/computer_vision/cv_mode.py).
 
 The `simSetCameraPose` sets the pose for the specified camera while taking an input pose as a combination of relative position and a quaternion in NED frame. The handy `airsim.to_quaternion()` function allows to convert pitch, roll, yaw to quaternion. For example, to set camera-0 to 15-degree pitch while maintaining the same position, you can use:
 ```
@@ -183,7 +183,7 @@ All Camera APIs take in 3 common parameters apart from the API-specific ones, `c
 ### Gimbal
 You can set stabilization for pitch, roll or yaw for any camera [using settings](settings.md#gimbal).
 
-Please see [example usage](https://github.com/Microsoft/AirSim/tree/main/PythonClient//computer_vision/cv_mode.py).
+Please see [example usage](https://github.com/microsoft/AirSim/tree/main/PythonClient/computer_vision/cv_mode.py).
 
 ## Changing Resolution and Camera Parameters
 To change resolution, FOV etc, you can use [settings.json](settings.md). For example, below addition in settings.json sets parameters for scene capture and uses "Computer Vision" mode described above. If you omit any setting then below default values will be used. For more information see [settings doc](settings.md). If you are using stereo camera, currently the distance between left and right is fixed at 25 cm.
@@ -263,7 +263,7 @@ print(np.unique(img_rgb[:,:,1], return_counts=True)) #green
 print(np.unique(img_rgb[:,:,2], return_counts=True)) #blue  
 ```
 
-A complete ready-to-run example can be found in [segmentation.py](https://github.com/Microsoft/AirSim/tree/main/PythonClient//computer_vision/segmentation.py).
+A complete ready-to-run example can be found in [segmentation.py](https://github.com/microsoft/AirSim/tree/main/PythonClient/computer_vision/segmentation.py).
 
 #### Unsetting object ID
 An object's ID can be set to -1 to make it not show up on the segmentation image.
@@ -293,4 +293,4 @@ Currently this is just a map from object ID to grey scale 0-255. So any mesh wit
 These image types return information about motion perceived by the point of view of the camera. OpticalFlow returns a 2-channel image where the channels correspond to vx and vy respectively. OpticalFlowVis is similar to OpticalFlow but converts flow data to RGB for a more 'visual' output.
 
 ## Example Code
-A complete example of setting vehicle positions at random locations and orientations and then taking images can be found in [GenerateImageGenerator.hpp](https://github.com/Microsoft/AirSim/tree/main/Examples/DataCollection/StereoImageGenerator.hpp). This example generates specified number of stereo images and ground truth disparity image and saving it to [pfm format](pfm.md).
+A complete example of setting vehicle positions at random locations and orientations and then taking images can be found in [GenerateImageGenerator.hpp](https://github.com/microsoft/AirSim/tree/main/Examples/DataCollection/StereoImageGenerator.hpp). This example generates specified number of stereo images and ground truth disparity image and saving it to [pfm format](pfm.md).

--- a/docs/upgrade_apis.md
+++ b/docs/upgrade_apis.md
@@ -2,7 +2,7 @@
 There have been several API changes in AirSim v1.2 that we hope removes inconsistency, adds future extensibility and presents cleaner interface. Many of these changes are however *breaking changes* which means you will need to modify your client code that talks to AirSim.
 
 ## Quicker Way
-While most changes you need to do in your client code are fairly easy, a quicker way is simply to take a look at the example code such as [Hello Drone](https://github.com/Microsoft/AirSim/tree/main/PythonClient//multirotor/hello_drone.py)or [Hello Car](https://github.com/Microsoft/AirSim/tree/main/PythonClient//car/hello_car.py) to get gist of changes.
+While most changes you need to do in your client code are fairly easy, a quicker way is simply to take a look at the example code such as [Hello Drone](https://github.com/microsoft/AirSim/tree/main/PythonClient/multirotor/hello_drone.py)or [Hello Car](https://github.com/microsoft/AirSim/tree/main/PythonClient/car/hello_car.py) to get gist of changes.
 
 ## Importing AirSim
 Instead of,


### PR DESCRIPTION
## Summary
Image/upgrade/IR docs had accidental `PythonClient//`, `HelloDrone//`, and `HelloCar//` fragments in GitHub tree links, plus legacy `github.com/Microsoft/AirSim` casing. This normalizes those three files only.

## Files
- `docs/image_apis.md`
- `docs/upgrade_apis.md`
- `docs/InfraredCamera.md`

## Notes
Orthogonal to open casing PRs on `docs/apis.md` / build clone guides.

## Verification
- [x] Spot-check links for single-slash paths
- [x] Diff limited to the three docs above

AI-assisted; human-reviewed.