### PR TITLE
salvage: fix PD position kp_x param name in ROS docs (credit @PiggyGaGa #4945)

### DIFF
--- a/docs/airsim_ros_pkgs.md
+++ b/docs/airsim_ros_pkgs.md
@@ -174,7 +174,7 @@ Throttle, brake, steering and gear selections for control. Both automatic and ma
 #### Parameters:
 
 - PD controller parameters:
-  * `/pd_position_node/kd_x` [double],
+  * `/pd_position_node/kp_x` [double],
     `/pd_position_node/kp_y` [double],
     `/pd_position_node/kp_z` [double],
     `/pd_position_node/kp_yaw` [double]


### PR DESCRIPTION
## Salvage
Credit **@PiggyGaGa** for [#4945](https://github.com/microsoft/AirSim/pull/4945) (opened 2024-04, quiet since mid-2024).

The ROS package docs listed the first PD gain as `/pd_position_node/kd_x` while siblings are `kp_*`. Restore `kp_x` so the parameter table matches the controller gains.

Original insight preserved; rebased onto current `main` as a one-line docs fix.

## Verification
Docs-only; parameter name cross-check against consecutive `kp_y/z/yaw` lines.

<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->
