### PR TITLE
fix(simple_flight): protect Params kMinThrottle from Windows min macros

### DIFF
--- a/AirLib/include/vehicles/multirotor/firmwares/simple_flight/firmware/Params.hpp
+++ b/AirLib/include/vehicles/multirotor/firmwares/simple_flight/firmware/Params.hpp
@@ -100,7 +100,7 @@ public:
 
     struct VelocityPid
     {
-        const float kMinThrottle = std::min(1.0f, Params::min_armed_throttle() * 3.0f);
+        const float kMinThrottle = (std::min)(1.0f, Params::min_armed_throttle() * 3.0f);
         const float kMaxLimit = 6.0f; // m/s
         const float kP = 0.2f;
         const float kI = 2.0f;


### PR DESCRIPTION
Protects SimpleFlight `VelocityPid::kMinThrottle` from Windows `min` macros by using `(std::min)(...)`.

No behavior change when macros are absent.

AI-assisted; human-reviewed.


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->