### PR TITLE
fix(simple_flight): protect motor/PID clamps from Windows min/max macros

### DIFF
--- a/AirLib/include/vehicles/multirotor/firmwares/simple_flight/firmware/Mixer.hpp
+++ b/AirLib/include/vehicles/multirotor/firmwares/simple_flight/firmware/Mixer.hpp
@@ -43,8 +43,8 @@ public:
         }
 
         for (int motor_index = 0; motor_index < kMotorCount; ++motor_index)
-            motor_outputs[motor_index] = std::max(params_->motor.min_motor_output,
-                                                  std::min(motor_outputs[motor_index], params_->motor.max_motor_output));
+            motor_outputs[motor_index] = (std::max)(params_->motor.min_motor_output,
+                                                  (std::min)(motor_outputs[motor_index], params_->motor.max_motor_output));
     }
 
 private:

--- a/AirLib/include/vehicles/multirotor/firmwares/simple_flight/firmware/PidController.hpp
+++ b/AirLib/include/vehicles/multirotor/firmwares/simple_flight/firmware/PidController.hpp
@@ -114,7 +114,7 @@ private:
     //TODO: replace with std::clamp after moving to C++17
     static T clip(T val, T min_value, T max_value)
     {
-        return std::max(min_value, std::min(val, max_value));
+        return (std::max)(min_value, (std::min)(val, max_value));
     }
 
 private:

--- a/AirLib/include/vehicles/multirotor/firmwares/simple_flight/firmware/RungKuttaPidIntegrator.hpp
+++ b/AirLib/include/vehicles/multirotor/firmwares/simple_flight/firmware/RungKuttaPidIntegrator.hpp
@@ -54,7 +54,7 @@ private:
     //TODO: replace with std::clamp after moving to C++17
     static T clip(T val, T min_value, T max_value)
     {
-        return std::max(min_value, std::min(val, max_value));
+        return (std::max)(min_value, (std::min)(val, max_value));
     }
 
     void model(float* y_val, float last_time_, float* y_out)

--- a/AirLib/include/vehicles/multirotor/firmwares/simple_flight/firmware/StdPidIntegrator.hpp
+++ b/AirLib/include/vehicles/multirotor/firmwares/simple_flight/firmware/StdPidIntegrator.hpp
@@ -53,7 +53,7 @@ private:
     //TODO: replace with std::clamp after moving to C++17
     static T clip(T val, T min_value, T max_value)
     {
-        return std::max(min_value, std::min(val, max_value));
+        return (std::max)(min_value, (std::min)(val, max_value));
     }
 
 private:

--- a/AirLib/include/vehicles/multirotor/firmwares/simple_flight/firmware/VelocityController.hpp
+++ b/AirLib/include/vehicles/multirotor/firmwares/simple_flight/firmware/VelocityController.hpp
@@ -114,7 +114,7 @@ public:
             break;
         case 3: //+vz is -ve throttle (NED coordinates)
             output_ = (-pid_->getOutput() + 1) / 2; //-1 to 1 --> 0 to 1
-            output_ = std::max(output_, params_->velocity_pid.min_throttle);
+            output_ = (std::max)(output_, params_->velocity_pid.min_throttle);
             break;
         default:
             throw std::invalid_argument("axis must be 0, 1 or 3 for VelocityController");


### PR DESCRIPTION
simple_flight motor output clamping and velocity throttle floor call `std::max`/`std::min` in headers that can be compiled after Windows min/max macros. Switches to the `(std::max)` / `(std::min)` form used elsewhere in AirLib.

AI-assisted; human-reviewed.


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->