### PR TITLE
fix(tools): correct occurred spelling in batch error echoes

### DIFF
--- a/Unreal/Environments/Blocks/package.bat
+++ b/Unreal/Environments/Blocks/package.bat
@@ -53,7 +53,7 @@ for %%f in (*.uproject) do (
 goto :done
 
 :failed
-echo "Error occured while packaging"
+echo "Error occurred while packaging"
 echo "Usage: package.bat <path\to\output> <path to Engine\Build\BatchFiles> <UE Version>"
 exit /b 1
 

--- a/Unreal/Environments/Blocks/update_from_git.bat
+++ b/Unreal/Environments/Blocks/update_from_git.bat
@@ -27,7 +27,7 @@ cmd /c GenerateProjectFiles.bat
 goto :done
 
 :failed
-echo Error occured while updating.
+echo Error occurred while updating.
 exit /b 1
 
 :done

--- a/Unreal/Environments/Blocks/update_from_git_ci.bat
+++ b/Unreal/Environments/Blocks/update_from_git_ci.bat
@@ -27,7 +27,7 @@ REM cmd /c GenerateProjectFiles.bat
 goto :done
 
 :failed
-echo Error occured while updating.
+echo Error occurred while updating.
 exit /b 1
 
 :done

--- a/tools/build_all_ue_projects.bat
+++ b/tools/build_all_ue_projects.bat
@@ -66,7 +66,7 @@ if ERRORLEVEL 1 goto :failed
 goto :done
 
 :failed
-echo "Error occured while building all UE projects"
+echo "Error occurred while building all UE projects"
 exit /b 1
 
 :done

--- a/tools/gitcommitall.bat
+++ b/tools/gitcommitall.bat
@@ -52,7 +52,7 @@ cd ..
 goto :done
 
 :failed
-@echo "Error occured"
+@echo "Error occurred"
 @echo Usage: gitcommitall <repo root> <commit message>
 cd "%ROOT_DIR%"
 exit /b 1


### PR DESCRIPTION
## Summary
Replaces `occured` with `occurred` in batch error `echo` lines:

- `tools/build_all_ue_projects.bat`
- `tools/gitcommitall.bat`
- `Unreal/Environments/Blocks/update_from_git.bat`
- `Unreal/Environments/Blocks/package.bat`
- `Unreal/Environments/Blocks/update_from_git_ci.bat`

String-only; control flow unchanged.

## Test plan
- [x] `rg occured` on touched paths empty
- [x] Diff is echo-text only

Human-reviewed micro-fix. No flight/arm/geofence code.