### PR TITLE
salvage: lidar ring channel (credit @davidtr99 #4611)

### DIFF
--- a/AirLib/include/sensors/lidar/LidarBase.hpp
+++ b/AirLib/include/sensors/lidar/LidarBase.hpp
@@ -26,7 +26,7 @@ namespace airlib
             UpdatableObject::reportState(reporter);
 
             reporter.writeValue("Lidar-Timestamp", output_.time_stamp);
-            reporter.writeValue("Lidar-NumPoints", static_cast<int>(output_.point_cloud.size() / 3));
+            reporter.writeValue("Lidar-NumPoints", static_cast<int>(output_.point_cloud.size() / 4));
         }
 
         const LidarData& getOutput() const

--- a/Unreal/Plugins/AirSim/Source/UnrealSensors/UnrealLidarSensor.cpp
+++ b/Unreal/Plugins/AirSim/Source/UnrealSensors/UnrealLidarSensor.cpp
@@ -91,6 +91,7 @@ void UnrealLidarSensor::getPointCloud(const msr::airlib::Pose& lidar_pose, const
                 point_cloud.emplace_back(point.x());
                 point_cloud.emplace_back(point.y());
                 point_cloud.emplace_back(point.z());
+                point_cloud.emplace_back(laser);
                 segmentation_cloud.emplace_back(segmentationID);
             }
         }

--- a/ros/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
+++ b/ros/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
@@ -733,14 +733,15 @@ sensor_msgs::PointCloud2 AirsimROSWrapper::get_lidar_msg_from_airsim(const msr::
     lidar_msg.header.stamp = ros::Time::now();
     lidar_msg.header.frame_id = vehicle_name + "/" + sensor_name;
 
-    if (lidar_data.point_cloud.size() > 3) {
+    if (lidar_data.point_cloud.size() > 4) {
         lidar_msg.height = 1;
-        lidar_msg.width = lidar_data.point_cloud.size() / 3;
+        lidar_msg.width = lidar_data.point_cloud.size() / 4;
 
-        lidar_msg.fields.resize(3);
+        lidar_msg.fields.resize(4);
         lidar_msg.fields[0].name = "x";
         lidar_msg.fields[1].name = "y";
         lidar_msg.fields[2].name = "z";
+        lidar_msg.fields[3].name = "ring";
 
         int offset = 0;
 

--- a/ros2/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
+++ b/ros2/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
@@ -651,14 +651,15 @@ sensor_msgs::msg::PointCloud2 AirsimROSWrapper::get_lidar_msg_from_airsim(const 
     lidar_msg.header.stamp = rclcpp::Time(lidar_data.time_stamp);
     lidar_msg.header.frame_id = vehicle_name + "/" + sensor_name;
 
-    if (lidar_data.point_cloud.size() > 3) {
+    if (lidar_data.point_cloud.size() > 4) {
         lidar_msg.height = 1;
-        lidar_msg.width = lidar_data.point_cloud.size() / 3;
+        lidar_msg.width = lidar_data.point_cloud.size() / 4;
 
-        lidar_msg.fields.resize(3);
+        lidar_msg.fields.resize(4);
         lidar_msg.fields[0].name = "x";
         lidar_msg.fields[1].name = "y";
         lidar_msg.fields[2].name = "z";
+        lidar_msg.fields[3].name = "ring";
 
         int offset = 0;
 


### PR DESCRIPTION
salvage: lidar point cloud `ring` field (credit @davidtr99 #4611)

Rebases the useful core of #4611 onto current `main`:
- Unreal lidar emits laser index after x,y,z
- Lidar-NumPoints uses stride 4
- ROS1/ROS2 PointCloud2 advertise `ring` and stride accordingly

Original: @davidtr99 https://github.com/microsoft/AirSim/pull/4611

AI-assisted; human-reviewed/rebased.


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->