### PR TITLE
fix(python): NumPy 2-safe scalar ops for Vector3r/Quaternionr

### DIFF
--- a/PythonClient/airsim/types.py
+++ b/PythonClient/airsim/types.py
@@ -2,6 +2,23 @@ from __future__ import print_function
 import msgpackrpc #install as admin: pip install msgpack-rpc-python
 import numpy as np #pip install numpy
 import math
+import numbers
+
+
+def _is_numeric_scalar(value):
+    """True for real numeric scalars usable in Vector3r/Quaternionr ops.
+
+    Accepts Python int/float and NumPy integer/floating scalars. Rejects bool
+    (bool subclasses int) and non-scalars. Avoids NumPy 2-removed scalar-type maps.
+    """
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, numbers.Real):
+        return True
+    if isinstance(value, (np.integer, np.floating)):
+        return True
+    return False
+
 
 class MsgpackMixin:
     def __repr__(self):
@@ -110,13 +127,13 @@ class Vector3r(MsgpackMixin):
         return Vector3r(self.x_val - other.x_val, self.y_val - other.y_val, self.z_val - other.z_val)
 
     def __truediv__(self, other):
-        if type(other) in [int, float] + np.sctypes['int'] + np.sctypes['uint'] + np.sctypes['float']:
+        if _is_numeric_scalar(other):
             return Vector3r( self.x_val / other, self.y_val / other, self.z_val / other)
         else:
             raise TypeError('unsupported operand type(s) for /: %s and %s' % ( str(type(self)), str(type(other))) )
 
     def __mul__(self, other):
-        if type(other) in [int, float] + np.sctypes['int'] + np.sctypes['uint'] + np.sctypes['float']:
+        if _is_numeric_scalar(other):
             return Vector3r(self.x_val*other, self.y_val*other, self.z_val*other)
         else:
             raise TypeError('unsupported operand type(s) for *: %s and %s' % ( str(type(self)), str(type(other))) )
@@ -174,6 +191,13 @@ class Quaternionr(MsgpackMixin):
         else:
             raise TypeError('unsupported operand type(s) for +: %s and %s' % ( str(type(self)), str(type(other))) )
 
+
+    def __sub__(self, other):
+        if type(self) == type(other):
+            return Quaternionr( self.x_val-other.x_val, self.y_val-other.y_val, self.z_val-other.z_val, self.w_val-other.w_val )
+        else:
+            raise TypeError('unsupported operand type(s) for -: %s and %s' % ( str(type(self)), str(type(other))) )
+
     def __mul__(self, other):
         if type(self) == type(other):
             t, x, y, z = self.w_val, self.x_val, self.y_val, self.z_val
@@ -188,7 +212,7 @@ class Quaternionr(MsgpackMixin):
     def __truediv__(self, other):
         if type(other) == type(self):
             return self * other.inverse()
-        elif type(other) in [int, float] + np.sctypes['int'] + np.sctypes['uint'] + np.sctypes['float']:
+        elif _is_numeric_scalar(other):
             return Quaternionr( self.x_val / other, self.y_val / other, self.z_val / other, self.w_val / other)
         else:
             raise TypeError('unsupported operand type(s) for /: %s and %s' % ( str(type(self)), str(type(other))) )

--- a/PythonClient/tests/test_vector_quat_numeric_ops.py
+++ b/PythonClient/tests/test_vector_quat_numeric_ops.py
@@ -1,0 +1,64 @@
+"""Offline Vector3r/Quaternionr numeric-operator checks (no sim)."""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+
+def _load_types():
+    if "msgpackrpc" not in sys.modules:
+        sys.modules["msgpackrpc"] = types.ModuleType("msgpackrpc")
+    root = Path(__file__).resolve().parents[1] / "airsim" / "types.py"
+    spec = importlib.util.spec_from_file_location("airsim_types_ops_under_test", root)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestVectorQuatNumericOps(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.t = _load_types()
+
+    def test_vector_scale_python_and_numpy_scalars(self):
+        v = self.t.Vector3r(2.0, 4.0, 6.0)
+        self.assertEqual(tuple(v * 2), (4.0, 8.0, 12.0))
+        self.assertEqual(tuple(v / 2), (1.0, 2.0, 3.0))
+        self.assertEqual(tuple(v * np.float32(0.5)), (1.0, 2.0, 3.0))
+        self.assertEqual(tuple(v / np.int64(2)), (1.0, 2.0, 3.0))
+
+    def test_bool_not_numeric_scalar(self):
+        v = self.t.Vector3r(1.0, 2.0, 3.0)
+        with self.assertRaises(TypeError):
+            _ = v * True
+        with self.assertRaises(TypeError):
+            _ = v / False
+        q = self.t.Quaternionr(0, 0, 0, 1)
+        with self.assertRaises(TypeError):
+            _ = q / True
+
+    def test_quaternion_sub_and_scale(self):
+        a = self.t.Quaternionr(1, 2, 3, 4)
+        b = self.t.Quaternionr(1, 1, 1, 1)
+        d = a - b
+        self.assertEqual(tuple(d), (0.0, 1.0, 2.0, 3.0))
+        s = a / 2.0
+        self.assertEqual(tuple(s), (0.5, 1.0, 1.5, 2.0))
+
+    def test_no_sctypes_dependency(self):
+        src = (Path(__file__).resolve().parents[1] / "airsim" / "types.py").read_text()
+        self.assertNotIn("np.sctypes", src)
+        self.assertTrue(hasattr(self.t, "_is_numeric_scalar"))
+        self.assertFalse(self.t._is_numeric_scalar(True))
+        self.assertTrue(self.t._is_numeric_scalar(3))
+        self.assertTrue(self.t._is_numeric_scalar(np.float64(1.25)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Replace `np.sctypes` gates in `Vector3r`/`Quaternionr` multiply/divide (removed in NumPy 2.0) with a portable `_is_numeric_scalar` helper.
- Add missing `Quaternionr.__sub__` so `cross()` / `outer_product()` work.
- Offline unittest for scalar scale, bool rejection, and subtraction.

## Motivation

`type(x) in [int,float] + np.sctypes[...]` raises `AttributeError` on NumPy 2 for any scale attempt once `sctypes` is gone. Replacing the gate keeps client math working across NumPy 1.x and 2.x. Bool is rejected (impostor `int` subclass).

## Verification

- `PYTHONPATH=PythonClient python3 -m unittest tests.test_vector_quat_numeric_ops -v` → 4 passed
- `np.sctypes` no longer referenced by operators
- No arm/geofence/control changes

## Notes

- Same file `types.py` as sibling barometer-type PR; hunks are non-overlapping if merged in either order
- AI-assisted; human-reviewed

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h