### PR TITLE
fix(airlib): protect MultirotorApiBase std::max from Windows macros

### DIFF
--- a/AirLib/src/vehicles/multirotor/api/MultirotorApiBase.cpp
+++ b/AirLib/src/vehicles/multirotor/api/MultirotorApiBase.cpp
@@ -918,7 +918,7 @@ namespace airlib
         //if auto mode requested for lookahead then calculate based on velocity
         float command_period_dist = velocity * getCommandPeriod();
         float lookahead = command_period_dist * (adaptive_lookahead > 0 ? min_factor : max_factor);
-        lookahead = std::max(lookahead, getDistanceAccuracy() * 1.5f); //50% more than distance accuracy
+        lookahead = (std::max)(lookahead, getDistanceAccuracy() * 1.5f); //50% more than distance accuracy (paren form: Windows min/max macros)
         return lookahead;
     }
 


### PR DESCRIPTION
Use `(std::max)` in getAutoLookahead so Windows min/max macros cannot break the call (same pattern as SafetyEval).

AI-assisted; human-reviewed.


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->