### PR TITLE
salvage: clarify Epic Launcher UE install path on macOS (credit @soumildatta #5021)

### DIFF
--- a/docs/build_macos.md
+++ b/docs/build_macos.md
@@ -15,8 +15,8 @@ Please see instructions [here](docker_ubuntu.md)
 #### Download Unreal Engine
 
 1. [Download](https://www.unrealengine.com/download) the Epic Games Launcher. While the Unreal Engine is open source and free to download, registration is still required.
-2. Run the Epic Games Launcher, open the `Library` tab on the left pane.
-   Click on the `Add Versions` which should show the option to download **Unreal 4.27** as shown below. If you have multiple versions of Unreal installed then **make sure 4.27 is set to `current`** by clicking down arrow next to the Launch button for the version.
+2. Run the Epic Games Launcher, open the `Unreal Engine` tab on the left pane, then the `Library` tab along the top of that section.
+   Click on **Install Engine** / `Engine Versions` → add (wording varies slightly by Launcher version; formerly `Add Versions`) which should show the option to download **Unreal 4.27** as shown below. If you have multiple versions of Unreal installed then **make sure 4.27 is set to `current`** by clicking the down arrow next to the Launch button for the version.
 
    **Note**: AirSim also works with UE >= 4.24, however, we recommend 4.27.
    **Note**: If you have UE 4.16 or older projects, please see the [upgrade guide](unreal_upgrade.md) to upgrade your projects.


### PR DESCRIPTION
## salvage (credit @soumildatta #5021)

Rebased / refreshed the macOS build guide so Epic Games Launcher nav matches current UI:

- `Unreal Engine` (left) → `Library` (top of that section), not a root left-pane `Library` tab alone
- install control wording coverer slightly broader Launcher label drift

Original PR #5021 remains the source of the insight; this fork branch is maintainer-ready on current `main`.

## Verification
Markdown-only; previewed instructions against Epic Launcher layout notes from #5021.

<!--
Claim: bartok
Operator: bartok
Campaign: aerial-drone
-->