### PR TITLE
fix(python): default LidarData point_cloud/segmentation to lists

### DIFF
--- a/PythonClient/airsim/types.py
+++ b/PythonClient/airsim/types.py
@@ -415,10 +415,13 @@ class CameraInfo(MsgpackMixin):
     proj_mat = ProjectionMatrix()
 
 class LidarData(MsgpackMixin):
-    point_cloud = 0.0
+    # C++ SoT: vector<real_T> point_cloud + vector<int> segmentation
+    # (see CommonStructs.hpp / RpcLibAdaptorsBase). Defaults must be lists so
+    # clients can len()/slice before any RPC payload is applied.
+    point_cloud = []
     time_stamp = np.uint64(0)
     pose = Pose()
-    segmentation = 0
+    segmentation = []
 
 class ImuData(MsgpackMixin):
     time_stamp = np.uint64(0)

--- a/PythonClient/tests/__init__.py
+++ b/PythonClient/tests/__init__.py
@@ -1,0 +1,1 @@
+# Offline PythonClient unit tests (no AirSim sim required).

--- a/PythonClient/tests/test_lidar_data_types.py
+++ b/PythonClient/tests/test_lidar_data_types.py
@@ -1,0 +1,54 @@
+"""Offline checks for LidarData list field defaults (no AirSim sim required)."""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+def _load_types():
+    # Stub msgpackrpc so types.py imports cleanly without the RPC package.
+    if "msgpackrpc" not in sys.modules:
+        sys.modules["msgpackrpc"] = types.ModuleType("msgpackrpc")
+    root = Path(__file__).resolve().parents[1] / "airsim" / "types.py"
+    spec = importlib.util.spec_from_file_location("airsim_types_under_test", root)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestLidarDataTypes(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.types = _load_types()
+
+    def test_defaults_are_empty_lists(self):
+        data = self.types.LidarData()
+        self.assertIsInstance(data.point_cloud, list)
+        self.assertIsInstance(data.segmentation, list)
+        self.assertEqual(len(data.point_cloud), 0)
+        self.assertEqual(len(data.segmentation), 0)
+        # Historical bug: scalar defaults break sample len()/slice code paths.
+        self.assertFalse(isinstance(data.point_cloud, float))
+        self.assertFalse(isinstance(data.segmentation, int))
+
+    def test_assign_point_cloud_and_segmentation(self):
+        data = self.types.LidarData()
+        data.point_cloud = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+        data.segmentation = [10, 20]
+        self.assertEqual(len(data.point_cloud), 6)
+        self.assertEqual(data.point_cloud[0:3], [1.0, 2.0, 3.0])
+        self.assertEqual(data.segmentation, [10, 20])
+        # Triplet walk matches public sample clients (drone_lidar / point_cloud).
+        triplets = [
+            data.point_cloud[i : i + 3]
+            for i in range(0, len(data.point_cloud), 3)
+        ]
+        self.assertEqual(triplets, [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Default `LidarData.point_cloud` and `LidarData.segmentation` to empty lists.
- Aligns Python defaults with C++ `vector` fields so sample clients can `len()` / slice before RPC fill.

## Motivation

C++ SoT (`CommonStructs.hpp` / `RpcLibAdaptorsBase::LidarData`):

- `vector<real_T> point_cloud`
- `vector<int> segmentation`

Python historically used `point_cloud = 0.0` and `segmentation = 0`. Public samples (`drone_lidar.py`, `car_lidar.py`, point-cloud scripts) call `len(lidarData.point_cloud)` and walk XYZ triplets — scalar defaults raise `TypeError` and mislead typed consumers. Same class of Python≠C++ default bug as BarometerData scalars.

Hunk is confined to `LidarData` class fields (orthogonal to open numpy2 ops / BarometerData / Magnetometer covariance on the same file).

## Verification

```text
cd PythonClient
PYTHONPATH=. python3.11 -m unittest tests.test_lidar_data_types -v
# 2 tests OK (offline; msgpackrpc stubbed; real numpy)
```

Did **not** change: Vector3r/Quaternionr ops, BarometerData, MagnetometerData, utils/pfm IO.

## Notes

- Spec: `aerial-drone-pr-campaign/specs/airsim/2026-07-23-1.md`
- AI-assisted; human-reviewed.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h
