### PR TITLE
fix(python): avoid shared list defaults on rotor/proj types

### DIFF
--- a/PythonClient/airsim/types.py
+++ b/PythonClient/airsim/types.py
@@ -404,10 +404,12 @@ class MultirotorState(MsgpackMixin):
 
 class RotorStates(MsgpackMixin):
     timestamp = np.uint64(0)
-    rotors = []
+    # None avoids a shared mutable class default; RPC fills a list of rotor states.
+    rotors = None
 
 class ProjectionMatrix(MsgpackMixin):
-    matrix = []
+    # None avoids a shared mutable class default; RPC fills nested matrix lists.
+    matrix = None
 
 class CameraInfo(MsgpackMixin):
     pose = Pose()


### PR DESCRIPTION
RotorStates.rotors and ProjectionMatrix.matrix used a shared class-level `[]`. Default them to None so local instances do not share buffers before RPC fill.

AI-assisted; human-reviewed.

<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->