### PR TITLE
fix(python): type ImageResponse.pixels_as_float as bool

### DIFF
--- a/PythonClient/airsim/types.py
+++ b/PythonClient/airsim/types.py
@@ -329,7 +329,7 @@ class ImageResponse(MsgpackMixin):
     camera_orientation = Quaternionr()
     time_stamp = np.uint64(0)
     message = ''
-    pixels_as_float = 0.0
+    pixels_as_float = False
     compress = True
     width = 0
     height = 0

--- a/PythonClient/tests/test_image_response_pixels_as_float.py
+++ b/PythonClient/tests/test_image_response_pixels_as_float.py
@@ -1,0 +1,34 @@
+"""Offline check: ImageResponse.pixels_as_float is a bool (matches C++ RPC)."""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+def _load_types():
+    if "msgpackrpc" not in sys.modules:
+        sys.modules["msgpackrpc"] = types.ModuleType("msgpackrpc")
+    root = Path(__file__).resolve().parents[1] / "airsim" / "types.py"
+    spec = importlib.util.spec_from_file_location("airsim_types_under_test", root)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestImageResponsePixelsAsFloat(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.types = _load_types()
+
+    def test_pixels_as_float_is_bool_false(self):
+        r = self.types.ImageResponse()
+        self.assertIsInstance(r.pixels_as_float, bool)
+        self.assertIs(r.pixels_as_float, False)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Symptom: ImageResponse.pixels_as_float defaulted to 0.0 while C++/RPC use bool false.

Fix: default False; small offline unit test.

AI-assisted; human-reviewed.

<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->