### PR TITLE
fix(python): type magnetometer covariance as list

### DIFF
--- a/PythonClient/airsim/tests/test_magnetometer_covariance.py
+++ b/PythonClient/airsim/tests/test_magnetometer_covariance.py
@@ -1,0 +1,36 @@
+import unittest
+
+import numpy as np
+
+# Import without full client stack when msgpackrpc missing
+try:
+    from airsim.types import MagnetometerData, Vector3r
+except Exception:
+    import sys, types
+    from pathlib import Path
+    root = Path(__file__).resolve().parents[2]
+    sys.path.insert(0, str(root))
+    if 'msgpackrpc' not in sys.modules:
+        sys.modules['msgpackrpc'] = types.ModuleType('msgpackrpc')
+    from airsim.types import MagnetometerData, Vector3r
+
+
+class MagnetometerCovarianceTests(unittest.TestCase):
+    def test_default_is_list(self):
+        m = MagnetometerData()
+        self.assertIsInstance(m.magnetic_field_covariance, list)
+        self.assertEqual(m.magnetic_field_covariance, [])
+
+    def test_from_msgpack_list(self):
+        payload = {
+            'time_stamp': np.uint64(1),
+            'magnetic_field_body': {'x_val': 0.0, 'y_val': 0.0, 'z_val': 0.1},
+            'magnetic_field_covariance': [1.0] * 9,
+        }
+        m = MagnetometerData.from_msgpack(payload)
+        self.assertEqual(len(m.magnetic_field_covariance), 9)
+        self.assertIsInstance(m.magnetic_field_covariance, list)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/PythonClient/airsim/types.py
+++ b/PythonClient/airsim/types.py
@@ -435,7 +435,8 @@ class BarometerData(MsgpackMixin):
 class MagnetometerData(MsgpackMixin):
     time_stamp = np.uint64(0)
     magnetic_field_body = Vector3r()
-    magnetic_field_covariance = 0.0
+    # C++ MagnetometerBase::Output uses vector<real_T> (3x3, 9 elements)
+    magnetic_field_covariance = []
 
 class GnssFixType(MsgpackMixin):
     GNSS_FIX_NO_FIX = 0


### PR DESCRIPTION
## Summary
Default `MagnetometerData.magnetic_field_covariance` to a list so the Python field shape matches C++ `vector<real_T>` (3×3 / 9 elements) instead of a misleading `0.0` float.

## Motivation
msgpack decode/encode and typed consumers expect a sequence of covariances; a float default diverges from `MagnetometerBase::Output`.

## Verification
- `PythonClient/airsim/tests/test_magnetometer_covariance.py` covers default type and from_msgpack list of 9.

AI-assisted; human-reviewed.


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->