### PR TITLE
docs(faq): fix environment spelling in PATH note

### DIFF
--- a/docs/build_faq.md
+++ b/docs/build_faq.md
@@ -73,7 +73,7 @@
 
 ###### I get error: 'where' is not recognized as an internal or external command
 
->You have to add `C:\WINDOWS\SYSTEM32` to your PATH enviroment variable.
+>You have to add `C:\WINDOWS\SYSTEM32` to your PATH environment variable.
 
 <!-- ======================================================================= -->
 


### PR DESCRIPTION
### What
One-character-class typo in `docs/build_faq.md`: PATH **enviroment** → **environment**.

### Scope
FAQ path guidance only. No build scripts.

### Check
`rg enviroment docs/build_faq.md` is empty after the change.

Human-reviewed micro-doc fix (AI-assisted draft).