### PR TITLE
fix(airlib): protect SafetyEval std::max from Windows macros

### DIFF
--- a/AirLib/src/safety/SafetyEval.cpp
+++ b/AirLib/src/safety/SafetyEval.cpp
@@ -211,7 +211,7 @@ namespace airlib
     {
         //breaking distance at this velocity
         float velocity_mag = velocity.norm();
-        float dest_pos_dist = std::max(velocity_mag * vehicle_params_.vel_to_breaking_dist,
+        float dest_pos_dist = (std::max)(velocity_mag * vehicle_params_.vel_to_breaking_dist,
                                        vehicle_params_.min_breaking_dist);
 
         //calculate dest_pos cur_pos we will be if we had to break suddenly


### PR DESCRIPTION
## Summary

- Parenthesize `std::max` in `SafetyEval::getDestination` breaking-distance clamp.
- Prevents MSVC `windows.h` min/max macro expansion from breaking the template call.

## Motivation

Bare `std::max(a, b)` is unsafe when Windows headers define `max` as a macro (same class of fix as MultirotorApiBase lookahead protection in #9803 / portable subset of #4788). SafetyEval computes slam-braking destination distance with:

```cpp
dest_pos_dist = max(velocity * vel_to_breaking_dist, min_breaking_dist)
```

No control gain or threshold change — operators and order are identical under `(std::max)(...)`.

## Verification

- Diff is one parenthesized call site in `AirLib/src/safety/SafetyEval.cpp`.
- Pattern parity with #9803 lookahead protect (compile-time macro-safe form).
- Did **not** change MultirotorApiBase (owned by open #9803) or flight/geofence policy.

## Notes

- Spec: `aerial-drone-pr-campaign/specs/airsim/2026-07-23-2b-safetyeval-stdmax.md`
- Pivot: concurrent Bartok #9806 already owns Magnetometer covariance list tonight — left alone.
- AI-assisted; human-reviewed.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h
