### PR TITLE
salvage: Unity multi-drone CaptureCameras lookup (credit @shabpompeiano #4815)

### DIFF
--- a/Unity/UnityDemo/Assets/AirSimAssets/Scripts/Vehicles/Vehicle.cs
+++ b/Unity/UnityDemo/Assets/AirSimAssets/Scripts/Vehicles/Vehicle.cs
@@ -343,12 +343,26 @@ namespace AirSimUnity {
             captureResetEvent = new AutoResetEvent(false);
         }
 
-        //Register all the capture cameras in the scene for recording and data capture.
-        //Make sure every camera is a child of a gameobject with tag "CaptureCameras"
+        //Register capture cameras for this vehicle (recording / data capture).
+        //Each vehicle should own a child hierarchy tagged "CaptureCameras".
+        //Scene-wide FindGameObjectWithTag only returns the first match and breaks multi-drone simGetImages.
+        private GameObject FindChildWithTag(GameObject parent, string tag) {
+            if (parent == null) {
+                return null;
+            }
+            foreach (Transform transform in parent.transform) {
+                if (transform.CompareTag(tag)) {
+                    return transform.gameObject;
+                }
+            }
+            return null;
+        }
+
         private void SetUpCameras() {
-            GameObject camerasParent = GameObject.FindGameObjectWithTag("CaptureCameras");
+            GameObject thisVehicle = GameObject.Find(this.name);
+            GameObject camerasParent = FindChildWithTag(thisVehicle, "CaptureCameras");
             if (!camerasParent) {
-                Debug.LogWarning("No Cameras found in the scene to capture data");
+                Debug.LogWarning("No CaptureCameras found under vehicle '" + this.name + "'");
                 return;
             }
 


### PR DESCRIPTION
## Summary
**Salvage** of @shabpompeiano’s approach in #4815, rebased onto current `main` with a null-safe helper and clearer multi-vehicle comments.

`SetUpCameras` used `GameObject.FindGameObjectWithTag("CaptureCameras")`, which only returns the **first** match in the scene. In multi-drone Unity setups, every vehicle therefore registered the same camera set and `simGetImages` only reflected one drone.

This finds the `CaptureCameras` child under the **current** vehicle by name, matching the original salvage intent.

## Credit
Original work: @shabpompeiano in https://github.com/microsoft/AirSim/pull/4815

## Verification
- Diff limited to `Vehicle.cs`
- Review against #4815 patch semantics
- AI-assisted; human-reviewed. Human author trailers only.