### PR TITLE
feat(api): expose simGetClockRate RPC (salvage credit @davidtr99 #4612)

### DIFF
--- a/AirLib/include/api/RpcLibClientBase.hpp
+++ b/AirLib/include/api/RpcLibClientBase.hpp
@@ -49,6 +49,7 @@ namespace airlib
         int getMinRequiredClientVersion() const;
 
         bool simIsPaused() const;
+        float simGetClockRate() const;
         void simPause(bool is_paused);
         void simContinueForTime(double seconds);
         void simContinueForFrames(uint32_t frames);

--- a/AirLib/src/api/RpcLibClientBase.cpp
+++ b/AirLib/src/api/RpcLibClientBase.cpp
@@ -453,6 +453,11 @@ __pragma(warning(disable : 4239))
             return pimpl_->client.call("simIsPaused").as<bool>();
         }
 
+        float RpcLibClientBase::simGetClockRate() const
+        {
+            return pimpl_->client.call("simGetClockRate").as<float>();
+        }
+
         void RpcLibClientBase::simPause(bool is_paused)
         {
             pimpl_->client.call("simPause", is_paused);

--- a/AirLib/src/api/RpcLibServerBase.cpp
+++ b/AirLib/src/api/RpcLibServerBase.cpp
@@ -8,6 +8,7 @@
 //if using Unreal Build system then include precompiled header file first
 
 #include "api/RpcLibServerBase.hpp"
+#include "common/ClockFactory.hpp"
 
 #include "common/Common.hpp"
 STRICT_MODE_OFF
@@ -106,6 +107,11 @@ namespace airlib
 
         pimpl_->server.bind("simIsPaused", [&]() -> bool {
             return getWorldSimApi()->isPaused();
+        });
+
+        // True scale of sim clock vs wall clock (credit: davidtr99 #4612 naming aligned to sim* APIs)
+        pimpl_->server.bind("simGetClockRate", [&]() -> float {
+            return ClockFactory::get()->getTrueScaleWrtWallClock();
         });
 
         pimpl_->server.bind("simContinueForTime", [&](double seconds) -> void {

--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -102,6 +102,16 @@ class VehicleClient:
         """
         return self.client.call("simIsPaused")
 
+    def simGetClockRate(self):
+        """
+        Returns the true scale of the simulation clock relative to wall clock
+        (settings ClockSpeed). For example, ClockSpeed 0.5 yields about 0.5.
+
+        Returns:
+            float: sim clock rate vs wall clock
+        """
+        return self.client.call("simGetClockRate")
+
     def simContinueForTime(self, seconds):
         """
         Continue the simulation for the specified number of seconds


### PR DESCRIPTION
## Summary
**Salvage** of #@davidtr99's useful clock-rate RPC (**#4612**), rebased onto current `main`.

Exposes `simGetClockRate` on the RPC server/client (true sim/wall scale via `ClockFactory::getTrueScaleWrtWallClock`) plus a matching Python `VehicleClient.simGetClockRate`. Naming uses the `sim*` prefix to match neighboring pause/continue APIs while preserving the original idea and credit.

## Credit
Original work: **@davidtr99** in https://github.com/microsoft/AirSim/pull/4612 (opened 2022; VERY OLD / quiet — §15a salvage).

## Motivation
Scripts that change `ClockSpeed` have no first-class way to read back true scale vs wall time from the running sim.

## Verification
- C++ bind + client method compile-path aligned with existing `simIsPaused` pattern.
- Python client mirrors other thin RPC wrappers.
- No simulator behavior change beyond additive RPC.

AI-assisted; human-reviewed.


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->