### PR TITLE
fix(azure): replace EOL python3.6 in Docker image

### DIFF
--- a/azure/docker/Dockerfile
+++ b/azure/docker/Dockerfile
@@ -1,32 +1,36 @@
 FROM nvidia/cudagl:9.0-devel
 
-RUN apt-get update
-RUN apt-get install \
+RUN apt-get update && apt-get install -y --no-install-recommends \
 	sudo \
 	libglu1-mesa-dev \
 	xdg-user-dirs \
 	pulseaudio \
-	sudo \
 	x11-xserver-utils \
 	unzip \
 	wget \
 	software-properties-common \
-	-y --no-install-recommends
+	ca-certificates \
+	&& rm -rf /var/lib/apt/lists/*
 
-RUN apt-add-repository ppa:deadsnakes/ppa
-RUN apt-get update
-RUN apt-get install -y \
-	python3.6 \
-	python3-pip 
+# python3.6 is no longer available (issue #9778). Use deadsnakes Python 3.8 when present;
+# otherwise fall back to the distro python3 package.
+RUN apt-get update \
+	&& (apt-add-repository -y ppa:deadsnakes/ppa || true) \
+	&& apt-get update \
+	&& (apt-get install-y python3.8 python3.8-distutils \
+		|| apt-get install -y python3 python3-pip) \
+	&& if command -v python3.8 >/dev/null 2>&1; then \
+		update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1 || true; \
+		python3.8 -m pip install --upgrade pip setuptools wheel || python3 -m pip install --upgrade pip setuptools wheel; \
+	else \
+		python3 -m pip install --upgrade pip setuptools wheel; \
+	fi \
+	&& rm -rf /var/lib/apt/lists/*
 
-RUN python3.6 -m pip install --upgrade pip
-
-RUN python3.6 -m pip install setuptools wheel
-
-RUN adduser --force-badname --disabled-password --gecos '' --shell /bin/bash airsim_user && \ 
-	echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \ 
-	adduser airsim_user sudo && \ 
-	adduser airsim_user audio && \ 
+RUN adduser --force-badname --disabled-password --gecos '' --shell /bin/bash airsim_user && \
+	echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
+	adduser airsim_user sudo && \
+	adduser airsim_user audio && \
 	adduser airsim_user video
 
 USER airsim_user
@@ -34,18 +38,16 @@ WORKDIR /home/airsim_user
 
 # Change the following values to use a different AirSim binary
 # Also change the AIRSIM_EXECUTABLE variable in docker-entrypoint.sh
-ENV AIRSIM_BINARY_ZIP_URL=https://github.com/microsoft/AirSim/releases/download/v1.3.1-linux/Blocks.zip 
+ENV AIRSIM_BINARY_ZIP_URL=https://github.com/microsoft/AirSim/releases/download/v1.3.1-linux/Blocks.zip
 ENV AIRSIM_BINARY_ZIP_FILENAME=Blocks.zip
 
 ENV SDL_VIDEODRIVER_VALUE=offscreen
 ENV SDL_HINT_CUDA_DEVICE=0
 
-# Download and unzip the AirSim binary
-RUN wget -c $AIRSIM_BINARY_ZIP_URL
-RUN unzip $AIRSIM_BINARY_ZIP_FILENAME
-RUN rm $AIRSIM_BINARY_ZIP_FILENAME
+RUN wget -c $AIRSIM_BINARY_ZIP_URL \
+	&& unzip $AIRSIM_BINARY_ZIP_FILENAME \
+	&& rm $AIRSIM_BINARY_ZIP_FILENAME
 
-# Add the Python app to the image
 ADD ./app /home/airsim_user/app
 
 WORKDIR /home/airsim_user
@@ -57,7 +59,6 @@ RUN sudo chown -R airsim_user /home/airsim_user
 
 WORKDIR /home/airsim_user/app
 
-# Install Python requirements
-RUN python3.6 -m pip install -r requirements.txt
+RUN python3 -m pip install --user -r requirements.txt
 
 ENTRYPOINT /home/airsim_user/docker-entrypoint.sh

--- a/azure/docker/docker-entrypoint.sh
+++ b/azure/docker/docker-entrypoint.sh
@@ -8,4 +8,4 @@ echo Waiting 10 seconds before starting app...
 sleep 10
 
 echo Starting Python app
-python3.6 /home/airsim_user/app/multirotor.py
+python3 /home/airsim_user/app/multirotor.py


### PR DESCRIPTION
Fixes #9778 — Azure Dockerfile/entrypoint still pinned python3.6, which apt can no longer install. Prefer Python 3.8 (deadsnakes) with distro python3 fallback; run pip as python3.

AI-assisted; human-reviewed.


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->