### PR TITLE
fix(airlib): protect Utils clip/limitAbsValue from Windows min/max macros

### DIFF
--- a/AirLib/include/common/common_utils/Utils.hpp
+++ b/AirLib/include/common/common_utils/Utils.hpp
@@ -201,8 +201,8 @@ public:
     static T limitAbsValue(T val, T min_value, T max_value)
     {
         T val_abs = std::abs(val);
-        T val_limited = std::max(val_abs, min_value);
-        val_limited = std::min(val_limited, max_value);
+        T val_limited = (std::max)(val_abs, min_value);
+        val_limited = (std::min)(val_limited, max_value);
         return sign(val) * val_limited;
     }
 
@@ -210,7 +210,7 @@ public:
     template <typename T>
     static T clip(T val, T min_value, T max_value)
     {
-        return std::max(min_value, std::min(val, max_value));
+        return (std::max)(min_value, (std::min)(val, max_value));
     }
 
     template <typename Range>


### PR DESCRIPTION
Windows headers can define min/max macros that break bare `std::max`/`std::min` in `Utils::limitAbsValue` and `Utils::clip`. Same parenthesized form already used elsewhere in AirLib.

AI-assisted; human-reviewed.


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->