### PR TITLE
fix(mavlink): protect Utils clip from Windows min/max macros

### DIFF
--- a/MavLinkCom/common_utils/Utils.hpp
+++ b/MavLinkCom/common_utils/Utils.hpp
@@ -153,8 +153,8 @@ public:
     static T limitAbsValue(T val, T min_value, T max_value)
     {
         T val_abs = std::abs(val);
-        T val_limited = std::max(val_abs, min_value);
-        val_limited = std::min(val_limited, max_value);
+        T val_limited = (std::max)(val_abs, min_value);
+        val_limited = (std::min)(val_limited, max_value);
         return sign(val) * val_limited;
     }
 
@@ -162,7 +162,7 @@ public:
     template <typename T>
     static T clip(T val, T min_value, T max_value)
     {
-        return std::max(min_value, std::min(val, max_value));
+        return (std::max)(min_value, (std::min)(val, max_value));
     }
 
     template <typename Range>


### PR DESCRIPTION
Protects MavLinkCom Utils clip/limitAbsValue from windows.h min/max macros by parenthesizing std::min/max (same pattern as AirLib Utils).

AI-assisted; human-reviewed.


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->