### PR TITLE
fix(python): correct mesh vertex/index buffer default types

### DIFF
--- a/PythonClient/airsim/types.py
+++ b/PythonClient/airsim/types.py
@@ -575,6 +575,7 @@ class PositionControllerGains():
 class MeshPositionVertexBuffersResponse(MsgpackMixin):
     position = Vector3r()
     orientation = Quaternionr()
-    vertices = 0.0
-    indices = 0.0
+    # Mesh buffers arrive as lists from RPC; 0.0 was a misleading scalar default.
+    vertices = None
+    indices = None
     name = ''


### PR DESCRIPTION
MeshPositionVertexBuffersResponse used float 0.0 for vertices and indices. Those fields are list buffers from simGetMeshPositionVertexBuffers; default to None.

AI-assisted; human-reviewed.

<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->