### PR TITLE
fix(examples): protect DepthNavOptAStar ray costs from Windows min macros

### DIFF
--- a/Examples/DepthNav/DepthNavOptAStar.hpp
+++ b/Examples/DepthNav/DepthNavOptAStar.hpp
@@ -238,8 +238,8 @@ namespace airlib
 
         void setRayCost(SampleRay& sample_ray, const Vector3r& goal_body, real_T goal_dist)
         {
-            real_T goal_on_ray = std::min(goal_body.dot(sample_ray.ray), 0.0f);
-            real_T d1 = std::min(sample_ray.obs_dist, goal_on_ray);
+            real_T goal_on_ray = (std::min)(goal_body.dot(sample_ray.ray), 0.0f);
+            real_T d1 = (std::min)(sample_ray.obs_dist, goal_on_ray);
 
             sample_ray.d1_v = sample_ray.ray * d1;
             sample_ray.d2_v = goal_body - sample_ray.d1_v;


### PR DESCRIPTION
Paren-wraps `std::min` in DepthNav A* ray cost so Windows `min` macros cannot break example builds including `windows.h`.

Cost math unchanged without macros. Example-only path.

AI-assisted; human-reviewed.


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->