### PR TITLE
salvage: ROS1 distance max_range (credit @1aal #4908)

### DIFF
--- a/ros/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
+++ b/ros/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
@@ -840,7 +840,7 @@ sensor_msgs::Range AirsimROSWrapper::get_range_from_airsim(const msr::airlib::Di
     dist_msg.header.stamp = airsim_timestamp_to_ros(dist_data.time_stamp);
     dist_msg.range = dist_data.distance;
     dist_msg.min_range = dist_data.min_distance;
-    dist_msg.max_range = dist_data.min_distance;
+    dist_msg.max_range = dist_data.max_distance;
 
     return dist_msg;
 }


### PR DESCRIPTION
salvage: ROS1 distance sensor `max_range` used `min_distance` (credit @1aal #4908).

ROS2 path already publishes `max_distance`; ROS1 still mirrored min. One-line fix; Fixes #4907.

AI-assisted; human-reviewed.


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->