### PR TITLE
salvage: Ubuntu/UE compile hygiene (credit @zimmy87 #4561)

### DIFF
--- a/Unreal/Plugins/AirSim/Source/AirSim.Build.cs
+++ b/Unreal/Plugins/AirSim/Source/AirSim.Build.cs
@@ -105,12 +105,6 @@ public class AirSim : ModuleRules
             PublicAdditionalLibraries.Add("dxguid.lib");
         }
 
-		if (Target.Platform == UnrealTargetPlatform.Linux)
-		{
-			// needed when packaging
-			PublicAdditionalLibraries.Add("stdc++");
-			PublicAdditionalLibraries.Add("supc++");
-		}
     }
 
     static void CopyFileIfNewer(string srcFilePath, string destFolder)

--- a/Unreal/Plugins/AirSim/Source/UnrealImageCapture.h
+++ b/Unreal/Plugins/AirSim/Source/UnrealImageCapture.h
@@ -5,7 +5,7 @@
 #include "common/ImageCaptureBase.hpp"
 #include "common/common_utils/UniqueValueMap.hpp"
 
-class UnrealImageCapture : public msr::airlib::ImageCaptureBase
+class AIRSIM_API UnrealImageCapture : public msr::airlib::ImageCaptureBase
 {
 public:
     typedef msr::airlib::ImageCaptureBase::ImageType ImageType;

--- a/cmake/cmake-modules/CommonSetup.cmake
+++ b/cmake/cmake-modules/CommonSetup.cmake
@@ -59,9 +59,10 @@ macro(CommonSetup)
             if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
                 set(CMAKE_CXX_FLAGS "-stdlib=libc++ -Wno-documentation -Wno-unknown-warning-option ${CMAKE_CXX_FLAGS}")
                 find_package(LLVM REQUIRED CONFIG)
-                set(CXX_EXP_LIB "-L${LLVM_LIBRARY_DIRS} -lc++fs -ferror-limit=10")
+                # c++17 filesystem is in the standard library; do not force c++fs/stdc++fs.
+                set(CXX_EXP_LIB "-L${LLVM_LIBRARY_DIRS} -ferror-limit=10")
             else()
-                set(CXX_EXP_LIB "-lstdc++fs -fmax-errors=10 -Wnoexcept -Wstrict-null-sentinel")
+                set(CXX_EXP_LIB "-fmax-errors=10 -Wnoexcept -Wstrict-null-sentinel")
             endif ()
         endif ()
 


### PR DESCRIPTION
salvage: compile hygiene on modern Linux/UE (credit @zimmy87 #4561)

VERY OLD open PR. Keeps AIRSIM_API on UnrealImageCapture, drops Linux packaging force-links for stdc++/supc++, and stops linking standalone c++fs/stdc++fs now that std::filesystem is in the standard library. Drops retired ubuntu-21.10 runner pin from the original.

AI-assisted; human-reviewed.


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->