### PR TITLE
fix(python): use context managers in standalone pfm IO

### DIFF
--- a/PythonClient/airsim/pfm.py
+++ b/PythonClient/airsim/pfm.py
@@ -1,85 +1,78 @@
 import numpy as np
-import matplotlib.pyplot as plt
 import re
 import sys
-import pdb
 
 
 def read_pfm(file):
-    """ Read a pfm file """
-    file = open(file, 'rb')
+    """Read a pfm file. `file` is a path (str/Path). Returns (data, scale)."""
+    with open(file, 'rb') as f:
+        color = None
+        width = None
+        height = None
+        scale = None
+        endian = None
 
-    color = None
-    width = None
-    height = None
-    scale = None
-    endian = None
+        header = f.readline().rstrip()
+        header = str(bytes.decode(header, encoding='utf-8'))
+        if header == 'PF':
+            color = True
+        elif header == 'Pf':
+            color = False
+        else:
+            raise Exception('Not a PFM file.')
 
-    header = file.readline().rstrip()
-    header = str(bytes.decode(header, encoding='utf-8'))
-    if header == 'PF':
-        color = True
-    elif header == 'Pf':
-        color = False
-    else:
-        raise Exception('Not a PFM file.')
-
-    pattern = r'^(\d+)\s(\d+)\s$'
-    temp_str = str(bytes.decode(file.readline(), encoding='utf-8'))
-    dim_match = re.match(pattern, temp_str)
-    if dim_match:
-        width, height = map(int, dim_match.groups())
-    else:
-        temp_str += str(bytes.decode(file.readline(), encoding='utf-8'))
+        pattern = r'^(\d+)\s(\d+)\s$'
+        temp_str = str(bytes.decode(f.readline(), encoding='utf-8'))
         dim_match = re.match(pattern, temp_str)
         if dim_match:
             width, height = map(int, dim_match.groups())
         else:
-            raise Exception('Malformed PFM header: width, height cannot be found')
+            temp_str += str(bytes.decode(f.readline(), encoding='utf-8'))
+            dim_match = re.match(pattern, temp_str)
+            if dim_match:
+                width, height = map(int, dim_match.groups())
+            else:
+                raise Exception('Malformed PFM header: width, height cannot be found')
 
-    scale = float(file.readline().rstrip())
-    if scale < 0: # little-endian
-        endian = '<'
-        scale = -scale
-    else:
-        endian = '>' # big-endian
+        scale = float(f.readline().rstrip())
+        if scale < 0:  # little-endian
+            endian = '<'
+            scale = -scale
+        else:
+            endian = '>'  # big-endian
 
-    data = np.fromfile(file, endian + 'f')
-    shape = (height, width, 3) if color else (height, width)
+        data = np.fromfile(f, endian + 'f')
+        shape = (height, width, 3) if color else (height, width)
+        data = np.reshape(data, shape)
 
-    data = np.reshape(data, shape)
-    # DEY: I don't know why this was there.
-    file.close()
-    
     return data, scale
 
 
 def write_pfm(file, image, scale=1):
-    """ Write a pfm file """
-    file = open(file, 'wb')
-
+    """Write a pfm file. `file` is a path (str/Path)."""
     color = None
 
     if image.dtype.name != 'float32':
         raise Exception('Image dtype must be float32.')
 
-    if len(image.shape) == 3 and image.shape[2] == 3: # color image
+    if len(image.shape) == 3 and image.shape[2] == 3:  # color image
         color = True
-    elif len(image.shape) == 2 or len(image.shape) == 3 and image.shape[2] == 1: # greyscale
+    elif len(image.shape) == 2 or len(image.shape) == 3 and image.shape[2] == 1:  # greyscale
         color = False
     else:
         raise Exception('Image must have H x W x 3, H x W x 1 or H x W dimensions.')
 
-    file.write(bytes('PF\n', 'UTF-8') if color else bytes('Pf\n', 'UTF-8'))
-    temp_str = '%d %d\n' % (image.shape[1], image.shape[0])
-    file.write(bytes(temp_str, 'UTF-8'))
+    with open(file, 'wb') as f:
+        f.write(bytes('PF\n', 'UTF-8') if color else bytes('Pf\n', 'UTF-8'))
+        temp_str = '%d %d\n' % (image.shape[1], image.shape[0])
+        f.write(bytes(temp_str, 'UTF-8'))
 
-    endian = image.dtype.byteorder
+        endian = image.dtype.byteorder
 
-    if endian == '<' or endian == '=' and sys.byteorder == 'little':
-        scale = -scale
+        if endian == '<' or endian == '=' and sys.byteorder == 'little':
+            scale = -scale
 
-    temp_str = '%f\n' % scale
-    file.write(bytes(temp_str, 'UTF-8'))
+        temp_str = '%f\n' % scale
+        f.write(bytes(temp_str, 'UTF-8'))
 
-    image.tofile(file)
+        image.tofile(f)

--- a/PythonClient/tests/test_pfm_roundtrip.py
+++ b/PythonClient/tests/test_pfm_roundtrip.py
@@ -1,0 +1,54 @@
+"""Offline PFM read/write roundtrip (no sim, no matplotlib)."""
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+
+def _load_pfm():
+    root = Path(__file__).resolve().parents[1] / "airsim" / "pfm.py"
+    spec = importlib.util.spec_from_file_location("airsim_pfm_under_test", root)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestPfmRoundtrip(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.pfm = _load_pfm()
+
+    def test_gray_roundtrip(self):
+        img = np.arange(12, dtype=np.float32).reshape(3, 4)
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "g.pfm"
+            self.pfm.write_pfm(str(path), img, scale=1)
+            data, scale = self.pfm.read_pfm(str(path))
+        self.assertEqual(data.shape, (3, 4))
+        self.assertTrue(np.allclose(data, img))
+        self.assertAlmostEqual(scale, 1.0)
+
+    def test_color_roundtrip(self):
+        img = np.linspace(0, 1, 24, dtype=np.float32).reshape(2, 4, 3)
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "c.pfm"
+            self.pfm.write_pfm(str(path), img, scale=1)
+            data, scale = self.pfm.read_pfm(str(path))
+        self.assertEqual(data.shape, (2, 4, 3))
+        self.assertTrue(np.allclose(data, img))
+
+    def test_rejects_non_float32(self):
+        img = np.zeros((2, 2), dtype=np.float64)
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "bad.pfm"
+            with self.assertRaises(Exception):
+                self.pfm.write_pfm(str(path), img)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Rewrite standalone `PythonClient/airsim/pfm.py` read/write to use `with open(...)` so handles close on exception paths.
- Drop unused `matplotlib` / `pdb` imports (blocked headless offline unit tests).
- Add offline gray/color roundtrip unittest.

## Motivation

The standalone PFM helpers opened files without context managers (`file.close()` only on the success path for reads; write never explicit-close). Mid-parse failures could leak FDs. GUI imports also made casual import of the helper heavy / fragile.

Note: `utils.py` has parallel PFM helpers (#9796 hardens those); this PR is the **standalone** `pfm.py` module used by some samples.

## Verification

- `PYTHONPATH=PythonClient python3 -m unittest tests.test_pfm_roundtrip -v` → 3 passed
- No arm/geofence changes
- Orthogonal to open `utils.py` / `types.py` Bartok9 stack

## Notes

- AI-assisted; human-reviewed
- Replaces prior same-night #9802 which closed as near-dup of concurrent #9798

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h