### PR TITLE
docs(python): lowercase microsoft org in computer_vision sample headers

### DIFF
--- a/PythonClient/computer_vision/cv_capture.py
+++ b/PythonClient/computer_vision/cv_capture.py
@@ -1,5 +1,5 @@
 # In settings.json first activate computer vision mode: 
-# https://github.com/Microsoft/AirSim/blob/main/docs/image_apis.md#computer-vision-mode
+# https://github.com/microsoft/AirSim/blob/main/docs/image_apis.md#computer-vision-mode
 
 import setup_path 
 import airsim

--- a/PythonClient/computer_vision/cv_mode.py
+++ b/PythonClient/computer_vision/cv_mode.py
@@ -1,5 +1,5 @@
 # In settings.json first activate computer vision mode:
-# https://github.com/Microsoft/AirSim/blob/main/docs/image_apis.md#computer-vision-mode
+# https://github.com/microsoft/AirSim/blob/main/docs/image_apis.md#computer-vision-mode
 
 import setup_path
 import airsim

--- a/PythonClient/computer_vision/cv_navigate.py
+++ b/PythonClient/computer_vision/cv_navigate.py
@@ -1,6 +1,6 @@
 
 # In settings.json first activate computer vision mode: 
-# https://github.com/Microsoft/AirSim/blob/main/docs/image_apis.md#computer-vision-mode
+# https://github.com/microsoft/AirSim/blob/main/docs/image_apis.md#computer-vision-mode
 
 import setup_path 
 import airsim

--- a/PythonClient/computer_vision/getpos.py
+++ b/PythonClient/computer_vision/getpos.py
@@ -1,5 +1,5 @@
 # In settings.json first activate computer vision mode: 
-# https://github.com/Microsoft/AirSim/blob/main/docs/image_apis.md#computer-vision-mode
+# https://github.com/microsoft/AirSim/blob/main/docs/image_apis.md#computer-vision-mode
 
 import setup_path 
 import airsim

--- a/PythonClient/computer_vision/ground_truth.py
+++ b/PythonClient/computer_vision/ground_truth.py
@@ -1,5 +1,5 @@
 # In settings.json first activate computer vision mode: 
-# https://github.com/Microsoft/AirSim/blob/main/docs/image_apis.md#computer-vision-mode
+# https://github.com/microsoft/AirSim/blob/main/docs/image_apis.md#computer-vision-mode
 
 import setup_path 
 import airsim

--- a/PythonClient/computer_vision/objects.py
+++ b/PythonClient/computer_vision/objects.py
@@ -1,5 +1,5 @@
 # In settings.json first activate computer vision mode: 
-# https://github.com/Microsoft/AirSim/blob/main/docs/image_apis.md#computer-vision-mode
+# https://github.com/microsoft/AirSim/blob/main/docs/image_apis.md#computer-vision-mode
 
 import setup_path 
 import airsim

--- a/PythonClient/computer_vision/segmentation.py
+++ b/PythonClient/computer_vision/segmentation.py
@@ -1,5 +1,5 @@
 # In settings.json first activate computer vision mode: 
-# https://github.com/Microsoft/AirSim/blob/main/docs/image_apis.md#computer-vision-mode
+# https://github.com/microsoft/AirSim/blob/main/docs/image_apis.md#computer-vision-mode
 
 import airsim
 import cv2


### PR DESCRIPTION
## Summary
Computer-vision Python samples used `github.com/Microsoft/AirSim` in file-header comments. This normalizes those seven sample headers to `github.com/microsoft/AirSim`.

## Why
Matches the live GitHub org slug and remaining docs hygiene on this fork lane. Comment-only — no runtime behavior change.

## Verification
- `rg 'github\.com/Microsoft/AirSim' PythonClient/computer_vision/` → empty on touched paths
- Review: cv_capture, cv_mode, cv_navigate, getpos, ground_truth, objects, segmentation

AI-assisted; human-reviewed.