### PR TITLE
salvage: protect path lookahead std::max from Windows macros (credit @2750666716 #4788)

### DIFF
--- a/AirLib/src/vehicles/multirotor/api/MultirotorApiBase.cpp
+++ b/AirLib/src/vehicles/multirotor/api/MultirotorApiBase.cpp
@@ -918,7 +918,8 @@ namespace airlib
         //if auto mode requested for lookahead then calculate based on velocity
         float command_period_dist = velocity * getCommandPeriod();
         float lookahead = command_period_dist * (adaptive_lookahead > 0 ? min_factor : max_factor);
-        lookahead = std::max(lookahead, getDistanceAccuracy() * 1.5f); //50% more than distance accuracy
+        // Parenthesize std::max so MSVC Windows min/max macros cannot break this call.
+        lookahead = (std::max)(lookahead, getDistanceAccuracy() * 1.5f); //50% more than distance accuracy
         return lookahead;
     }
 


### PR DESCRIPTION
## Summary

- Parenthesize path-follow lookahead `std::max` as `(std::max)(...)` so MSVC Windows `max` macros cannot break the call.
- **Salvage of #4788** by @2750666716 — credit original author.

## Motivation / differential value vs #4788

Open #4788 also proposes `#include <windows.h>` + `Sleep(30)` in the path loop. That is non-portable and changes path-following latency on every iteration. This salvage keeps **only** the portable macro-safe `std::max` form identified in that PR.

| | #4788 | This PR |
|--|--|--|
| `(std::max)` lookahead | yes | **yes** |
| `Sleep(30)` / `windows.h` | yes | **no** |

Recommend: merge this micro-fix; original #4788 can close or drop the Sleep path.

## Verification

- Diff review on `MultirotorApiBase.cpp` only
- No behavior change on non-Windows / when macros absent
- No arm/geofence weakening

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h