### PR TITLE
fix(python): use integer timestamp default on CollisionInfo

### DIFF
--- a/PythonClient/airsim/types.py
+++ b/PythonClient/airsim/types.py
@@ -267,7 +267,7 @@ class CollisionInfo(MsgpackMixin):
     impact_point = Vector3r()
     position = Vector3r()
     penetration_depth = 0.0
-    time_stamp = 0.0
+    time_stamp = np.uint64(0)
     object_name = ""
     object_id = -1
 

--- a/PythonClient/tests/test_collision_info_types.py
+++ b/PythonClient/tests/test_collision_info_types.py
@@ -1,0 +1,17 @@
+import unittest
+
+import numpy as np
+
+from airsim.types import CollisionInfo
+
+
+class TestCollisionInfoDefaults(unittest.TestCase):
+    def test_timestamp_uint64_default(self):
+        c = CollisionInfo()
+        self.assertTrue(isinstance(c.time_stamp, (int, np.integer)))
+        self.assertEqual(int(c.time_stamp), 0)
+        self.assertFalse(c.has_collided)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
`CollisionInfo.time_stamp` class default was float `0.0` while neighboring airsim types expose stamp fields as `np.uint64(0)`. Switch the default to `np.uint64(0)` so cold instances match RPC integer timing fields.

## Motivation
Keeps client-side type expectations consistent when serializing or comparing collision stamps without a live sim connection.

## Verification
- `PythonClient/tests/test_collision_info_types.py`
- Diff limited to class default + unit test

Human-reviewed; single focused type fix.

<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->
