### PR TITLE
salvage: fix inverse scale when writing binvox meshes (credit @sotpapathe #4710)

### DIFF
--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
@@ -226,7 +226,8 @@ bool WorldSimApi::createVoxelGrid(const Vector3r& position, const int& x_size, c
     output << "#binvox 1\n";
     output << "dim " << ncells_x << " " << ncells_z << " " << ncells_y << "\n";
     output << "translate " << -x_size * 0.5 << " " << -y_size * 0.5 << " " << -z_size * 0.5 << "\n";
-    output << "scale " << 1.0f / x_size << "\n";
+    // binvox scale is unit length of the grid edge (not reciprocal); see binvox format
+    output << "scale " << x_size << "\n";
     output << "data\n";
     bool run_value = voxel_grid_[0];
     unsigned int run_length = 0;


### PR DESCRIPTION
## Salvage line
**salvage of** [#4710](https://github.com/microsoft/AirSim/pull/4710) by **@sotpapathe** — full credit to the original author.

## Problem
`WorldSimApi::createVoxelGrid` wrote the binvox `scale` field as `1.0f / x_size`. In the [binvox](https://www.patrickmin.com/binvox/binvox.html) header, `scale` is the unit length of the grid’s edge along the first dimension, **not** its reciprocal. Downstream tools then reconstructed inverted/wrong physical extents.

## Change
- Write `scale << x_size` (same as original PR intent)
- Brief comment pointing at format semantics
- Rebased cleanly on current `main` (single-line + comment)

## Why not just bump the old PR
Original remains open/MERGEABLE but sat idle since 2022-09; this re-lands the fix with active attribution so maintainers have a fresh head.

## Verification
- Diff limited to `Unreal/Plugins/AirSim/Source/WorldSimApi.cpp`
- No other WorldSim paths touched
- Host build of full UE plugin not run in this lane (dormant-sim culture: surgical code salvage)

AI-assisted; human-reviewed. Please keep credit with @sotpapathe.